### PR TITLE
Do not emit encoding warning when chardet is sure

### DIFF
--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -753,7 +753,9 @@ class TranslationStore(object):
                     encodings.append(encoding)
         else:
             encodings.append(self.encoding)
-            if detected_encoding and detected_encoding['encoding'] != self.encoding:
+            if (detected_encoding
+                    and detected_encoding['encoding'] != self.encoding
+                    and detected_encoding['confidence'] != 1.0):
                 logging.warn("trying to parse %s with encoding: %s but "
                              "detected encoding is %s (confidence: %s)",
                              self.filename, self.encoding,


### PR DESCRIPTION
The chardet module returns confidence 1.0 when BOM is found and this
case should be safe enough not to emit any warning about detection.

This is IMHO better approach to get rid of the warning than pull request #9.
