### PR TITLE
Removing duplicate messages in PO file parsers

### DIFF
--- a/translate/convert/test_po2ts.py
+++ b/translate/convert/test_po2ts.py
@@ -78,7 +78,7 @@ msgstr "b"
 '''
         tsfile = self.po2ts(posource)
         print(tsfile)
-        assert tsfile.find("English") != tsfile.rfind("English")
+        assert tsfile.find("English") == tsfile.rfind("English")
 
 
 class TestPO2TSCommand(test_convert.TestConvertCommand, TestPO2TS):

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -667,11 +667,17 @@ class pofile(pocommon.pofile):
                         markedpos.append(thepo)
                     thepo.setcontext(" ".join(thepo.getlocations()))
                     uniqueunits.append(thepo)
+                else:
+                    if self.filename:
+                        logger.warning("Duplicate message ignored "
+                                       "in '%s': '%s'" % (self.filename, id))
+                    else:
+                        logger.warning("Duplicate message ignored: '%s'" % id)
             else:
                 if not id:
                     if duplicatestyle == "merge":
                         addcomment(thepo)
-                    else:
+                    elif duplicatestyle == "msgctxt":
                         thepo.setcontext(" ".join(thepo.getlocations()))
                 id_dict[id] = thepo
                 uniqueunits.append(thepo)
@@ -735,7 +741,7 @@ class pofile(pocommon.pofile):
                 return False
         return True
 
-    def parse(self, input):
+    def parse(self, input, duplicatestyle="merge"):
         if hasattr(input, 'name'):
             self.filename = input.name
         elif not getattr(self, 'filename', ''):
@@ -776,6 +782,10 @@ class pofile(pocommon.pofile):
             self.addunit(newunit, new=False)
             newmessage = gpo.po_next_message(self._gpo_message_iterator)
         self._free_iterator()
+
+        # duplicates are now removed by default unless duplicatestyle=allow
+        if duplicatestyle != "allow":
+            self.removeduplicates(duplicatestyle=duplicatestyle)
 
     def __del__(self):
         # We currently disable this while we still get segmentation faults.

--- a/translate/storage/pocommon.py
+++ b/translate/storage/pocommon.py
@@ -201,13 +201,13 @@ class pofile(poheader.poheader, base.TranslationStore):
     # We don't want windows line endings on Windows:
     _binary = True
 
-    def __init__(self, inputfile=None, encoding=None):
+    def __init__(self, inputfile=None, encoding=None, duplicatestyle=None):
         super(pofile, self).__init__(unitclass=self.UnitClass)
         self.units = []
         self.filename = ''
         self._encoding = encodingToUse(encoding)
         if inputfile is not None:
-            self.parse(inputfile)
+            self.parse(inputfile, duplicatestyle)
         else:
             self.init_headers()
 

--- a/translate/storage/test_cpo.py
+++ b/translate/storage/test_cpo.py
@@ -99,8 +99,7 @@ class TestCPOFile(test_po.TestPOFile):
     def test_merge_duplicates_msgctxt(self):
         """checks that merging duplicates works for msgctxt"""
         posource = '#: source1\nmsgid "test me"\nmsgstr ""\n\n#: source2\nmsgid "test me"\nmsgstr ""\n'
-        pofile = self.poparse(posource)
-        assert len(pofile.units) == 2
+        pofile = self.poparse(posource, duplicatestyle="allow")
         pofile.removeduplicates("msgctxt")
         print(pofile)
         assert len(pofile.units) == 2
@@ -111,8 +110,7 @@ class TestCPOFile(test_po.TestPOFile):
     def test_merge_blanks(self):
         """checks that merging adds msgid_comments to blanks"""
         posource = '#: source1\nmsgid ""\nmsgstr ""\n\n#: source2\nmsgid ""\nmsgstr ""\n'
-        pofile = self.poparse(posource)
-        assert len(pofile.units) == 2
+        pofile = self.poparse(posource, duplicatestyle="allow")
         pofile.removeduplicates("merge")
         assert len(pofile.units) == 2
         print(pofile.units[0].msgidcomments)
@@ -124,8 +122,7 @@ class TestCPOFile(test_po.TestPOFile):
     def test_msgid_comment(self):
         """checks that when adding msgid_comments we place them on a newline"""
         posource = '#: source0\nmsgid "Same"\nmsgstr ""\n\n#: source1\nmsgid "Same"\nmsgstr ""\n'
-        pofile = self.poparse(posource)
-        assert len(pofile.units) == 2
+        pofile = self.poparse(posource, duplicatestyle="allow")
         pofile.removeduplicates("msgid_comment")
         assert len(pofile.units) == 2
         assert po.unquotefrompo(pofile.units[0].msgidcomments) == "_: source0\n"
@@ -139,8 +136,7 @@ class TestCPOFile(test_po.TestPOFile):
     def test_keep_blanks(self):
         """checks that keeping keeps blanks and doesn't add msgid_comments"""
         posource = '#: source1\nmsgid ""\nmsgstr ""\n\n#: source2\nmsgid ""\nmsgstr ""\n'
-        pofile = self.poparse(posource)
-        assert len(pofile.units) == 2
+        pofile = self.poparse(posource, duplicatestyle="allow")
         pofile.removeduplicates("keep")
         assert len(pofile.units) == 2
         # check we don't add msgidcomments

--- a/translate/storage/test_po.py
+++ b/translate/storage/test_po.py
@@ -171,11 +171,10 @@ class TestPOUnit(test_base.TestTranslationUnit):
 class TestPOFile(test_base.TestTranslationStore):
     StoreClass = po.pofile
 
-    def poparse(self, posource):
+    def poparse(self, posource, duplicatestyle=None):
         """helper that parses po source without requiring files"""
-        dummyfile = wStringIO.StringIO(posource)
-        pofile = self.StoreClass(dummyfile)
-        return pofile
+        return self.StoreClass(wStringIO.StringIO(posource),
+                               duplicatestyle=duplicatestyle)
 
     def poregen(self, posource):
         """helper that converts po source to pofile object and back"""
@@ -589,8 +588,7 @@ msgstr[1] "Koeie"
     def test_merge_duplicates(self):
         """checks that merging duplicates works"""
         posource = '#: source1\nmsgid "test me"\nmsgstr ""\n\n#: source2\nmsgid "test me"\nmsgstr ""\n'
-        pofile = self.poparse(posource)
-        #assert len(pofile.units) == 2
+        pofile = self.poparse(posource, duplicatestyle="allow")
         pofile.removeduplicates("merge")
         assert len(pofile.units) == 1
         assert pofile.units[0].getlocations() == ["source1", "source2"]
@@ -608,7 +606,7 @@ msgstr ""
 msgid "test"
 msgstr ""
 '''
-        pofile = self.poparse(posource)
+        pofile = self.poparse(posource, duplicatestyle="allow")
         print(str(pofile))
         pofile.removeduplicates("merge")
         print(str(pofile))

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -209,11 +209,32 @@ class TestPYPOFile(test_po.TestPOFile):
         regenposource = str(pofile)
         assert regenposource.count("_:") == 1
 
+    def test_duplicates_default(self):
+        """checks that duplicates are ignored by default"""
+        posource = '#: source1\nmsgid "test me"\nmsgstr ""\n\n#: source2\nmsgid "test me"\nmsgstr ""\n'
+        pofile = self.poparse(posource)
+        assert len(pofile.units) == 1
+        assert str(pofile.units[0]).count("source1") == 1
+        assert str(pofile.units[0]).count("source2") == 0
+
+    def test_duplicates_allow(self):
+        """
+        checks that you can create a pofile with duplicates - this is useful
+        or converting to other formats
+        """
+        posource = ('#: source1\nmsgid "test me"\nmsgstr ""\n\n'
+                    '#: source2\nmsgid "test me"\nmsgstr ""\n')
+        pofile = self.poparse(posource, duplicatestyle="allow")
+        assert len(pofile.units) == 2
+        assert str(pofile.units[0]).count("source1") == 1
+        assert str(pofile.units[0]).count("source2") == 0
+        assert str(pofile.units[1]).count("source1") == 0
+        assert str(pofile.units[1]).count("source2") == 1
+
     def test_merge_duplicates_msgctxt(self):
         """checks that merging duplicates works for msgctxt"""
         posource = '#: source1\nmsgid "test me"\nmsgstr ""\n\n#: source2\nmsgid "test me"\nmsgstr ""\n'
-        pofile = self.poparse(posource)
-        assert len(pofile.units) == 2
+        pofile = self.poparse(posource, duplicatestyle="allow")
         pofile.removeduplicates("msgctxt")
         print(pofile)
         assert len(pofile.units) == 2
@@ -223,8 +244,7 @@ class TestPYPOFile(test_po.TestPOFile):
     def test_merge_blanks(self):
         """checks that merging adds msgid_comments to blanks"""
         posource = '#: source1\nmsgid ""\nmsgstr ""\n\n#: source2\nmsgid ""\nmsgstr ""\n'
-        pofile = self.poparse(posource)
-        assert len(pofile.units) == 2
+        pofile = self.poparse(posource, duplicatestyle="allow")
         pofile.removeduplicates("merge")
         assert len(pofile.units) == 2
         print(pofile.units[0].msgidcomments)
@@ -307,7 +327,7 @@ msgstr[0] "toet"
 msgstr[1] "toetse"
 '''
 
-        pofile = self.poparse(posource)
+        pofile = self.poparse(posource, duplicatestyle="allow")
 
         assert pofile.units[1].prev_msgctxt == []
         assert pofile.units[1].prev_source == multistring([u"trea"])


### PR DESCRIPTION
PO files can't cope with duplicate messages, so they are removed when parsing
and a warning is logged

Fixes translate/pootle#3564