### PR TITLE
Removed usage of remaining print-as-a-statement

### DIFF
--- a/docs/developers/styleguide.rst
+++ b/docs/developers/styleguide.rst
@@ -101,11 +101,11 @@ Example:
 .. code-block:: python
 
     def hello(name):
-        print 'Hello %s!' % name
+        print('Hello %s!' % name)
 
 
     def goodbye(name):
-        print 'See you %s.' % name
+        print('See you %s.' % name)
 
 
     class MyClass(object):

--- a/docs/formats/base_classes.rst
+++ b/docs/formats/base_classes.rst
@@ -158,12 +158,12 @@ what we discussed is related to the above.  A quick summary:
     of duplicate code in them). Ideally conversion should be as simple as::
 
       >>> po_store = POStore(filecontent)
-      >>> print str(po_store)
+      >>> print(str(po_store))
       msgid "bleep"
       msgstr "blorp"
        
       >>> xliff_store = XliffStore(po_store)
-      >>> print str(xliff_store)
+      >>> print(str(xliff_store))
       <xliff>
         <file>
           <trans-unit>

--- a/translate/search/match.py
+++ b/translate/search/match.py
@@ -90,8 +90,6 @@ class matcher(object):
         for store in stores:
             self.extendtm(store.units, store=store, sort=False)
         self.candidates.units.sort(key=sourcelen, reverse=self.sort_reverse)
-        # print "TM initialised with %d candidates (%d to %d characters long)" % \
-        #        (len(self.candidates.units), len(self.candidates.units[0].source), len(self.candidates.units[-1].source))
 
     def extendtm(self, units, store=None, sort=True):
         """Extends the memory with extra unit(s).

--- a/translate/storage/benchmark.py
+++ b/translate/storage/benchmark.py
@@ -154,7 +154,6 @@ if __name__ == "__main__":
             methods.append(("parse_placeables", ""))
 
         for methodname, methodparam in methods:
-            #print methodname, "%d dirs, %d files, %d strings, %d/%d words" % sample_file_sizes
             print("_______________________________________________________")
             statsfile = "%s_%s" % (methodname, storetype) + '_%d_%d_%d_%d_%d.stats' % sample_file_sizes
             cProfile.run('benchmarker.%s(%s)' % (methodname, methodparam), statsfile)

--- a/translate/storage/dtd.py
+++ b/translate/storage/dtd.py
@@ -323,7 +323,6 @@ class dtdunit(base.TranslationUnit):
         for line in lines:
             line += "\n"
             linesprocessed += 1
-            # print "line(%d,%d): " % (self.incomment,self.inentity),line[:-1]
             if not self.incomment:
                 if (line.find('<!--') != -1):
                     self.incomment = True
@@ -355,7 +354,6 @@ class dtdunit(base.TranslationUnit):
             if self.incomment:
                 # some kind of comment
                 (comment, self.incomment) = quote.extract(line, "<!--", "-->", None, self.continuecomment)
-                # print "comment(%d,%d): " % (self.incomment,self.continuecomment),comment
                 self.continuecomment = self.incomment
                 # strip the comment out of what will be parsed
                 line = line.replace(comment, "", 1)
@@ -554,7 +552,6 @@ class dtdfile(base.TranslationStore):
                     end += 1
                     break
                 end += 1
-            # print "processing from %d to %d" % (start,end)
 
             linesprocessed = 1  # to initialise loop
             while linesprocessed >= 1:

--- a/translate/storage/mo.py
+++ b/translate/storage/mo.py
@@ -55,7 +55,7 @@ def mounpack(filename='messages.mo'):
     """Helper to unpack Gettext MO files into a Python string"""
     f = open(filename)
     s = f.read()
-    print "\\x%02x" * len(s) % tuple(map(ord, s))
+    print("\\x%02x" * len(s) % tuple(map(ord, s)))
     f.close()
 
 

--- a/translate/storage/qm.py
+++ b/translate/storage/qm.py
@@ -158,7 +158,6 @@ class qmfile(base.TranslationStore):
         while pos < messages_start + len(messages_data):
             subsection, = struct.unpack(">B", input[pos:pos + 1])
             if subsection == 0x01:  # End
-                #print "End"
                 pos = pos + 1
                 if not source is None and not target is None:
                     newunit = self.addsourceunit(source)
@@ -167,7 +166,6 @@ class qmfile(base.TranslationStore):
                 else:
                     raise ValueError("Old .qm format with no source defined")
                 continue
-            #print pos, subsection
             pos = pos + 1
             length, = struct.unpack(">l", input[pos:pos + 4])
             if subsection == 0x03:  # Translation
@@ -183,22 +181,17 @@ class qmfile(base.TranslationStore):
                 else:
                     target = u""
                     pos = pos + 4
-                #print "Translation: %s" % target.encode('utf-8')
             elif subsection == 0x06:  # SourceText
                 source = input[pos + 4:pos + 4 + length].decode('iso-8859-1')
-                #print "SourceText: %s" % source
                 pos = pos + 4 + length
             elif subsection == 0x07:  # Context
                 context = input[pos + 4:pos + 4 + length].decode('iso-8859-1')
-                #print "Context: %s" % context
                 pos = pos + 4 + length
             elif subsection == 0x08:  # Disambiguating-comment
                 comment = input[pos + 4:pos + 4 + length]
-                #print "Disambiguating-comment: %s" % comment
                 pos = pos + 4 + length
             elif subsection == 0x05:  # hash
                 hash = input[pos:pos + 4]
-                #print "Hash: %s" % hash
                 pos = pos + 4
             else:
                 if subsection == 0x02:  # SourceText16

--- a/translate/storage/qm.py
+++ b/translate/storage/qm.py
@@ -75,7 +75,7 @@ def qmunpack(file_='messages.qm'):
     """Helper to unpack Qt .qm files into a Python string"""
     f = open(file_)
     s = f.read()
-    print "\\x%02x" * len(s) % tuple(map(ord, s))
+    print("\\x%02x" * len(s) % tuple(map(ord, s)))
     f.close()
 
 
@@ -125,7 +125,7 @@ class qmfile(base.TranslationStore):
         sectionheader = 5
 
         def section_debug(name, section_type, startsection, length):
-            print "Section: %s (type: %#x, offset: %#x, length: %d)" % (name, section_type, startsection, length)
+            print("Section: %s (type: %#x, offset: %#x, length: %d)" % (name, section_type, startsection, length))
             return
 
         while startsection < len(input):


### PR DESCRIPTION
print 'as a statement' does not exist any longer in Python 3.