### PR TITLE
Accesskeys: tests for numeric and fixes for Unicode

### DIFF
--- a/translate/convert/accesskey.py
+++ b/translate/convert/accesskey.py
@@ -185,9 +185,7 @@ def combine(label, accesskey,
         accesskeypos = accesskeyaltcasepos
     # now we want to handle whatever we found...
     if accesskeypos >= 0:
-        string = label[:accesskeypos] + accesskey_marker + label[accesskeypos:]
-        string = string.encode("UTF-8", "replace")
-        return string
+        return label[:accesskeypos] + accesskey_marker + label[accesskeypos:]
     else:
         # can't currently mix accesskey if it's not in label
         return None

--- a/translate/convert/test_accesskey.py
+++ b/translate/convert/test_accesskey.py
@@ -54,6 +54,7 @@ def test_unicode():
     label, akey = accesskey.extract(u"E&ḓiṱ")
     assert label, akey == (u"Eḓiṱ", u"ḓ")
     assert isinstance(label, unicode) and isinstance(akey, unicode)
+    assert accesskey.combine(u"Eḓiṱ", u"ḓ") == (u"E&ḓiṱ")
 
 
 def test_numeric():


### PR DESCRIPTION
- Add a test for numeric accesskeys
- Add combining test for Unicode chars and drop code that converted the output to UTF8.  Tested on Mozilla roundtrip with no problems.
