### PR TITLE
Mark some tests as xfail for bug 2780

### DIFF
--- a/translate/filters/test_checks.py
+++ b/translate/filters/test_checks.py
@@ -390,6 +390,7 @@ def test_long():
     assert fails(stdchecker.long, "a", "bc")
 
 
+@mark.xfail(reason="FIXME: All fails() tests are not working")
 def test_musttranslatewords():
     """tests stopwords"""
     stdchecker = checks.StandardChecker(checks.CheckerConfig(musttranslatewords=[]))
@@ -636,6 +637,7 @@ def test_simplecaps():
     assert passes(stdchecker.simplecaps, "Flies, flies, everywhere! Ack!", u"Vlieë, oral vlieë! Jig!")
 
 
+@mark.xfail(reason="FIXME: spell checking test not working")
 def test_spellcheck():
     """tests spell checking"""
     stdchecker = checks.StandardChecker(checks.CheckerConfig(targetlanguage="af"))


### PR DESCRIPTION
we'll want to fix these tests properly at some point, but for now this allows us to actually detect regressions in the rest of the test suite
