### PR TITLE
properties: escape leading and trailing spaces

### DIFF
--- a/translate/convert/test_po2prop.py
+++ b/translate/convert/test_po2prop.py
@@ -126,6 +126,48 @@ prop.accesskey=V
         print(propfile)
         assert propfile == propexpected
 
+    def test_mozilla_margin_whitespace(self):
+        """Check handling of Mozilla leading and trailing spaces"""
+        posource = '''#: sepAnd
+msgid " and "
+msgstr " و "
+
+#: sepComma
+msgid ", "
+msgstr "، "
+'''
+        proptemplate = r'''sepAnd = \u0020and\u0020
+sepComma = ,\u20
+'''
+        propexpected = r'''sepAnd = \u0020و\u0020
+sepComma = ،\u0020
+'''
+        propfile = self.merge2prop(proptemplate, posource, personality="mozilla")
+        print(propfile)
+        assert propfile == propexpected
+
+    def test_mozilla_all_whitespace(self):
+        """Check for all white-space Mozilla hack, remove when the
+        corresponding code is removed."""
+        posource = '''#: accesskey-accept
+msgctxt "accesskey-accept"
+msgid ""
+msgstr " "
+
+#: accesskey-help
+msgid "H"
+msgstr "م"
+'''
+        proptemplate = '''accesskey-accept=
+accesskey-help=H
+'''
+        propexpected = '''accesskey-accept=
+accesskey-help=م
+'''
+        propfile = self.merge2prop(proptemplate, posource, personality="mozilla")
+        print(propfile)
+        assert propfile == propexpected
+
     def test_merging_propertyless_template(self):
         """check that when merging with a template with no property values that we copy the template"""
         posource = ""

--- a/translate/misc/quote.py
+++ b/translate/misc/quote.py
@@ -325,6 +325,28 @@ def mozillapropertiesencode(source):
             output += char
     return output
 
+def escapespace(char):
+    assert(len(char) == 1)
+    if char.isspace():
+        return u"\\u%04X" %(ord(char))
+    return char
+
+def mozillaescapemarginspaces(source):
+    """Escape leading and trailing spaces for Mozilla .properties files."""
+    if not source:
+        return u""
+
+    if len(source) == 1 and source.isspace():
+        # FIXME: This is hack for people using white-space to mark empty
+        # Mozilla strings translated, drop this once we have better way to
+        # handle this in Pootle.
+        return u""
+
+    if len(source) == 1:
+        return escapespace(source)
+    else:
+        return escapespace(source[0]) + source[1:-1] + escapespace(source[-1])
+
 propertyescapes = {
     # escapes that are self-escaping
     "\\": "\\", "'": "'", '"': '"',

--- a/translate/misc/test_quote.py
+++ b/translate/misc/test_quote.py
@@ -74,6 +74,16 @@ class TestEncoding:
         assert quote.mozillapropertiesencode(u"abcḓ") == u"abcḓ"
         assert quote.mozillapropertiesencode(u"abc\n") == u"abc\\n"
 
+    def test_escapespace(self):
+        assert quote.escapespace(u" ") == u"\\u0020"
+        assert quote.escapespace(u"\t") == u"\\u0009"
+
+    def test_mozillaescapemarginspaces(self):
+        assert quote.mozillaescapemarginspaces(u" ") == u""
+        assert quote.mozillaescapemarginspaces(u"A") == u"A"
+        assert quote.mozillaescapemarginspaces(u" abc ") == u"\\u0020abc\\u0020"
+        assert quote.mozillaescapemarginspaces(u"  abc ") == u"\\u0020 abc\\u0020"
+
     def test_mozilla_control_escapes(self):
         r"""test that we do \uNNNN escapes for certain control characters instead of converting to UTF-8 characters"""
         prefix, suffix = "bling", "blang"

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -355,6 +355,13 @@ class DialectMozilla(DialectJavaUtf8):
     name = "mozilla"
     delimiters = [u"="]
 
+    @classmethod
+    def encode(cls, string, encoding=None):
+        """Encode the string"""
+        string = quote.mozillapropertiesencode(string or u"")
+        string = quote.mozillaescapemarginspaces(string or u"")
+        return string
+
 
 @register_dialect
 class DialectGaia(DialectMozilla):


### PR DESCRIPTION
Otherwise Mozilla’s parser will “eat” them.
