### PR TITLE
Set Strings encoding to UTF-16LE

### DIFF
--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -371,7 +371,7 @@ register_dialect(DialectSkype)
 
 class DialectStrings(Dialect):
     name = "strings"
-    default_encoding = "utf-16"
+    default_encoding = "UTF-16LE"
     delimiters = [u"="]
     pair_terminator = u";"
     key_wrap_char = u'"'


### PR DESCRIPTION
This way we won't get warning that detected encoding is different than
actually being used.

Warning being issued:

```
WARNING:root:trying to parse  with encoding: utf-16 but detected encoding is UTF-16LE (confidence: 1.0)
```
