### PR TITLE
Docs: Add docs about Android translation format

### DIFF
--- a/docs/formats/android.rst
+++ b/docs/formats/android.rst
@@ -1,0 +1,24 @@
+.. _android:
+
+Android string resources
+************************
+
+:wp:`Android <Android_%28operating_system%29>` programs make use of localisable
+string resources.
+
+.. note:: The toolkit supports this format, but still doesn't provide any
+   converter.
+
+
+.. _android#references:
+
+References
+==========
+
+* Android `Resource files reference
+  <http://developer.android.com/guide/topics/resources/resources-i18n.html>`_
+* Android `String resources reference
+  <http://developer.android.com/guide/topics/resources/available-resources.html#stringresources>`_
+* `Localizing Android Applications <http://www.linux-mag.com/id/7794>`_ tutorial
+* Reference for `translatable attribute
+  <http://tools.android.com/recent/non-translatablestrings>`_

--- a/docs/formats/index.rst
+++ b/docs/formats/index.rst
@@ -43,6 +43,7 @@ Other translation formats
    strings
    flex
    catkeys
+   android
 
 * :doc:`csv`
 * :doc:`ini` (including Inno Setup .isl dialect)
@@ -56,6 +57,7 @@ Other translation formats
 * Mac OSX :doc:`strings` files (also used on the iPhone) (from version 1.8)
 * Adobe :doc:`flex` files (from version 1.8)
 * Haiku :doc:`catkeys` (from version 1.8)
+* :doc:`android` (supports storage, not conversion)
 
 .. _formats#translation_memory_formats:
 
@@ -190,12 +192,6 @@ Formats that we would like to support but don't currently support:
   * Generic XML
   * :wp:`DocBook` (can be handled by KDE's :man:`xml2pot`)
   * `SVG <http://www.w3.org/TR/SVG/>`_
-  * :wp:`Android <Android_%28operating_system%29>`
-    `resource files
-    <http://developer.android.com/guide/topics/resources/resources-i18n.html>`_ specifically
-    `string resources
-    <http://developer.android.com/guide/topics/resources/available-resources.html#stringresources>`_
-    (`more background <http://www.linux-mag.com/id/7794>`_)
 
 * :wp:`DITA <Darwin_Information_Typing_Architecture>`
 * :wp:`PDF <Portable_Document_Format>` see `spec


### PR DESCRIPTION
Note that there is only support for the format, but no converters.
