### PR TITLE
Implicitly pass separators

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -155,7 +155,7 @@ class JsonFile(base.TranslationStore):
             self.parse(inputfile)
 
     def __str__(self):
-        return json.dumps(self._file, sort_keys=True,
+        return json.dumps(self._file, sort_keys=True, separators=(',', ': '),
                           indent=4, ensure_ascii=False).encode('utf-8')
 
     def _extract_translatables(self, data, stop=None, prev="", name_node=None,


### PR DESCRIPTION
When you pass indent without separators, leading space appears on the end of each line:
```
>>> json.dumps({'x': 'y', 'y': 'z'}, sort_keys=True, indent=4)
'{\n    "x": "y", \n    "y": "z"\n}'
>>> json.dumps({'x': 'y', 'y': 'z'}, sort_keys=True, indent=4, separators=(',', ': '))
'{\n    "x": "y",\n    "y": "z"\n}'
```
It not so big issue, but in weblate this leading to change of whole file in git, while no actual changes were done.