### PR TITLE
Mozilla lang files: import only real comments, not meta tags

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,7 +24,7 @@ Prerequisites
 
 * Remove old versions of toolkit on Debian
 
-The dollowing advice only applies to manual installation from tar ball.
+The following advice only applies to manual installation from tar ball.
 
 #. Find location of your python packages:
 
@@ -109,7 +109,7 @@ To install a tar.bz2:
    $ su
    $ ./setup.py install
 
- 
+
 On Windows simply click on the .exe file and follow the instructions.
 
 On Debian (if you are on etch), just type the following command:

--- a/translate/storage/mozilla_lang.py
+++ b/translate/storage/mozilla_lang.py
@@ -67,7 +67,7 @@ class LangStore(txt.TxtFile):
         super(LangStore, self).__init__(inputfile, flavour, encoding)
 
     def parse(self, lines):
-        #Have we just seen a ';' line, and so are ready for a translation
+        # Have we just seen a ';' line, and so are ready for a translation
         readyTrans = False
         comment = ""
 
@@ -91,7 +91,8 @@ class LangStore(txt.TxtFile):
                 readyTrans = False  # We already have our translation
                 continue
 
-            if line.startswith('#'):  # A comment
+            if line.startswith('#') and not line.startswith('##'):
+                # Read comments, but not meta tags (e.g. '## TAG')
                 comment += line[1:].strip() + "\n"
 
             if line.startswith(';'):


### PR DESCRIPTION
These days reference .lang files carry a lot of meta tags, no point in associating them to strings.

https://github.com/mozilla-l10n/langchecker/wiki/.lang-files-format