### PR TITLE
infofiles isn't a datafile, and breaks setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -283,7 +283,7 @@ def map_data_file(data_file):
 
 
 def getdatafiles():
-    datafiles = initfiles + infofiles
+    datafiles = initfiles
 
     def listfiles(srcdir):
         return join(sitepackages, srcdir), [join(srcdir, f) for f in os.listdir(srcdir) if os.path.isfile(join(srcdir, f))]


### PR DESCRIPTION
Kept running into this:

...
byte-compiling /usr/local/lib/python2.7/dist-packages/translate/tools/pocount.py to pocount.pyc
byte-compiling /usr/local/lib/python2.7/dist-packages/translate/tools/test_podebug.py to test_podebug.pyc
running install_data
## error: can't copy 'translate/ChangeLog': doesn't exist or not a regular file

Command /usr/bin/python -c "import setuptools;**file**='/root/build/translate/setup.py';execfile(**file**)" install --single-version-externally-managed --record /tmp/pip-mzUO3A-record/install-record.txt failed with error code 1
Storing complete log in /root/.pip/pip.log
