### PR TITLE
Bug2798

### DIFF
--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -130,8 +130,8 @@ class RecursiveOptionParser(optparse.OptionParser, object):
         description_lines = self.description.split('\n\n')[1:]
         if description_lines:
             result.append('.SH DESCRIPTION\n')
-            result.append('\n'.join([re.sub('\.\. note::', 'Note:', l)
-                                            for l in description_lines]))
+            result.append('\n\n'.join([re.sub('\.\. note::', 'Note:', l)
+                                              for l in description_lines]))
         result.append('.SH OPTIONS\n')
         ManHelpFormatter().store_option_strings(self)
         result.append('.PP\n')


### PR DESCRIPTION
Stuart Prescott's patches in [bug 2798](http://bugs.locamotion.org/show_bug.cgi?id=2798) to prevent spurious roff markup in manpages generated from optparse help (with rST docstrings), plus a small fix to preserve blank lines from docstrings (for paragraph breaks).
