### PR TITLE
Android plurals

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -10,3 +10,5 @@ vobject>=0.6.6       # iCal (ical2po)
 #aeidon>=0.14        # Subtitles (sub2po)
 # aeidon not available through pip/PyPI,
 # so recording this dependency here is pointless except as a comment
+
+Babel==1.3           # Android plurals


### PR DESCRIPTION
Here is a clean and rebased pull request in order to add support for Android plurals, as I said here https://github.com/translate/translate/pull/23#issuecomment-31671327.

I actually delegated the Unicode CLDR plural list maintenance to Babel (added as a new dependency), in order to get a cleaner and more maintainable code.

I also added a couple of simple tests.

Bye,
Luca
