### PR TITLE
Drop use of simplejson

### DIFF
--- a/translate/services/tmserver.py
+++ b/translate/services/tmserver.py
@@ -25,10 +25,7 @@ with clients using JSON over HTTP."""
 import logging
 from urlparse import parse_qs
 from optparse import OptionParser
-try:
-    import json  # available since Python 2.6
-except ImportError:
-    import simplejson as json  # API compatible with the json module
+import json
 
 from translate.misc import selector
 from translate.misc import wsgi

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -69,10 +69,7 @@ TODO:
 
 import os
 from StringIO import StringIO
-try:
-    import json as json  # available since Python 2.6
-except ImportError:
-    import simplejson as json  # API compatible with the json module
+import json
 
 from translate.storage import base
 


### PR DESCRIPTION
Since json is a standard library as of Python 2.6 and 2.6 is our
baseline target we can drop the need for simplejson.

I ran the tests outlined in http://stackoverflow.com/questions/712791/what-are-the-differences-between-json-and-simplejson-python-modules

The results are very similar for Python 2.7 but Python 2.6 is much slower.

Regardless of that I think this should land because:
1. It works fast for what will most likely be our largest userbase Python 2.7 and up
2. We get to use a standard library.
3. We know we don't have any Unicode issues that simplejson apparently won't fix, though I haven't checked what those are specifically.
