### PR TITLE
Replaced item.next() by next(item)

### DIFF
--- a/translate/misc/ourdom.py
+++ b/translate/misc/ourdom.py
@@ -108,16 +108,7 @@ def searchElementsByTagName_helper(parent, name, onlysearch):
 
 def getFirstElementByTagName(node, name):
     results = node.yieldElementsByTagName(name)
-#  if isinstance(results, list):
-#    if len(results) == 0:
-#      return None
-#    else:
-#      return results[0]
-    try:
-        result = results.next()
-        return result
-    except StopIteration:
-        return None
+    return next(results, None)
 
 
 def getnodetext(node):

--- a/translate/misc/wsgiserver/wsgiserver3.py
+++ b/translate/misc/wsgiserver/wsgiserver3.py
@@ -291,7 +291,7 @@ class SizeCheckWrapper(object):
         return data
 
     def next(self):
-        data = self.rfile.next()
+        data = next(self.rfile)
         self.bytes_read += len(data)
         self._check_length()
         return data

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -334,7 +334,7 @@ def detect_header(sample, dialect, fieldnames):
             inputfile.seek(0)
             reader = csv.reader(inputfile, 'excel')
 
-    header = reader.next()
+    header = next(reader)
     columncount = max(len(header), 3)
     if valid_fieldnames(header):
         return header

--- a/translate/storage/ical.py
+++ b/translate/storage/ical.py
@@ -121,9 +121,9 @@ class icalfile(base.TranslationStore):
             input = inisrc
         if isinstance(input, str):
             input = BytesIO(input)
-            self._icalfile = vobject.readComponents(input).next()
+            self._icalfile = next(vobject.readComponents(input))
         else:
-            self._icalfile = vobject.readComponents(open(input)).next()
+            self._icalfile = next(vobject.readComponents(open(input)))
         for component in self._icalfile.components():
             if component.name == "VEVENT":
                 for property in component.getChildren():

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -157,7 +157,7 @@ class LISAunit(base.TranslationUnit):
                 if self.textNode:
                     terms = languageNode.iter(self.namespaced(self.textNode))
                     try:
-                        languageNode = terms.next()
+                        languageNode = next(terms)
                     except StopIteration as e:
                         pass
                 languageNode.text = text
@@ -235,11 +235,11 @@ class LISAunit(base.TranslationUnit):
             terms = languageNode.iterdescendants(self.namespaced(self.textNode))
             if terms is None:
                 return None
-            try:
-                return getText(terms.next(), xml_space)
-            except StopIteration:
-                # didn't have the structure we expected
-                return None
+            node = next(terms, None)
+            if node is not None:
+                return getText(node, xml_space)
+            # didn't have the structure we expected
+            return None
         else:
             return getText(languageNode, xml_space)
 

--- a/translate/storage/poparser.py
+++ b/translate/storage/poparser.py
@@ -63,9 +63,9 @@ class ParseState(object):
         if self.eof:
             return current
         try:
-            self.next_line = self._input_iterator.next()
+            self.next_line = next(self._input_iterator)
             while not self.eof and isspace(self.next_line):
-                self.next_line = self._input_iterator.next()
+                self.next_line = next(self._input_iterator)
         except StopIteration:
             self.next_line = ''
             self.eof = True

--- a/translate/storage/poxliff.py
+++ b/translate/storage/poxliff.py
@@ -384,18 +384,12 @@ class PoXliffFile(xliff.xlifffile, poheader.poheader):
         if len(singularunits) == 0:
             return
         pluralunit_iter = pluralunits(pluralgroups)
-        try:
-            nextplural = pluralunit_iter.next()
-        except StopIteration:
-            nextplural = None
+        nextplural = next(pluralunit_iter, None)
 
         for entry in singularunits:
             term = self.UnitClass.createfromxmlElement(entry, namespace=self.namespace)
             if nextplural and unicode(term.getid()) == ("%s[0]" % nextplural.getid()):
                 self.addunit(nextplural, new=False)
-                try:
-                    nextplural = pluralunit_iter.next()
-                except StopIteration as i:
-                    nextplural = None
+                nextplural = next(pluralunit_iter, None)
             else:
                 self.addunit(term, new=False)

--- a/translate/storage/symbian.py
+++ b/translate/storage/symbian.py
@@ -43,7 +43,7 @@ class ParseState(object):
     def read_line(self):
         current_line = self.current_line
         self.read_hook(current_line)
-        self.current_line = self.f.next().decode(self.charset)
+        self.current_line = next(self.f).decode(self.charset)
         return current_line
 
 

--- a/translate/storage/tmx.py
+++ b/translate/storage/tmx.py
@@ -129,7 +129,7 @@ class tmxfile(lisa.LISAfile):
 </tmx>'''
 
     def addheader(self):
-        headernode = self.document.getroot().iterchildren(self.namespaced("header")).next()
+        headernode = next(self.document.getroot().iterchildren(self.namespaced("header")))
         headernode.set("creationtool", "Translate Toolkit - po2tmx")
         headernode.set("creationtoolversion", __version__.sver)
         headernode.set("segtype", "sentence")
@@ -151,8 +151,8 @@ class tmxfile(lisa.LISAfile):
             unit.addnote(comment)
 
         tuvs = unit.xmlelement.iterdescendants(self.namespaced('tuv'))
-        lisa.setXMLlang(tuvs.next(), srclang)
-        lisa.setXMLlang(tuvs.next(), translang)
+        lisa.setXMLlang(next(tuvs), srclang)
+        lisa.setXMLlang(next(tuvs), translang)
 
     def translate(self, sourcetext, sourcelang=None, targetlang=None):
         """method to test old unit tests"""

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -112,8 +112,8 @@ class xliffunit(lisa.LISAunit):
         target = None
         nodes = []
         try:
-            source = self.xmlelement.iterchildren(self.namespaced(self.languageNode)).next()
-            target = self.xmlelement.iterchildren(self.namespaced('target')).next()
+            source = next(self.xmlelement.iterchildren(self.namespaced(self.languageNode)))
+            target = next(self.xmlelement.iterchildren(self.namespaced('target')))
             nodes = [source, target]
         except StopIteration:
             if source is not None:
@@ -218,14 +218,14 @@ class xliffunit(lisa.LISAunit):
                 # the source tag is optional
                 sourcenode = node.iterdescendants(self.namespaced("source"))
                 try:
-                    newunit.source = lisa.getText(sourcenode.next(),
+                    newunit.source = lisa.getText(next(sourcenode),
                                                   getXMLspace(node, self._default_xml_space))
                 except StopIteration:
                     pass
 
                 # must have one or more targets
                 targetnode = node.iterdescendants(self.namespaced("target"))
-                newunit.target = lisa.getText(targetnode.next(),
+                newunit.target = lisa.getText(next(targetnode),
                                               getXMLspace(node, self._default_xml_space))
                 # TODO: support multiple targets better
                 # TODO: support notes in alt-trans
@@ -417,7 +417,7 @@ class xliffunit(lisa.LISAunit):
     def getid(self):
         uid = u""
         try:
-            filename = self.xmlelement.iterancestors(self.namespaced('file')).next().get('original')
+            filename = next(self.xmlelement.iterancestors(self.namespaced('file'))).get('original')
             if filename:
                 uid = filename + ID_SEPARATOR
         except StopIteration:
@@ -563,7 +563,7 @@ class xlifffile(lisa.LISAfile):
         if self._filename:
             filenode = self.getfilenode(self._filename, createifmissing=True)
         else:
-            filenode = self.document.getroot().iterchildren(self.namespaced('file')).next()
+            filenode = next(self.document.getroot().iterchildren(self.namespaced('file')))
         self.body = self.getbodynode(filenode, createifmissing=True)
 
     def addheader(self):
@@ -639,22 +639,22 @@ class xlifffile(lisa.LISAfile):
     def setsourcelanguage(self, language):
         if not language:
             return
-        filenode = self.document.getroot().iterchildren(self.namespaced('file')).next()
+        filenode = next(self.document.getroot().iterchildren(self.namespaced('file')))
         filenode.set("source-language", language)
 
     def getsourcelanguage(self):
-        filenode = self.document.getroot().iterchildren(self.namespaced('file')).next()
+        filenode = next(self.document.getroot().iterchildren(self.namespaced('file')))
         return filenode.get("source-language")
     sourcelanguage = property(getsourcelanguage, setsourcelanguage)
 
     def settargetlanguage(self, language):
         if not language:
             return
-        filenode = self.document.getroot().iterchildren(self.namespaced('file')).next()
+        filenode = next(self.document.getroot().iterchildren(self.namespaced('file')))
         filenode.set("target-language", language)
 
     def gettargetlanguage(self):
-        filenode = self.document.getroot().iterchildren(self.namespaced('file')).next()
+        filenode = next(self.document.getroot().iterchildren(self.namespaced('file')))
         return filenode.get("target-language")
     targetlanguage = property(gettargetlanguage, settargetlanguage)
 
@@ -706,7 +706,7 @@ class xlifffile(lisa.LISAfile):
         # TODO: Deprecated?
         headernode = filenode.iterchildren(self.namespaced("header"))
         try:
-            return headernode.next()
+            return next(headernode)
         except StopIteration:
             pass
         if not createifmissing:
@@ -718,7 +718,7 @@ class xlifffile(lisa.LISAfile):
         """finds the body node for the given filenode"""
         bodynode = filenode.iterchildren(self.namespaced("body"))
         try:
-            return bodynode.next()
+            return next(bodynode)
         except StopIteration:
             pass
         if not createifmissing:


### PR DESCRIPTION
This new 'next' syntax is needed for Python 3 compatibility.