### PR TITLE
properties: handle \uNN

### DIFF
--- a/translate/misc/quote.py
+++ b/translate/misc/quote.py
@@ -369,8 +369,7 @@ def propertiesdecode(source):
             # we just return the character, unescaped
             # if people want to escape them they can use escapecontrols
             return unichr(i)
-        else:
-            return "\\u%04x" % i
+        return "\\u%04x" % i
 
     while s < len(source):
         c = source[s]
@@ -397,16 +396,18 @@ def propertiesdecode(source):
             digits = 4
             x = 0
             for digit in range(digits):
-                x <<= 4
                 if s + digit >= len(source):
                     digits = digit
                     break
                 c = source[s + digit].lower()
-                if c.isdigit():
-                    x += ord(c) - ord('0')
-                elif c in "abcdef":
-                    x += ord(c) - ord('a') + 10
+                if c.isdigit() or c in "abcdef":
+                    x <<= 4
+                    if c.isdigit():
+                        x += ord(c) - ord('0')
+                    else:
+                        x += ord(c) - ord('a') + 10
                 else:
+                    digits = digit
                     break
             s += digits
             output += unichr2(x)

--- a/translate/misc/test_quote.py
+++ b/translate/misc/test_quote.py
@@ -87,6 +87,14 @@ class TestEncoding:
         assert quote.propertiesdecode(u"abc\u1E13") == u"abcḓ"
         assert quote.propertiesdecode(u"abc\N{LEFT CURLY BRACKET}") == u"abc{"
         assert quote.propertiesdecode(u"abc\\") == u"abc\\"
+        assert quote.propertiesdecode(u"abc\\") == u"abc\\"
+
+    def test_properties_decode_slashu(self):
+        assert quote.propertiesdecode(u"abc\u1e13") == u"abcḓ"
+        assert quote.propertiesdecode(u"abc\u0020") == u"abc "
+        # NOTE Java only accepts 4 digit unicode, Mozilla accepts two
+        # unfortunately, but it seems harmless to accept both.
+        assert quote.propertiesdecode("abc\u20") == u"abc "
 
     def _html_encoding_helper(self, pairs):
         for from_, to in pairs:


### PR DESCRIPTION
Slight change in processing to make sure that we don't bitshift if the
char is not a hex char.  The code worked otherwise.

Not Java does not support \uNN or \uNNN.  But it can't hurt to support
this in either.
