### PR TITLE
Change ordering of PO headers

### DIFF
--- a/translate/storage/poheader.py
+++ b/translate/storage/poheader.py
@@ -114,10 +114,10 @@ class poheader(object):
         "PO-Revision-Date",
         "Last-Translator",
         "Language-Team",
-        "Language",
         "MIME-Version",
         "Content-Type",
         "Content-Transfer-Encoding",
+        "Language",
         "Plural-Forms",
         "X-Generator",
         ]


### PR DESCRIPTION
This way it matches what Gettext produces prevent change of placement of
Language header on every header change.
