### PR TITLE
printf: fix handling multiple occurrences of positional directives

### DIFF
--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -914,6 +914,7 @@ class StandardChecker(TranslationChecker):
 
             if str2ord:
                 str1ord = None
+                gotmatch = False
 
                 for var_num1, match1 in enumerate(printf_pat.finditer(str1)):
                     count1 = var_num1 + 1
@@ -924,17 +925,20 @@ class StandardChecker(TranslationChecker):
                             str1ord = str2ord
                             str1fullvar = match1.group('fullvar') if not match1.group('boost_ord') else '%'
 
-                            if str2fullvar != str1fullvar:
-                                raise FilterFailure(u"Different printf variable: %s" % match2.group())
+                            if str2fullvar == str1fullvar:
+                                gotmatch = True
                     elif int(str2ord) == var_num1 + 1:
                         str1ord = str2ord
                         str1fullvar = match1.group('fullvar') if not match1.group('boost_ord') else '%'
 
-                        if str2fullvar != str1fullvar:
-                            raise FilterFailure(u"Different printf variable: %s" % match2.group())
+                        if str2fullvar == str1fullvar:
+                            gotmatch = True
 
                 if str1ord is None:
                     raise FilterFailure(u"Added printf variable: %s" % match2.group())
+
+                if not gotmatch:
+                    raise FilterFailure(u"Different printf variable: %s" % match2.group())
             elif str2key:
                 str1key = None
 


### PR DESCRIPTION
In reply to #3267:  'the checker fails when parsing the string "%1$+5d %1$d"'

The current code IMO enforces that the same positional parameter always has the same format, even if it occurs multiple times. The above string causes a 'Different printf variable' exception when comparing str2(%1$+5d) against str1(%1$d) after it successfully compared str2(%1$+5d) against str1(%1$+5d).

If multiple occurrences of the same positional parameter (%1$) with different formats are allowed, the inner loop comparing the parameters in str1 against a specific one in str2, should end as soon as a match was found. That's what the above patch tries.