### PR TITLE
Support for new Subversion client storing data in one .svn directory at ...

### DIFF
--- a/translate/storage/versioncontrol/svn.py
+++ b/translate/storage/versioncontrol/svn.py
@@ -54,7 +54,7 @@ class svn(GenericRevisionControlSystem):
     """Class to manage items under revision control of Subversion."""
 
     RCS_METADIR = ".svn"
-    SCAN_PARENTS = False
+    SCAN_PARENTS = True
 
     def update(self, revision=None, needs_revert=True):
         """update the working copy - remove local modifications if necessary"""
@@ -83,7 +83,7 @@ class svn(GenericRevisionControlSystem):
     def add(self, files, message=None, author=None):
         """Add and commit the new files."""
         files = prepare_filelist(files)
-        command = ["svn", "add", "-q", "--non-interactive", "--parents"] + files
+        command = ["svn", "add", "-q", "--non-interactive", "--parents", "--force"] + files
         exitcode, output, error = run_command(command)
         if exitcode != 0:
             raise IOError("[SVN] Error running SVN command '%s': %s" %


### PR DESCRIPTION
According to:
http://subversion.apache.org/docs/release-notes/1.7.html#wc-ng

In 1.7, the .svn directory is no longer in every versioned directory and just in the root

"A key feature of the changes introduced in Subversion 1.7 is the centralization of working copy metadata storage into a single location. Instead of a .svn directory in every directory in the working copy, Subversion 1.7 working copies have just one .svn directory—in the root of the working copy."

This results that pootle cannot handle repos checked ou by svn 1.7 - pootle cannot find .svn subdirectory.

This fix tries to correct it.
