### PR TITLE
Fix bug with the BOM symbol in the middle of contents

### DIFF
--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -588,8 +588,9 @@ class propfile(base.TranslationStore):
         """Convert the units back to lines."""
         lines = []
         for unit in self.units:
-            lines.append(str(unit))
-        return "".join(lines)
+            lines.append(unit.getoutput())
+        uret = u"".join(lines)
+        return uret.encode(self.encoding)
 
 
 class javafile(propfile):

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -329,3 +329,12 @@ key=value
         assert propunit.name == u''
         assert propunit.source == u''
         assert propunit.getnotes() == u"# END"
+
+    def test_utf16_byte_order_mark(self):
+        """test that BOM appears in the resulting text once only"""
+        propsource = u"key1 = value1\nkey2 = value2\n".encode('utf-16')
+        propfile = self.propparse(propsource, encoding='utf-16')
+        result = str(propfile)
+        bom = propsource[:2]
+        assert result.startswith(bom)
+        assert bom not in result[2:]


### PR DESCRIPTION
Please consider merging yet another minor fix to upstream.

The problem is that encoding to utf-16 prepends BOM to every string, so that it's no longer safe to concatenate two utf-16 encoded strings.

Thus, left and right part of the equality don't match

```
>>> u'foo'.encode('utf-16') == ''.join(c.encode('utf-16') for c in u'foo')
False
```

Instead text should be concatenated first, then converted to utf-16
