### PR TITLE
Fix a syntax error in Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ else:
     sitepackages = packagesdir.replace(sys.prefix + os.sep, '')
 
 infofiles = [(join(sitepackages, 'translate'),
-             [filename for filename in 'COPYING', 'README.rst'])]
+             [filename for filename in ('COPYING', 'README.rst')])]
 initfiles = [(join(sitepackages, 'translate'), [join('translate', '__init__.py')])]
 
 subpackages = [


### PR DESCRIPTION
`[filename for filename in 'COPYING', 'README.rst']` is only valid in Python 2.
