### PR TITLE
Inject a default section for section-less INI files

### DIFF
--- a/translate/storage/ini.py
+++ b/translate/storage/ini.py
@@ -29,10 +29,12 @@ a = a string
 b : a string
 """
 
+import logging
 import re
 from io import BytesIO
 
 from iniparse import INIConfig
+from six.moves.configparser import MissingSectionHeaderError
 
 from translate.storage import base
 
@@ -123,10 +125,29 @@ class inifile(base.TranslationStore):
             input = inisrc
 
         if isinstance(input, bytes):
-            input = BytesIO(input)
-            self._inifile = INIConfig(input, optionxformvalue=None)
+            input_io = BytesIO(input)
+            try:
+                self._inifile = INIConfig(input_io, optionxformvalue=None)
+            except MissingSectionHeaderError:
+                # Dirty workaround to be able to process section-less INI files
+                # that iniparse don't like.
+                logging.error("INI file lacks sections. Trying again "
+                              "injecting a [default] section at the file "
+                              "beginning.")
+                input_io = BytesIO("[default]\n" + input)
+                self._inifile = INIConfig(input_io, optionxformvalue=None)
         else:
-            self._inifile = INIConfig(file(input), optionxformvalue=None)
+            try:
+                self._inifile = INIConfig(file(input), optionxformvalue=None)
+            except MissingSectionHeaderError:
+                # Dirty workaround to be able to process section-less INI files
+                # that iniparse don't like.
+                logging.error("INI file lacks sections. Trying again "
+                              "injecting a [default] section at the file "
+                              "beginning.")
+                f = file(input)
+                input_io = BytesIO("".join(["[default]\n"] + f.readlines()))
+                self._inifile = INIConfig(input_io, optionxformvalue=None)
 
         for section in self._inifile:
             for entry in self._inifile[section]:

--- a/translate/storage/ini.py
+++ b/translate/storage/ini.py
@@ -107,7 +107,7 @@ class inifile(base.TranslationStore):
         for unit in self.units:
             for location in unit.getlocations():
                 match = re.match('\\[(?P<section>.+)\\](?P<entry>.+)', location)
-                _outinifile[match.groupdict()['section']][match.groupdict()['entry']] = self._dialect.escape(unit.target)
+                _outinifile[match.groupdict()['section']][match.groupdict()['entry']] = self._dialect.escape(unit.source)
         if _outinifile:
             out.write(str(_outinifile))
 

--- a/translate/storage/test_ini.py
+++ b/translate/storage/test_ini.py
@@ -24,3 +24,30 @@ class TestINIFile(test_monolingual.TestMonolingualStore):
     def regen_ini(self, ini_source):
         """Helper that converts INI source to inifile object and back."""
         return str(self.parse_ini(ini_source))
+
+    def test_section_less(self):
+        """Check that a section-less INI is parsed correctly."""
+        ini_source = """3dArt=3D art
+About=About
+AdvancedGameOptions=Advanced Options
+"""
+        ini_file = self.parse_ini(ini_source)
+        assert len(ini_file.units) == 3
+        ini_unit = ini_file.units[0]
+        assert ini_unit.location == "[default]3dArt"
+        assert ini_unit.source == "3D art"
+        ini_unit = ini_file.units[1]
+        assert ini_unit.location == "[default]About"
+        assert ini_unit.source == "About"
+        ini_unit = ini_file.units[2]
+        assert ini_unit.location == "[default]AdvancedGameOptions"
+        assert ini_unit.source == "Advanced Options"
+
+    def test_section_less_source(self):
+        """checks that a simple php definition can be regenerated as source"""
+        ini_source = """3dArt=3D art
+About=About
+AdvancedGameOptions=Advanced Options
+"""
+        regen_ini = self.regen_ini(ini_source)
+        assert '[default]\n' + ini_source == regen_ini

--- a/translate/storage/test_ini.py
+++ b/translate/storage/test_ini.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from translate.misc import wStringIO
+from translate.storage import ini, test_monolingual
+
+
+class TestINIUnit(test_monolingual.TestMonolingualUnit):
+    UnitClass = ini.iniunit
+
+    def test_difficult_escapes(self):
+        pass
+
+
+class TestINIFile(test_monolingual.TestMonolingualStore):
+    StoreClass = ini.inifile
+
+    def parse_ini(self, ini_source):
+        """Helper that parses INI source without requiring files."""
+        dummy_file = wStringIO.StringIO(ini_source)
+        ini_file = self.StoreClass(dummy_file)
+        return ini_file
+
+    def regen_ini(self, ini_source):
+        """Helper that converts INI source to inifile object and back."""
+        return str(self.parse_ini(ini_source))


### PR DESCRIPTION
This is a workaround for iniparse inability to parse INI files without any section.

Fixes bug #342
Fixes bug #1428