### PR TITLE
Replaced cStringIO.StringIO by io.BytesIO

### DIFF
--- a/docs/api/misc.rst
+++ b/docs/api/misc.rst
@@ -106,7 +106,6 @@ wStringIO
 
 .. automodule:: translate.misc.wStringIO
    :members:
-   :inherited-members:
 
 
 xml_helpers

--- a/translate/convert/convert.py
+++ b/translate/convert/convert.py
@@ -22,7 +22,7 @@
 :mod:`translate.convert` tools)."""
 
 import os.path
-from cStringIO import StringIO
+from io import BytesIO
 
 from translate.misc import optrecurse
 
@@ -391,7 +391,7 @@ class ArchiveConvertOptionParser(ConvertOptionParser):
             if outputstream is None:
                 self.warning("Could not find where to put %s in output "
                              "archive; writing to tmp" % fulloutputpath)
-                return StringIO()
+                return BytesIO()
             return outputstream
         else:
             return super(ArchiveConvertOptionParser, self).openoutputfile(options, fulloutputpath)

--- a/translate/convert/idml2po.py
+++ b/translate/convert/idml2po.py
@@ -20,7 +20,7 @@
 
 """Convert IDML files to PO localization files."""
 
-from cStringIO import StringIO
+from io import BytesIO
 
 from translate.convert import convert
 from translate.storage import factory
@@ -48,7 +48,7 @@ def convert_idml(inputfile, outputfile, template):
     for filename, translatable_file in contents.iteritems():
         parse_state = ParseState(NO_TRANSLATE_ELEMENTS, INLINE_ELEMENTS)
         po_store_adder = make_postore_adder(store, id_maker, filename)
-        build_idml_store(StringIO(translatable_file), store, parse_state,
+        build_idml_store(BytesIO(translatable_file), store, parse_state,
                          store_adder=po_store_adder)
 
     store.save()

--- a/translate/convert/odf2xliff.py
+++ b/translate/convert/odf2xliff.py
@@ -24,7 +24,7 @@ See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/command
 for examples and usage instructions.
 """
 
-from cStringIO import StringIO
+from io import BytesIO
 
 from translate.convert import convert
 from translate.storage import factory
@@ -52,7 +52,7 @@ def convertodf(inputfile, outputfile, templates):
     contents = open_odf(inputfile)
     for data in contents.values():
         parse_state = ParseState(no_translate_content_elements, inline_elements)
-        build_store(StringIO(data), store, parse_state)
+        build_store(BytesIO(data), store, parse_state)
 
     store.save()
     return True

--- a/translate/convert/po2idml.py
+++ b/translate/convert/po2idml.py
@@ -23,7 +23,7 @@ strings in the IDML template. It creates a new IDML file using the translations
 of the PO file.
 """
 
-from cStringIO import StringIO
+from io import BytesIO
 from zipfile import ZIP_DEFLATED, ZipFile
 
 import lxml.etree as etree
@@ -167,7 +167,7 @@ def convertpo(input_file, output_file, template):
                           if filename.startswith('Stories/')]
 
     po_data = input_file.read()
-    dom_trees = translate_idml(template, StringIO(po_data), translatable_files)
+    dom_trees = translate_idml(template, BytesIO(po_data), translatable_files)
 
     write_idml(template_zip, output_file, dom_trees)
     output_file.close()

--- a/translate/convert/po2web2py.py
+++ b/translate/convert/po2web2py.py
@@ -25,6 +25,8 @@ See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/command
 for examples and usage instructions.
 """
 
+from io import BytesIO
+
 from translate.convert import convert
 from translate.storage import factory
 
@@ -35,8 +37,7 @@ class po2pydict:
         return
 
     def convertstore(self, inputstore, includefuzzy):
-        from cStringIO import StringIO
-        str_obj = StringIO()
+        str_obj = BytesIO()
 
         mydict = dict()
         for unit in inputstore.units:

--- a/translate/convert/prop2mozfunny.py
+++ b/translate/convert/prop2mozfunny.py
@@ -37,6 +37,8 @@ def prop2inc(pf):
             else:
                 for blank in pendingblanks:
                     yield blank
+                if isinstance(comment, unicode):
+                    comment = comment.encode("UTF-8")
                 # TODO: could convert commented # x=y back to # #define x y
                 yield comment + "\n"
         if unit.isblank():

--- a/translate/convert/xliff2odf.py
+++ b/translate/convert/xliff2odf.py
@@ -25,7 +25,7 @@ for examples and usage instructions.
 """
 
 import zipfile
-from cStringIO import StringIO
+from io import BytesIO
 
 import lxml.etree as etree
 
@@ -49,7 +49,7 @@ def translate_odf(template, input_file):
         the etrees for each of those translatable files.
         """
         odf_data = open_odf(template)
-        return dict((filename, etree.parse(StringIO(data)))
+        return dict((filename, etree.parse(BytesIO(data)))
                     for filename, data in odf_data.iteritems())
 
     def load_unit_tree(input_file):
@@ -127,7 +127,7 @@ def convertxliff(input_file, output_file, template):
     output_file = file(output_file.name, mode='wb')
 
     xlf_data = input_file.read()
-    dom_trees = translate_odf(template, StringIO(xlf_data))
+    dom_trees = translate_odf(template, BytesIO(xlf_data))
     write_odf(template, output_file, dom_trees)
     output_file.close()
     return True

--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -25,7 +25,7 @@ import os.path
 import re
 import sys
 import traceback
-from cStringIO import StringIO
+from io import BytesIO
 
 from translate import __version__
 from translate.misc import progressbar
@@ -536,7 +536,7 @@ class RecursiveOptionParser(optparse.OptionParser, object):
 
     def opentempoutputfile(self, options, fulloutputpath):
         """Opens a temporary output file."""
-        return StringIO()
+        return BytesIO()
 
     def finalizetempoutputfile(self, options, outputfile, fulloutputpath):
         """Write the temp outputfile to its final destination."""

--- a/translate/misc/wStringIO.py
+++ b/translate/misc/wStringIO.py
@@ -18,128 +18,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-"""A wrapper for cStringIO that provides more of the functions of
-StringIO at the speed of cStringIO"""
+"""A thin wrapper around BytesIO that accepts and auto-convert non bytes input"""
 
-import cStringIO
+from io import BytesIO
 
 
-class StringIO:
+class StringIO(BytesIO):
 
     def __init__(self, buf=''):
         if not isinstance(buf, (str, unicode)):
             buf = str(buf)
         if isinstance(buf, unicode):
             buf = buf.encode('utf-8')
-        self.len = len(buf)
-        self.buf = cStringIO.StringIO()
-        self.buf.write(buf)
-        self.buf.seek(0)
-        self.pos = 0
-        self.closed = 0
-
-    def __iter__(self):
-        return self
-
-    def next(self):
-        if self.closed:
-            raise StopIteration
-        r = self.readline()
-        if not r:
-            raise StopIteration
-        return r
-
-    def close(self):
-        """Free the memory buffer.
-        """
-        if not self.closed:
-            self.closed = 1
-            del self.buf, self.pos
-
-    def isatty(self):
-        if self.closed:
-            raise ValueError("I/O operation on closed file")
-        return False
-
-    def seek(self, pos, mode=0):
-        if self.closed:
-            raise ValueError("I/O operation on closed file")
-        self.buf.seek(pos, mode)
-        self.pos = self.buf.tell()
-
-    def tell(self):
-        if self.closed:
-            raise ValueError("I/O operation on closed file")
-        return self.pos
-
-    def read(self, n=None):
-        if self.closed:
-            raise ValueError("I/O operation on closed file")
-        if n is None:
-            r = self.buf.read()
-        else:
-            r = self.buf.read(n)
-        self.pos = self.buf.tell()
-        return r
-
-    def readline(self, length=None):
-        if self.closed:
-            raise ValueError("I/O operation on closed file")
-        if length is not None:
-            r = self.buf.readline(length)
-        else:
-            r = self.buf.readline()
-        self.pos = self.buf.tell()
-        return r
-
-    def readlines(self):
-        if self.closed:
-            raise ValueError("I/O operation on closed file")
-        lines = self.buf.readlines()
-        self.pos = self.buf.tell()
-        return lines
-
-    def truncate(self, size=None):
-        if self.closed:
-            raise ValueError("I/O operation on closed file")
-        self.buf.truncate(size)
-        self.pos = self.buf.tell()
-        self.buf.seek(0, 2)
-        self.len = self.buf.tell()
-        self.buf.seek(self.pos)
-
-    def write(self, s):
-        if self.closed:
-            raise ValueError("I/O operation on closed file")
-        origpos = self.buf.tell()
-        self.buf.write(s)
-        self.pos = self.buf.tell()
-        if origpos + len(s) > self.len:
-            self.buf.seek(0, 2)
-            self.len = self.buf.tell()
-            self.buf.seek(self.pos)
-
-    def writelines(self, lines):
-        if self.closed:
-            raise ValueError("I/O operation on closed file")
-        self.buf.writelines(lines)
-        self.pos = self.buf.tell()
-        self.buf.seek(0, 2)
-        self.len = self.buf.tell()
-        self.buf.seek(self.pos)
-
-    def flush(self):
-        if self.closed:
-            raise ValueError("I/O operation on closed file")
-        self.buf.flush()
-
-    def getvalue(self):
-        if self.closed:
-            raise ValueError("I/O operation on closed file")
-        return self.buf.getvalue()
+        super(StringIO, self).__init__(buf)
 
 
-class CatchStringOutput(StringIO, object):
+class CatchStringOutput(StringIO):
     """catches the output before it is closed and sends it to an onclose
     method"""
 

--- a/translate/services/tmserver.py
+++ b/translate/services/tmserver.py
@@ -24,6 +24,7 @@ with clients using JSON over HTTP."""
 import json
 import logging
 from argparse import ArgumentParser
+from io import BytesIO
 from urlparse import parse_qs
 
 from translate.misc import selector, wsgi
@@ -122,10 +123,9 @@ class TMServer(object):
     @selector.opliant
     def upload_store(self, environ, start_response, sid, slang, tlang):
         """add units from uploaded file to tmdb"""
-        from cStringIO import StringIO
         from translate.storage import factory
         start_response("200 OK", [('Content-type', 'text/plain')])
-        data = StringIO(environ['wsgi.input'].read(int(environ['CONTENT_LENGTH'])))
+        data = BytesIO(environ['wsgi.input'].read(int(environ['CONTENT_LENGTH'])))
         data.name = sid
         store = factory.getobject(data)
         count = self.tmdb.add_store(store, slang, tlang)

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -24,7 +24,7 @@ or entire files (csvfile) for use with localisation
 
 import codecs
 import csv
-from cStringIO import StringIO
+from io import BytesIO
 
 from translate.misc import sparse
 from translate.storage import base
@@ -323,7 +323,7 @@ def valid_fieldnames(fieldnames):
 
 def detect_header(sample, dialect, fieldnames):
     """Test if file has a header or not, also returns number of columns in first row"""
-    inputfile = StringIO(sample)
+    inputfile = BytesIO(sample)
     try:
         reader = csv.reader(inputfile, dialect)
     except csv.Error:
@@ -420,7 +420,7 @@ class csvfile(base.TranslationStore):
         return source.encode(encoding)
 
     def getoutput(self):
-        outputfile = StringIO()
+        outputfile = BytesIO()
         writer = csv.DictWriter(outputfile, self.fieldnames, extrasaction='ignore', dialect=self.dialect)
         # write header
         hdict = dict(map(None, self.fieldnames, self.fieldnames))

--- a/translate/storage/dtd.py
+++ b/translate/storage/dtd.py
@@ -86,7 +86,7 @@ Escaping in Android DTD
 
 import re
 import warnings
-from cStringIO import StringIO
+from io import BytesIO
 try:
     from lxml import etree
 except ImportError:
@@ -598,7 +598,7 @@ class dtdfile(base.TranslationStore):
         if etree is not None and not self.android:
             try:
                 # #expand is a Mozilla hack and are removed as they are not valid in DTDs
-                dtd = etree.DTD(StringIO(re.sub("#expand", "", self.getoutput())))
+                dtd = etree.DTD(BytesIO(re.sub("#expand", "", self.getoutput())))
             except etree.DTDParseError as e:
                 warnings.warn("DTD parse error: %s" % e.error_log)
                 return False

--- a/translate/storage/fpo.py
+++ b/translate/storage/fpo.py
@@ -30,7 +30,7 @@ directly, but can be used once cpo has been established to work."""
 
 import copy
 import re
-from cStringIO import StringIO
+from io import BytesIO
 
 from translate.lang import data
 from translate.misc.multistring import multistring
@@ -330,7 +330,7 @@ class pounit(pocommon.pounit):
 
     def parse(self, src):
         raise DeprecationWarning("Should not be parsing with a unit")
-        return poparser.parse_unit(poparser.ParseState(StringIO(src), pounit), self)
+        return poparser.parse_unit(poparser.ParseState(BytesIO(src), pounit), self)
 
     def __str__(self):
         """convert to a string. double check that unicode is handled somehow here"""

--- a/translate/storage/ical.py
+++ b/translate/storage/ical.py
@@ -53,7 +53,7 @@ Future Format Support
 """
 
 import re
-from cStringIO import StringIO
+from io import BytesIO
 
 import vobject
 
@@ -120,7 +120,7 @@ class icalfile(base.TranslationStore):
             input.close()
             input = inisrc
         if isinstance(input, str):
-            input = StringIO(input)
+            input = BytesIO(input)
             self._icalfile = vobject.readComponents(input).next()
         else:
             self._icalfile = vobject.readComponents(open(input)).next()

--- a/translate/storage/ini.py
+++ b/translate/storage/ini.py
@@ -31,7 +31,7 @@ b : a string
 """
 
 import re
-from cStringIO import StringIO
+from io import BytesIO
 
 from iniparse import INIConfig
 
@@ -128,7 +128,7 @@ class inifile(base.TranslationStore):
             input = inisrc
 
         if isinstance(input, str):
-            input = StringIO(input)
+            input = BytesIO(input)
             self._inifile = INIConfig(input, optionxformvalue=None)
         else:
             self._inifile = INIConfig(file(input), optionxformvalue=None)

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -71,7 +71,7 @@ TODO:
 
 import json
 import os
-from cStringIO import StringIO
+from io import BytesIO
 
 from translate.storage import base
 
@@ -212,7 +212,7 @@ class JsonFile(base.TranslationStore):
             input.close()
             input = src
         if isinstance(input, str):
-            input = StringIO(input)
+            input = BytesIO(input)
         try:
             self._file = json.load(input)
         except ValueError as e:

--- a/translate/storage/placeables/test_terminology.py
+++ b/translate/storage/placeables/test_terminology.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-from cStringIO import StringIO
+from io import BytesIO
 
 from translate.search.match import terminologymatcher
 from translate.storage.placeables import StringElem, base, general, parse
@@ -43,7 +43,7 @@ msgstr "lêernaam"
 """
 
     def setup_method(self, method):
-        self.term_po = pofile(StringIO(self.TERMINOLOGY))
+        self.term_po = pofile(BytesIO(self.TERMINOLOGY))
         self.matcher = terminologymatcher(self.term_po)
         self.test_string = u'<b>Inpüt</b> file name thingy.'
 

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -26,7 +26,7 @@ files (pofile).
 import copy
 import re
 import textwrap
-from cStringIO import StringIO
+from io import BytesIO
 
 from translate.lang import data
 from translate.misc import quote
@@ -576,7 +576,7 @@ class pounit(pocommon.pounit):
         return len(self.msgid_plural) > 0
 
     def parse(self, src):
-        return poparser.parse_unit(poparser.ParseState(StringIO(src), pounit), self)
+        return poparser.parse_unit(poparser.ParseState(BytesIO(src), pounit), self)
 
     def _getmsgpartstr(self, partname, partlines, partcomments=""):
         if isinstance(partlines, dict):
@@ -765,7 +765,7 @@ class pofile(pocommon.pofile):
             elif not getattr(self, 'filename', ''):
                 self.filename = ''
             if isinstance(input, str):
-                input = StringIO(input)
+                input = BytesIO(input)
             # clear units to get rid of automatically generated headers before parsing
             self.units = []
             poparser.parse_units(poparser.ParseState(input, pounit), self)

--- a/translate/storage/subtitles.py
+++ b/translate/storage/subtitles.py
@@ -29,7 +29,7 @@
 
 import os
 import tempfile
-from cStringIO import StringIO
+from io import BytesIO
 
 try:
     from aeidon import Subtitle, documents, newlines
@@ -97,7 +97,7 @@ class SubtitleFile(base.TranslationStore):
             subtitle.start = unit._start
             subtitle.end = unit._end
             subtitles.append(subtitle)
-        output = StringIO()
+        output = BytesIO()
         self._subtitlefile.write_to_file(subtitles, documents.MAIN, output)
         return output.getvalue().encode(self._subtitlefile.encoding)
 

--- a/translate/storage/test_mo.py
+++ b/translate/storage/test_mo.py
@@ -3,7 +3,7 @@
 import os
 import subprocess
 import sys
-from cStringIO import StringIO
+from io import BytesIO
 
 from translate.storage import factory, mo, test_base
 
@@ -150,7 +150,7 @@ class TestMOFile(test_base.TestTranslationStore):
             subprocess.call(['msgfmt', PO_FILE, '-o', MO_MSGFMT])
             subprocess.call(['pocompile', '--errorlevel=traceback', PO_FILE, MO_POCOMPILE])
 
-            store = factory.getobject(StringIO(posource))
+            store = factory.getobject(BytesIO(posource))
             if store.isempty() and not os.path.exists(MO_POCOMPILE):
                 # pocompile doesn't create MO files for empty PO files, so we
                 # can skip the checks here.

--- a/translate/tools/test_pocount.py
+++ b/translate/tools/test_pocount.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from cStringIO import StringIO
+from io import BytesIO
 
 from pytest import mark
 
@@ -120,41 +120,41 @@ msgstr ""
 '''
 
     def test_translated(self):
-        pofile = StringIO(self.inputdata)
+        pofile = BytesIO(self.inputdata)
         stats = pocount.calcstats_old(pofile)
         assert stats['translated'] == 1
 
     def test_fuzzy(self):
-        pofile = StringIO(self.inputdata)
+        pofile = BytesIO(self.inputdata)
         stats = pocount.calcstats_old(pofile)
         assert stats['fuzzy'] == 1
 
     def test_untranslated(self):
-        pofile = StringIO(self.inputdata)
+        pofile = BytesIO(self.inputdata)
         stats = pocount.calcstats_old(pofile)
         assert stats['untranslated'] == 1
 
     def test_total(self):
-        pofile = StringIO(self.inputdata)
+        pofile = BytesIO(self.inputdata)
         stats = pocount.calcstats_old(pofile)
         assert stats['total'] == 3
 
     def test_translatedsourcewords(self):
-        pofile = StringIO(self.inputdata)
+        pofile = BytesIO(self.inputdata)
         stats = pocount.calcstats_old(pofile)
         assert stats['translatedsourcewords'] == 2
 
     def test_fuzzysourcewords(self):
-        pofile = StringIO(self.inputdata)
+        pofile = BytesIO(self.inputdata)
         stats = pocount.calcstats_old(pofile)
         assert stats['fuzzysourcewords'] == 2
 
     def test_untranslatedsourcewords(self):
-        pofile = StringIO(self.inputdata)
+        pofile = BytesIO(self.inputdata)
         stats = pocount.calcstats_old(pofile)
         assert stats['untranslatedsourcewords'] == 2
 
     def test_totalsourcewords(self):
-        pofile = StringIO(self.inputdata)
+        pofile = BytesIO(self.inputdata)
         stats = pocount.calcstats_old(pofile)
         assert stats['totalsourcewords'] == 6


### PR DESCRIPTION
The cStringIO module is no more in Python 3, and the io module
has been introduced in Python 2.6.