### PR TITLE
Added support for Objecttive-C %@ printf specifiers

### DIFF
--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -42,10 +42,12 @@ from translate.lang import data
 
 # These are some regular expressions that are compiled for use in some tests
 
-# printf syntax based on http://en.wikipedia.org/wiki/Printf which doens't
+# printf syntax based on http://en.wikipedia.org/wiki/Printf which doesn't
 # cover everything we leave \w instead of specifying the exact letters as
 # this should capture printf types defined in other platforms.
-# extended to support Python named format specifiers
+# Extended to support Python named format specifiers and objective-C special
+# "%@" format specifier
+# (see https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html)
 printf_pat = re.compile('''
         %(                          # initial %
               (?:(?P<ord>\d+)\$|    # variable order, like %1$s
@@ -55,7 +57,7 @@ printf_pat = re.compile('''
             (?:\d+)?                # width
             (?:\.\d+)?              # precision
             (hh\|h\|l\|ll)?         # length formatting
-            (?P<type>[\w%]))        # type (%s, %d, etc.)
+            (?P<type>[\w%@]))       # type (%s, %d, etc.)
         )''', re.VERBOSE)
 
 # The name of the XML tag

--- a/translate/filters/test_checks.py
+++ b/translate/filters/test_checks.py
@@ -525,6 +525,11 @@ def test_printf():
     # checking omitted plural format string placeholder %.0s
     stdchecker.hasplural = 1
     assert passes(stdchecker.printf, "%d plurals", "%.0s plural")
+    # checking Objective-C %@ format specification
+    assert fails(stdchecker.printf, "I am %@", "Ek is @%")  # typo
+    assert fails(stdchecker.printf, "Object %@ and object %@", "String %1$@ en string %3$@")  # out of bounds
+    assert fails(stdchecker.printf, "I am %@", "Ek is %s")  # wrong specification
+    assert passes(stdchecker.printf, "Object %@ and string %s", "Object %1$@ en string %2$s")  # correct sentence
 
 
 def test_puncspacing():


### PR DESCRIPTION
Objective-C printf supports extra format specifier %@ which didn't checked by printf quality check. Could you please merge this commit to make it work. Thanks.
