### PR TITLE
resx addnote() bug fix - avoid endless comment duplication if there is leading/trailing whitespace

### DIFF
--- a/translate/convert/test_po2resx.py
+++ b/translate/convert/test_po2resx.py
@@ -285,6 +285,23 @@ msgstr "Bézier-kurwe"
         resx_file = self.po2resx(resx_template, po_source)
         assert resx_file == expected_output
 
+    def test_automaticcomments_existingduplicatecommentwithwhitespace(self):
+        """ Tests there is no duplication of automatic comments if it already exists, hasn't changed but has leading or
+        trailing whitespaces """
+        po_source = r'''#.  This is an existing comment with leading and trailing spaces
+#: ResourceKey
+msgid "Bézier curve"
+msgstr "Bézier-kurwe"
+'''
+        resx_template = self.XMLskeleton % '''<data name="ResourceKey" xml:space="preserve">
+        <value></value>
+        <comment> This is an existing comment with leading and trailing spaces </comment></data>'''
+        expected_output = self.XMLskeleton % '''<data name="ResourceKey" xml:space="preserve">
+        <value>Bézier-kurwe</value>
+    <comment>This is an existing comment with leading and trailing spaces</comment></data>'''
+        resx_file = self.po2resx(resx_template, po_source)
+        assert resx_file == expected_output
+
     def test_translatorcomments(self):
         """ Tests that translator comments are imported """
         po_source = r'''# This is a translator comment : 22.12.14
@@ -409,6 +426,7 @@ msgstr "Bézier-kurwe"
 [Translator Comment: This is an existing translator comment : 22.12.14]</comment></data>'''
         resx_file = self.po2resx(resx_template, po_source)
         assert resx_file == expected_output
+
 
 class TestPO2TSCommand(test_convert.TestConvertCommand, TestPO2RESX):
     """ Tests running actual po2ts commands on files """

--- a/translate/storage/resx.py
+++ b/translate/storage/resx.py
@@ -82,14 +82,15 @@ class RESXUnit(lisa.LISAunit):
         current_notes = self.getnotes(origin)
         self.removenotes(origin)
         note = etree.SubElement(self.xmlelement, self.namespaced("comment"))
+        text_stripped = text.strip()
         if position == "append":
-            if current_notes in text:
+            if current_notes.strip() in text_stripped:
                 # Don't add duplicate comments
-                note.text = text.strip()
+                note.text = text_stripped
             else:
-                note.text = "\n".join(filter(None, [current_notes, text.strip()]))
+                note.text = "\n".join(filter(None, [current_notes, text_stripped]))
         else:
-            note.text = text.strip()
+            note.text = text_stripped
 
     def getnotes(self, origin=None):
         comments = []


### PR DESCRIPTION
Discovered an issue whereby existing comments were being continually duplicated if the original comment contained leading or trailing whitespace. I've added a unit test to cover this scenario and fixed it by adding .strip() to the existing comment check in resx.py 