### PR TITLE
ts2: Improve the output of processed TS files

### DIFF
--- a/requirements/recommended.txt
+++ b/requirements/recommended.txt
@@ -3,7 +3,7 @@
 ###############
 
 # lxml - for XML processing (XLIFF, TMX, TBX, Android)
-lxml>=2.2.0
+lxml>=2.3.6
 
 # Faster matching in e.g. pot2po
 # 0.11.0 is broken using pip, later versions are fixed

--- a/translate/storage/test_ts2.py
+++ b/translate/storage/test_ts2.py
@@ -32,6 +32,35 @@ from translate.storage.placeables import parse, xliff
 from translate.storage.placeables.lisa import xml_to_strelem
 
 
+TS_NUMERUS = """<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>Dialog2</name>
+    <message numerus="yes">
+        <source>%n files</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message id="this_is_some_id" numerus="yes">
+        <source>%n cars</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Age: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="this_is_another_id">
+        <source>func3</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>
+"""
+
 xliffparsers = []
 for attrname in dir(xliff):
     attr = getattr(xliff, attrname)
@@ -216,35 +245,12 @@ class TestTSfile(test_base.TestTranslationStore):
 
     def test_getid(self):
         """test that getid works well"""
-        tsstr = """<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1">
-<context>
-    <name>Dialog2</name>
-    <message numerus="yes">
-        <source>%n files</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message id="this_is_some_id" numerus="yes">
-        <source>%n cars</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>Age: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="this_is_another_id">
-        <source>func3</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-</TS>"""
-
-        tsfile = ts.tsfile.parsestring(tsstr)
+        tsfile = ts.tsfile.parsestring(TS_NUMERUS)
         assert tsfile.units[0].getid() == "Dialog2%n files"
         assert tsfile.units[1].getid() == "Dialog2\nthis_is_some_id%n cars"
         assert tsfile.units[3].getid() == "Dialog2\nthis_is_another_idfunc3"
+
+    def test_backnforth(self):
+        """test that ts files are read and output properly"""
+        tsfile = ts.tsfile.parsestring(TS_NUMERUS)
+        assert str(tsfile) == TS_NUMERUS

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -481,5 +481,11 @@ class tsfile(lisa.LISAfile):
 
     def __str__(self):
         """Converts to a string containing the file's XML."""
-        return etree.tostring(self.document, pretty_print=True,
+        root = self.document.getroot()
+        doctype = self.document.docinfo.doctype
+        # Iterate over empty tags without children and force empty text
+        # This will prevent self-closing tags in pretty_print mode
+        for e in root.xpath("//*[not(./node()) and not(text())]"):
+            e.text = ""
+        return etree.tostring(root, doctype=doctype, pretty_print=True,
                               xml_declaration=True, encoding='utf-8')


### PR DESCRIPTION
- Remove a nasty hack we no longer need
- Pretty-print empty tags without self-closing them
- Always preserve TS doctype
- Add a test reusing existing ts data

Fixes #1420
