### PR TITLE
Dump current units content instead of file

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -155,7 +155,11 @@ class JsonFile(base.TranslationStore):
             self.parse(inputfile)
 
     def __str__(self):
-        return json.dumps(self._file, sort_keys=True,
+        units = {}
+        for unit in self.unit_iter():
+            path = unit.getid().lstrip('.')
+            units[path] = unit.target
+        return json.dumps(units, sort_keys=True, separators=(',', ': '),
                           indent=4, ensure_ascii=False).encode('utf-8')
 
     def _extract_translatables(self, data, stop=None, prev="", name_node=None,


### PR DESCRIPTION
`_file` is not updating anywhere and hold content of loaded file, and when new translated units manually added `__str__` still returns file content instead of current units content.