### PR TITLE
Report encoding detection errors as IOError to prevent fatal errors in P...

### DIFF
--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -547,6 +547,8 @@ class propfile(base.TranslationStore):
             default_encodings=[self.personality.default_encoding, 'utf-8',
                                'utf-16'])
         self.encoding = encoding
+        if not text:
+            raise IOError("Cannot detect encoding for %s" %  self.filename)
         propsrc = text
 
         newunit = propunit("", self.personality.name)

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pytest import deprecated_call
+from pytest import raises
 
 from translate.misc import wStringIO
 from translate.storage import properties
@@ -359,3 +360,9 @@ key=value
         bom = propsource[:2]
         assert result.startswith(bom)
         assert bom not in result[2:]
+
+    def test_raise_ioerror_if_cannot_detect_encoding(self):
+        """test that IOError is thrown if file encoding cannot be detected"""
+        propsource = u"key = ąćęłńóśźż".encode("cp1250")
+        with raises(IOError):
+            self.propparse(propsource, personality="strings")


### PR DESCRIPTION
Sometimes Java .properties files contain characters in encoding other than US-ASCII or UTF-8. Of course it should be fixed by using native2ascii and escaping such characters.
While loading project to Pootle with many property files it's impossible to find, which file is incorrect, because of badly encoded characters - Pootle show only error about NoneObject at properties.py, but no actual properties filename.
This fix checks if file can be read and if not - raise IOError with filename, so Pootle can read next file, and user can find problematic files in web GUI.
