### PR TITLE
Bug 3194 - Faulty error message while initializing properties storage

### DIFF
--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -564,7 +564,8 @@ class propfile(base.TranslationStore):
             default_encodings=[self.personality.default_encoding, 'utf-8',
                                'utf-16'])
         if not text:
-            raise IOError("Cannot detect encoding for %s" %  self.filename)
+            raise IOError("Cannot detect encoding for %s."
+                %  (self.filename or "given string") )
         self.encoding = encoding
         propsrc = text
 


### PR DESCRIPTION
Just improving error message when unable to find encoding for a string.
