### PR TITLE
Fix reST markup and adapt grammar

### DIFF
--- a/docs/commands/poterminology.rst
+++ b/docs/commands/poterminology.rst
@@ -57,7 +57,7 @@ Options:
 -F, --fold-titlecase  fold "Title Case" to lowercase (default)
 -C, --preserve-case   preserve all uppercase/lowercase
 -I, --ignore-case     make all terms lowercase
---accelerator=ACCELERATORS ignores the given accelerator characters when matching (accelerator characters probably require quoting)
+--accelerator=ACCELERATORS  ignore the given accelerator characters when matching (accelerator characters probably require quoting)
 -t LENGTH, --term-words=LENGTH  generate terms of up to LENGTH words (default 3)
 --inputs-needed=MIN   omit terms appearing in less than MIN input files (default 2, or 1 if only one input file)
 --fullmsg-needed=MIN  omit full message terms appearing in less than MIN different messages (default 1)

--- a/translate/tools/poterminology.py
+++ b/translate/tools/poterminology.py
@@ -481,7 +481,7 @@ def main():
         action="store_true", help="make all terms lowercase")
 
     parser.add_option("", "--accelerator", dest="accelchars", default="",
-        metavar="ACCELERATORS", help="ignores the given accelerator characters when matching")
+        metavar="ACCELERATORS", help="ignore the given accelerator characters when matching")
 
     parser.add_option("-t", "--term-words", type="int", dest="termlength", default="3",
         help="generate terms of up to LENGTH words (default 3)", metavar="LENGTH")


### PR DESCRIPTION
Noticed the markup issue at https://github.com/translate/translate/blob/master/docs/commands/poterminology.rst#usage.
