### PR TITLE
Added relative imports where appropriate

### DIFF
--- a/translate/search/indexing/__init__.py
+++ b/translate/search/indexing/__init__.py
@@ -25,7 +25,7 @@ import logging
 import os
 import shutil
 
-import CommonIndexer
+from . import CommonIndexer
 
 
 """ TODO for indexing engines:

--- a/translate/search/indexing/test_indexers.py
+++ b/translate/search/indexing/test_indexers.py
@@ -26,8 +26,8 @@ import sys
 
 import pytest
 
-import __init__ as indexing
-import CommonIndexer
+from .. import indexing
+from . import CommonIndexer
 
 
 # following block only needs running under pytest; unclear how to detect it?

--- a/translate/storage/_factory_classes.py
+++ b/translate/storage/_factory_classes.py
@@ -22,21 +22,21 @@
 just for the sake of the Windows installer to easily pick up all the stuff
 that we need and ensure they make it into the installer."""
 
-import catkeys
-import csvl10n
-import mo
-import omegat
-import po
-import qm
-import qph
-import tbx
-import tmx
-import ts2
-import utx
-import wordfast
-import xliff
+from . import catkeys
+from . import csvl10n
+from . import mo
+from . import omegat
+from . import po
+from . import qm
+from . import qph
+from . import tbx
+from . import tmx
+from . import ts2
+from . import utx
+from . import wordfast
+from . import xliff
 
 try:
-    import trados
+    from . import trados
 except ImportError:
     pass

--- a/translate/storage/placeables/__init__.py
+++ b/translate/storage/placeables/__init__.py
@@ -45,14 +45,14 @@ The placeables model follows the XLIFF standard's list of placeables.
 Please refer to the XLIFF specification to get a better understanding.
 """
 
-import base
-import interfaces
-import general
-import xliff
-from base import *
-from base import __all__ as all_your_base
-from strelem import StringElem
-from parse import parse
+from . import base
+from . import interfaces
+from . import general
+from . import xliff
+from .base import *
+from .base import __all__ as all_your_base
+from .strelem import StringElem
+from .parse import parse
 
 
 __all__ = [

--- a/translate/storage/xml_extract/test_xpath_breadcrumb.py
+++ b/translate/storage/xml_extract/test_xpath_breadcrumb.py
@@ -19,7 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 
-import xpath_breadcrumb
+from . import xpath_breadcrumb
 
 
 def test_breadcrumb():


### PR DESCRIPTION
Python 3 does not accept implicit relative imports.
Making those explicit.