### PR TITLE
po2moz: Extensions are either "EXT" or "EXT.po".

### DIFF
--- a/translate/convert/po2moz.py
+++ b/translate/convert/po2moz.py
@@ -41,9 +41,13 @@ class MozConvertOptionParser(convert.ConvertOptionParser):
         """splits a inputpath into name and extension"""
         # TODO: not sure if this should be here, was in po2moz
         d, n = os.path.dirname(inputpath), os.path.basename(inputpath)
-        s = n.find(".")
+        s = n.rfind(".")
         if s == -1:
             return (inputpath, "")
+        if n[s+1:].lower() == "po":
+            s = n.rfind(".", 0, s)
+            if s == -1:
+                s = n.rfind(".")
         root = os.path.join(d, n[:s])
         ext = n[s+1:]
         return (root, ext)


### PR DESCRIPTION
Firefox OS l10n has a file named "settings.device.properties" that has many dots and po2moz thinks that extension is ".device.properties" instead of just ".properties". The pull request fixes this by forcing extensions to be either "EXT" or "EXT.po".
