### PR TITLE
Small updates for the new resx2po / po2resx converter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -259,6 +259,7 @@ Use ``--help`` to find the syntax and options for all programs.
         ini2po   - convert .ini files to to PO
         ical2po  - Convert iCalendar files (*.ics) to PO
         sub2po   - Convert many subtitle files to PO
+        resx2po  - convert .Net Resource (.resx) files to PO
 
 * Tools (Quality Assurance)::
 

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ translatescripts = [join(*('translate', ) + script) for script in [
                   ('convert', 'tiki2po'), ('convert', 'po2tiki'),
                   ('convert', 'php2po'), ('convert', 'po2php'),
                   ('convert', 'rc2po'), ('convert', 'po2rc'),
+                  ('convert', 'resx2po'), ('convert', 'po2resx'),
                   ('convert', 'xliff2po'), ('convert', 'po2xliff'),
                   ('convert', 'sub2po'), ('convert', 'po2sub'),
                   ('convert', 'symb2po'), ('convert', 'po2symb'),

--- a/translate/convert/po2resx
+++ b/translate/convert/po2resx
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# 
+# Copyright 2015 Zuza Software Foundation
+# 
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+# 
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""simple script to convert a Gettext PO localisation file to a
+.Net Resource (.resx) file"""
+
+from translate.convert import po2resx
+
+if __name__ == '__main__':
+    po2resx.main()
+

--- a/translate/convert/po2resx.py
+++ b/translate/convert/po2resx.py
@@ -1,15 +1,35 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Convert Gettext PO localisation files to .Net Resource (.resx) files."""
+#
+# Copyright 2015 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""Convert Gettext PO localisation files to .Net Resource (.resx) files.
+
+See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/commands/resx2po.html
+for examples and usage instructions.
+"""
 
 from translate.convert import convert
-from translate.storage import factory
+from translate.storage import factory, resx
 
 
 class po2resx:
     def __init__(self, templatefile, inputstore):
-        from translate.storage import resx
-
         self.templatefile = templatefile
         self.templatestore = resx.RESXFile(templatefile)
         self.inputstore = inputstore

--- a/translate/convert/resx2po
+++ b/translate/convert/resx2po
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# 
+# Copyright 2015 Zuza Software Foundation
+# 
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+# 
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""simple script to convert a .Net Resource (.resx) file to a
+Gettext PO localisation file"""
+
+from translate.convert import resx2po
+
+if __name__ == '__main__':
+    resx2po.main()
+

--- a/translate/convert/resx2po.py
+++ b/translate/convert/resx2po.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Convert .Net Resource (.resx) to  Gettext PO localisation files  files."""
+#
+# Copyright 2015 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-import sys
+"""Convert .Net Resource (.resx) to  Gettext PO localisation files  files.
+
+See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/commands/resx2po.html
+for examples and usage instructions.
+"""
+
 import logging
 
 from translate.storage import po
@@ -10,7 +31,7 @@ from translate.storage import po
 logger = logging.getLogger(__name__)
 
 class resx2po:
-    """Convert a RESX file to a PO file"""
+    """Convert a RESX file to a PO file for handling translation"""
 
     def convert_store(self, input_store, duplicatestyle="msgctxt"):
         """Converts a RESX file to a PO file"""

--- a/translate/convert/test_po2resx.py
+++ b/translate/convert/test_po2resx.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# coding=utf-8
+# -*- coding: utf-8 -*-
 
 from translate.convert import po2resx, test_convert
 from translate.storage import po

--- a/translate/storage/resx.py
+++ b/translate/storage/resx.py
@@ -1,5 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+#
+# Copyright 2015 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
 """Module for handling .Net Resource (.resx) files."""
 
 from lxml import etree


### PR DESCRIPTION
Resolving issues found in the review of PR #3242.

Feedback from @dwaynebailey: 
> 1. Missing wrapper scripts for resx2po and po2resx see e.g. translate/convert/ical2po
> 2. Missing copyright headers - we're going to revise these soon anyway but for now how would you like to be credited e.g. SJ Hale, fullname version or some company.
> 3. Missing resx2po and po2resx in setup.py
> 4. Possibly an error in encoding headers in one of the test files.

@dwaynebailey - I think I've addressed all the issues above, please let me know if I've missed (or misunderstood!) anything! 

Re: 2, I'd like to use my full name (Sarah Hale) please :)
