### PR TITLE
Replaced dict.iter* by six.iter*(dict)

### DIFF
--- a/tests/odf_xliff/test_odf_xliff.py
+++ b/tests/odf_xliff/test_odf_xliff.py
@@ -21,6 +21,7 @@
 import difflib
 import os
 import os.path as path
+import six
 import sys
 import zipfile
 
@@ -44,7 +45,7 @@ def setup_module(module):
 def args(src, tgt, **kwargs):
     arg_list = []
     arg_list.extend([u'--errorlevel=traceback', src, tgt])
-    for flag, value in kwargs.iteritems():
+    for flag, value in six.iteritems(kwargs):
         value = unicode(value)
         if len(flag) == 1:
             arg_list.append(u'-%s' % flag)

--- a/translate/convert/convert.py
+++ b/translate/convert/convert.py
@@ -22,6 +22,7 @@
 :mod:`translate.convert` tools)."""
 
 import os.path
+import six
 from io import BytesIO
 
 from translate.misc import optrecurse
@@ -123,7 +124,7 @@ class ConvertOptionParser(optrecurse.RecursiveOptionParser, object):
         """Filters output options, processing relevant switches in options."""
         if self.usepots and options.pot:
             outputoptions = {}
-            for (inputformat, templateformat), (outputformat, convertor) in self.outputoptions.iteritems():
+            for (inputformat, templateformat), (outputformat, convertor) in six.iteritems(self.outputoptions):
                 inputformat = self.potifyformat(inputformat)
                 templateformat = self.potifyformat(templateformat)
                 outputformat = self.potifyformat(outputformat)

--- a/translate/convert/idml2po.py
+++ b/translate/convert/idml2po.py
@@ -20,6 +20,7 @@
 
 """Convert IDML files to PO localization files."""
 
+import six
 from io import BytesIO
 
 from translate.convert import convert
@@ -45,7 +46,7 @@ def convert_idml(inputfile, outputfile, template):
 
     id_maker = IdMaker()  # Create it here to avoid having repeated ids.
 
-    for filename, translatable_file in contents.iteritems():
+    for filename, translatable_file in six.iteritems(contents):
         parse_state = ParseState(NO_TRANSLATE_ELEMENTS, INLINE_ELEMENTS)
         po_store_adder = make_postore_adder(store, id_maker, filename)
         build_idml_store(BytesIO(translatable_file), store, parse_state,

--- a/translate/convert/po2idml.py
+++ b/translate/convert/po2idml.py
@@ -23,6 +23,7 @@ strings in the IDML template. It creates a new IDML file using the translations
 of the PO file.
 """
 
+import six
 from io import BytesIO
 from zipfile import ZIP_DEFLATED, ZipFile
 
@@ -50,7 +51,7 @@ def translate_idml(template, input_file, translatable_files):
         idml_data = open_idml(template)
         parser = etree.XMLParser(strip_cdata=False)
         return dict((filename, etree.fromstring(data, parser).getroottree())
-                    for filename, data in idml_data.iteritems())
+                    for filename, data in six.iteritems(idml_data))
 
     def load_unit_tree(input_file):
         """Return a dict with the translations grouped by files IDML package.
@@ -122,7 +123,7 @@ def translate_idml(template, input_file, translatable_files):
 
         make_parse_state = lambda: ParseState(NO_TRANSLATE_ELEMENTS,
                                               INLINE_ELEMENTS)
-        for filename, dom_tree in dom_trees.iteritems():
+        for filename, dom_tree in six.iteritems(dom_trees):
             file_unit_tree = unit_trees[filename]
             apply_translations(dom_tree.getroot(), file_unit_tree,
                                replace_dom_text(make_parse_state,
@@ -143,7 +144,7 @@ def write_idml(template_zip, output_file, dom_trees):
     output_zip = copy_idml(template_zip, output_zip, dom_trees.keys())
 
     # Replace the translated files in the IDML package.
-    for filename, dom_tree in dom_trees.iteritems():
+    for filename, dom_tree in six.iteritems(dom_trees):
         output_zip.writestr(filename, etree.tostring(dom_tree,
                                                      encoding='UTF-8',
                                                      xml_declaration=True,

--- a/translate/convert/po2oo.py
+++ b/translate/convert/po2oo.py
@@ -26,6 +26,7 @@ for examples and usage instructions.
 
 import logging
 import os
+import six
 import time
 
 from translate.convert import convert
@@ -58,7 +59,7 @@ class reoo:
     def makeindex(self):
         """makes an index of the oo keys that are used in the source file"""
         self.index = {}
-        for ookey, theoo in self.o.ookeys.iteritems():
+        for ookey, theoo in six.iteritems(self.o.ookeys):
             sourcekey = oo.makekey(ookey, self.long_keys)
             self.index[sourcekey] = theoo
 
@@ -159,7 +160,7 @@ class oocheckfilter(pofilter.pocheckfilter):
         filterresult = self.filterunit(unit)
         if filterresult:
             if filterresult != autocorrect:
-                for filtername, filtermessage in filterresult.iteritems():
+                for filtername, filtermessage in six.iteritems(filterresult):
                     location = unit.getlocations()[0].encode('utf-8')
                     if filtername in self.options.error:
                         logger.error("Error at %s::%s: %s",

--- a/translate/convert/po2prop.py
+++ b/translate/convert/po2prop.py
@@ -24,6 +24,7 @@ See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/command
 for examples and usage instructions.
 """
 
+import six
 import warnings
 
 from translate.convert import accesskey, convert
@@ -247,7 +248,7 @@ def main(argv=None):
             default=properties.default_dialect, type="choice",
             choices=properties.dialects.keys(),
             help="override the input file format: %s (for .properties files, default: %s)" %
-                 (", ".join(properties.dialects.iterkeys()),
+                 (", ".join(six.iterkeys(properties.dialects)),
                   properties.default_dialect),
             metavar="TYPE")
     parser.add_option("", "--encoding", dest="encoding", default=None,

--- a/translate/convert/po2symb.py
+++ b/translate/convert/po2symb.py
@@ -24,13 +24,15 @@ See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/command
 for examples and usage instructions.
 """
 
+import six
+
 from translate.storage import factory
 from translate.storage.pypo import po_escape_map
 from translate.storage.symbian import *
 
 
 def escape(text):
-    for key, val in po_escape_map.iteritems():
+    for key, val in six.iteritems(po_escape_map):
         text = text.replace(key, val)
     return '"%s"' % text
 

--- a/translate/convert/pot2po.py
+++ b/translate/convert/pot2po.py
@@ -25,6 +25,8 @@ See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/command
 for examples and usage instructions.
 """
 
+import six
+
 from translate.misc.multistring import multistring
 from translate.search import match
 from translate.storage import catkeys, factory, poheader
@@ -201,7 +203,7 @@ def _do_poheaders(input_store, output_store, template_store):
 
     if template_store is not None and isinstance(template_store, poheader.poheader):
         templateheadervalues = template_store.parseheader()
-        for key, value in templateheadervalues.iteritems():
+        for key, value in six.iteritems(templateheadervalues):
             if key == "Project-Id-Version":
                 project_id_version = value
             elif key == "Last-Translator":
@@ -223,7 +225,7 @@ def _do_poheaders(input_store, output_store, template_store):
                 kwargs[key] = value
 
     inputheadervalues = input_store.parseheader()
-    for key, value in inputheadervalues.iteritems():
+    for key, value in six.iteritems(inputheadervalues):
         if key in ("Project-Id-Version", "Last-Translator", "Language-Team",
                    "PO-Revision-Date", "Content-Type",
                    "Content-Transfer-Encoding", "Plural-Forms"):

--- a/translate/convert/prop2po.py
+++ b/translate/convert/prop2po.py
@@ -25,6 +25,7 @@ for examples and usage instructions.
 """
 
 import logging
+import six
 
 from translate.convert.accesskey import UnitMixer
 from translate.storage import po, properties
@@ -342,7 +343,7 @@ def main(argv=None):
             type="choice",
             choices=properties.dialects.keys(),
             help="override the input file format: %s (for .properties files, default: %s)" %
-                 (", ".join(properties.dialects.iterkeys()),
+                 (", ".join(six.iterkeys(properties.dialects)),
                   properties.default_dialect),
             metavar="TYPE")
     parser.add_option("", "--encoding", dest="encoding", default=None,

--- a/translate/convert/test_convert.py
+++ b/translate/convert/test_convert.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import six
 import sys
 
 import pytest
@@ -44,7 +45,7 @@ class TestConvertCommand:
         argv = list(argv)
         kwoptions = getattr(self, "defaultoptions", {}).copy()
         kwoptions.update(kwargs)
-        for key, value in kwoptions.iteritems():
+        for key, value in six.iteritems(kwoptions):
             if value is True:
                 argv.append("--%s" % key)
             else:

--- a/translate/convert/ts2po.py
+++ b/translate/convert/ts2po.py
@@ -24,6 +24,7 @@ See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/command
 for examples and usage instructions.
 """
 
+import six
 
 from translate.storage import po, ts
 
@@ -56,7 +57,7 @@ class ts2po:
         tsfile = ts.QtTsParser(inputfile)
         thetargetfile = po.pofile()
 
-        for contextname, messages in tsfile.iteritems():
+        for contextname, messages in six.iteritems(tsfile):
             messagenum = 0
             for message in messages:
                 messagenum += 1

--- a/translate/convert/xliff2odf.py
+++ b/translate/convert/xliff2odf.py
@@ -24,6 +24,7 @@ See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/command
 for examples and usage instructions.
 """
 
+import six
 import zipfile
 from io import BytesIO
 
@@ -50,7 +51,7 @@ def translate_odf(template, input_file):
         """
         odf_data = open_odf(template)
         return dict((filename, etree.parse(BytesIO(data)))
-                    for filename, data in odf_data.iteritems())
+                    for filename, data in six.iteritems(odf_data))
 
     def load_unit_tree(input_file):
         """Return a dict with the translations grouped by files ODF package.
@@ -85,7 +86,7 @@ def translate_odf(template, input_file):
         """
         make_parse_state = lambda: ParseState(no_translate_content_elements,
                                               inline_elements)
-        for filename, dom_tree in dom_trees.iteritems():
+        for filename, dom_tree in six.iteritems(dom_trees):
             file_unit_tree = unit_trees[filename]
             apply_translations(dom_tree.getroot(), file_unit_tree,
                                replace_dom_text(make_parse_state))
@@ -110,7 +111,7 @@ def write_odf(template, output_file, dom_trees):
     output_zip = copy_odf(template_zip, output_zip, dom_trees.keys())
 
     # Overwrite the translated files to the ODF package.
-    for filename, dom_tree in dom_trees.iteritems():
+    for filename, dom_tree in six.iteritems(dom_trees):
         output_zip.writestr(filename, etree.tostring(dom_tree,
                                                      encoding='UTF-8',
                                                      xml_declaration=True))

--- a/translate/convert/xliff2oo.py
+++ b/translate/convert/xliff2oo.py
@@ -26,6 +26,7 @@ for examples and usage instructions.
 
 import logging
 import os
+import six
 import time
 
 from translate.filters import autocorrect, checks, pofilter
@@ -57,7 +58,7 @@ class reoo:
     def makeindex(self):
         """makes an index of the oo keys that are used in the source file"""
         self.index = {}
-        for ookey, theoo in self.o.ookeys.iteritems():
+        for ookey, theoo in six.iteritems(self.o.ookeys):
             sourcekey = oo.makekey(ookey, self.long_keys)
             self.index[sourcekey] = theoo
 
@@ -160,7 +161,7 @@ class oocheckfilter(pofilter.pocheckfilter):
         filterresult = self.filterunit(unit)
         if filterresult:
             if filterresult != autocorrect:
-                for filtername, filtermessage in filterresult.iteritems():
+                for filtername, filtermessage in six.iteritems(filterresult):
                     location = unit.getlocations()[0]
                     if filtername in self.options.error:
                         logger.error("Error at %s::%s: %s",

--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -32,6 +32,7 @@ When adding a new test here, please document and explain their behaviour on the
 
 import logging
 import re
+import six
 
 from translate.filters import decoration, helpers, prefilters, spelling
 from translate.filters.decorators import (cosmetic, critical, extraction,
@@ -474,7 +475,7 @@ class UnitChecker(object):
         self.results_cache = {}
 
         if not categorised:
-            for name, info in failures.iteritems():
+            for name, info in six.iteritems(failures):
                 failures[name] = info['message']
         return failures
 

--- a/translate/filters/pofilter.py
+++ b/translate/filters/pofilter.py
@@ -30,6 +30,7 @@ for full descriptions of all tests.
 """
 
 import os
+import six
 
 from translate.filters import autocorrect, checks
 from translate.misc import optrecurse
@@ -97,7 +98,7 @@ class pocheckfilter:
         """Lists the docs for filters available on checker."""
         filterdict = self.checker.getfilters()
         filterdocs = ["%s\t%s" % (name, filterfunc.__doc__.split('\n\n')[0])
-                      for (name, filterfunc) in filterdict.iteritems()]
+                      for (name, filterfunc) in six.iteritems(filterdict)]
         filterdocs.sort()
 
         return "\n".join(filterdocs)
@@ -147,7 +148,7 @@ class pocheckfilter:
 
             if filter_result:
                 if filter_result != autocorrect:
-                    for filter_name in filter_result.iterkeys():
+                    for filter_name in six.iterkeys(filter_result):
                         filter_message = filter_result[filter_name]['message']
 
                         if self.options.addnotes:

--- a/translate/filters/prefilters.py
+++ b/translate/filters/prefilters.py
@@ -22,6 +22,7 @@
 """
 
 import re
+import six
 
 from translate.filters import decoration
 from translate.misc import quote
@@ -162,7 +163,7 @@ def filterwordswithpunctuation(str1):
     if u"'" not in str1:
         return str1
     occurrences = []
-    for word, replacement in wordswithpunctuation.iteritems():
+    for word, replacement in six.iteritems(wordswithpunctuation):
         occurrences.extend([(pos, word, replacement) for pos in quote.find_all(str1, word)])
     for match in word_with_apos_re.finditer(str1):
         word = match.group()

--- a/translate/lang/common.py
+++ b/translate/lang/common.py
@@ -62,6 +62,7 @@ TODOs and Ideas for possible features:
 
 import logging
 import re
+import six
 
 from translate.lang import data
 
@@ -245,7 +246,7 @@ class Common(object):
         ellipses_end = text.endswith(u"...")
         if ellipses_end:
             text = text[:-3]
-        for source, target in cls.puncdict.iteritems():
+        for source, target in six.iteritems(cls.puncdict):
             text = text.replace(source, target)
         if ellipses_end:
             if u"..." in cls.puncdict:

--- a/translate/lang/team.py
+++ b/translate/lang/team.py
@@ -23,6 +23,7 @@ the header of a Gettext PO file.
 """
 
 import re
+import six
 
 
 __all__ = ['LANG_TEAM_CONTACT_SNIPPETS', 'guess_language']
@@ -402,7 +403,7 @@ def _snippet_guesser(snippets_dict, string, filter_=_nofilter):
     before examination
     """
     string = filter_(string)
-    for possible_lang, snippets in snippets_dict.iteritems():
+    for possible_lang, snippets in six.iteritems(snippets_dict):
         for snippet in snippets:
             if filter_(snippet) in string:
                 return possible_lang

--- a/translate/misc/dictutils.py
+++ b/translate/misc/dictutils.py
@@ -21,6 +21,8 @@ order-sensitive dictionary"""
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import six
+
 
 class cidict(dict):
 
@@ -50,7 +52,7 @@ class cidict(dict):
     def update(self, updatedict):
         """D.update(E) -> None.
            Update D from E: for k in E.keys(): D[k] = E[k]"""
-        for key, value in updatedict.iteritems():
+        for key, value in six.iteritems(updatedict):
             self[key] = value
 
     def __delitem__(self, key):
@@ -116,7 +118,7 @@ class ordereddict(dict):
     def update(self, updatedict):
         """D.update(E) -> None.
         Update D from E: for k in E.keys(): D[k] = E[k]"""
-        for key, value in updatedict.iteritems():
+        for key, value in six.iteritems(updatedict):
             self[key] = value
 
     def __delitem__(self, key):

--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -23,6 +23,7 @@ import logging
 import optparse
 import os.path
 import re
+import six
 import sys
 import traceback
 from io import BytesIO
@@ -225,7 +226,7 @@ class RecursiveOptionParser(optparse.OptionParser, object):
         templateformats = []
         self.outputoptions = {}
         self.usetemplates = usetemplates
-        for formatgroup, outputoptions in formats.iteritems():
+        for formatgroup, outputoptions in six.iteritems(formats):
             if isinstance(formatgroup, (str, unicode)) or formatgroup is None:
                 formatgroup = (formatgroup, )
             if not isinstance(formatgroup, tuple):

--- a/translate/misc/quote.py
+++ b/translate/misc/quote.py
@@ -22,6 +22,7 @@
 of delimiters"""
 
 import logging
+import six
 
 from six.moves import html_entities
 
@@ -365,7 +366,7 @@ controlchars = {
 
 def escapecontrols(source):
     """escape control characters in the given string"""
-    for key, value in controlchars.iteritems():
+    for key, value in six.iteritems(controlchars):
         source = source.replace(key, value)
     return source
 

--- a/translate/misc/selector.py
+++ b/translate/misc/selector.py
@@ -25,6 +25,7 @@ Luke Arno can be found at http://lukearno.com/
 """
 
 import re
+import six
 from itertools import starmap
 from wsgiref.util import shift_path_info
 
@@ -144,7 +145,7 @@ class Selector(object):
         app, svars, methods, matched = \
             self.select(environ['PATH_INFO'], environ['REQUEST_METHOD'])
         unnamed, named = [], {}
-        for k, v in svars.iteritems():
+        for k, v in six.iteritems(svars):
             if k.startswith('__pos'):
                 k = k[5:]
             named[k] = v

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -21,6 +21,7 @@
 """Base classes for storage interfaces."""
 
 import logging
+import six
 try:
     import cPickle as pickle
 except ImportError:
@@ -460,7 +461,7 @@ class TranslationUnit(object):
     def get_state_id(self, n=None):
         if n is None:
             n = self.get_state_n()
-        for state_id, state_range in self.STATE.iteritems():
+        for state_id, state_range in six.iteritems(self.STATE):
             if state_range[0] <= n < state_range[1]:
                 return state_id
         if self.STATE:

--- a/translate/storage/bundleprojstore.py
+++ b/translate/storage/bundleprojstore.py
@@ -20,6 +20,7 @@
 
 import os
 import shutil
+import six
 import tempfile
 from zipfile import ZipFile
 
@@ -98,7 +99,7 @@ class BundleProjectStore(ProjectStore):
         """Remove the file with the given project name from the project."""
         super(BundleProjectStore, self).remove_file(fname, ftype)
         self._zip_delete([fname])
-        tempfiles = [tmpf for tmpf, prjf in self._tempfiles.iteritems() if prjf == fname]
+        tempfiles = [tmpf for tmpf, prjf in six.iteritems(self._tempfiles) if prjf == fname]
         if tempfiles:
             for tmpf in tempfiles:
                 try:

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -33,6 +33,7 @@ import ctypes.util
 import logging
 import os
 import re
+import six
 import sys
 import tempfile
 from ctypes import (CFUNCTYPE, POINTER, Structure, c_char_p, c_int, c_long,
@@ -338,7 +339,7 @@ class pounit(pocommon.pounit):
                 gpo.po_message_set_msgstr_plural(self._gpo_message, i, targetstring)
         # add the values of a dict
         elif isinstance(target, dict):
-            for i, targetstring in enumerate(target.itervalues()):
+            for i, targetstring in enumerate(six.itervalues(target)):
                 gpo.po_message_set_msgstr_plural(self._gpo_message, i, targetstring)
         # add a single string
         else:

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -24,6 +24,7 @@ or entire files (csvfile) for use with localisation
 
 import codecs
 import csv
+import six
 from io import BytesIO
 
 from translate.misc import sparse
@@ -206,7 +207,7 @@ class csvunit(base.TranslationUnit):
     def match_header(self):
         """see if unit might be a header"""
         some_value = False
-        for key, value in self.todict().iteritems():
+        for key, value in six.iteritems(self.todict()):
             if value:
                 some_value = True
             if key.lower() != 'fuzzy' and value and key.lower() != value.lower():
@@ -232,7 +233,7 @@ class csvunit(base.TranslationUnit):
         return source, target
 
     def fromdict(self, cedict, encoding='utf-8'):
-        for key, value in cedict.iteritems():
+        for key, value in six.iteritems(cedict):
             rkey = fieldname_map.get(key, key)
             if value is None or key is None or key == EXTRA_KEY:
                 continue

--- a/translate/storage/fpo.py
+++ b/translate/storage/fpo.py
@@ -30,6 +30,7 @@ directly, but can be used once cpo has been established to work."""
 
 import copy
 import re
+import six
 from io import BytesIO
 
 from translate.lang import data
@@ -171,7 +172,7 @@ class pounit(pocommon.pounit):
         # self.__shallow__
         shallow = set(self.__shallow__)
         # Make deep copies of all members which are not in shallow
-        for key, value in self.__dict__.iteritems():
+        for key, value in six.iteritems(self.__dict__):
             if key not in shallow:
                 setattr(new_unit, key, copy.deepcopy(value))
         # Make shallow copies of all members which are in shallow

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -71,6 +71,7 @@ TODO:
 
 import json
 import os
+import six
 from io import BytesIO
 
 from translate.storage import base
@@ -173,7 +174,7 @@ class JsonFile(base.TranslationStore):
         :param last_node: the last list or dict
         """
         if isinstance(data, dict):
-            for k, v in data.iteritems():
+            for k, v in six.iteritems(data):
                 for x in self._extract_translatables(v, stop,
                                                           "%s.%s" % (prev, k),
                                                           k, None, data):

--- a/translate/storage/poheader.py
+++ b/translate/storage/poheader.py
@@ -21,6 +21,7 @@
 """class that handles all header functions for a header in a po file"""
 
 import re
+import six
 import time
 
 try:
@@ -98,7 +99,7 @@ def update(existing, add=False, **kwargs):
             removed.append(key)
         elif add and key in fixedargs:
             headerargs[key] = fixedargs.pop(key)
-    for key, value in existing.iteritems():
+    for key, value in six.iteritems(existing):
         if not key in removed:
             headerargs[key] = value
     if add:

--- a/translate/storage/projstore.py
+++ b/translate/storage/projstore.py
@@ -19,6 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import os
+import six
 
 from lxml import etree
 
@@ -299,7 +300,7 @@ class ProjectStore(object):
         # Add conversion mappings
         if self.convert_map:
             conversions_el = etree.Element('conversions')
-            for in_fname, (out_fname, templ_fname) in self.convert_map.iteritems():
+            for in_fname, (out_fname, templ_fname) in six.iteritems(self.convert_map):
                 if in_fname not in self._files or out_fname not in self._files:
                     continue
                 conv_el = etree.Element('conv')

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -115,6 +115,7 @@ Name and Value pairs:
 """
 
 import re
+import six
 
 from translate.lang import data
 from translate.misc import quote
@@ -155,7 +156,7 @@ def _find_delimiter(line, delimiters):
         delimiter_dict[delimiter] = -1
     delimiters = delimiter_dict
     # Find the position of each delimiter type
-    for delimiter, pos in delimiters.iteritems():
+    for delimiter, pos in six.iteritems(delimiters):
         prewhitespace = len(line) - len(line.lstrip())
         pos = line.find(delimiter, prewhitespace)
         while pos != -1:
@@ -166,7 +167,7 @@ def _find_delimiter(line, delimiters):
     # Find the first delimiter
     mindelimiter = None
     minpos = -1
-    for delimiter, pos in delimiters.iteritems():
+    for delimiter, pos in six.iteritems(delimiters):
         if pos == -1 or delimiter == u" ":
             continue
         if minpos == -1 or pos < minpos:

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -25,6 +25,7 @@ files (pofile).
 
 import copy
 import re
+import six
 import textwrap
 from io import BytesIO
 
@@ -297,7 +298,7 @@ class pounit(pocommon.pounit):
         if isinstance(target, list):
             self.msgstr = dict([(i, quoteforpo(target[i])) for i in range(len(target))])
         elif isinstance(target, dict):
-            self.msgstr = dict([(i, quoteforpo(targetstring)) for i, targetstring in target.iteritems()])
+            self.msgstr = dict([(i, quoteforpo(targetstring)) for i, targetstring in six.iteritems(target)])
         else:
             self.msgstr = quoteforpo(target)
     target = property(gettarget, settarget)
@@ -374,7 +375,7 @@ class pounit(pocommon.pounit):
         # self.__shallow__
         shallow = set(self.__shallow__)
         # Make deep copies of all members which are not in shallow
-        for key, value in self.__dict__.iteritems():
+        for key, value in six.iteritems(self.__dict__):
             if key not in shallow:
                 setattr(new_unit, key, copy.deepcopy(value))
         # Make shallow copies of all members which are in shallow
@@ -397,7 +398,7 @@ class pounit(pocommon.pounit):
 
     def _msgstrlen(self):
         if isinstance(self.msgstr, dict):
-            combinedstr = "\n".join(filter(None, [unquotefrompo(msgstr) for msgstr in self.msgstr.itervalues()]))
+            combinedstr = "\n".join(filter(None, [unquotefrompo(msgstr) for msgstr in six.itervalues(self.msgstr)]))
             return len(combinedstr)
         else:
             return len(unquotefrompo(self.msgstr))

--- a/translate/storage/statistics.py
+++ b/translate/storage/statistics.py
@@ -22,6 +22,8 @@
 
 """
 
+import six
+
 from translate import lang
 from translate.lang import factory
 
@@ -144,7 +146,7 @@ class Statistics(object):
         #TODO: decoding should not be done here
 #        checkresult = self.checker.run_filters(unit, source, target)
         checkresult = {}
-        for checkname, checkmessage in checkresult.iteritems():
+        for checkname, checkmessage in six.iteritems(checkresult):
             classes.append("check-" + checkname)
         return classes
 

--- a/translate/storage/statsdb.py
+++ b/translate/storage/statsdb.py
@@ -26,6 +26,7 @@
 import logging
 import os.path
 import re
+import six
 import stat
 import sys
 from six.moves import _thread, UserDict
@@ -521,7 +522,7 @@ class StatsCache(object):
                 if unitindex:
                     index = unitindex
                 failures = checker.run_filters(unit)
-                for checkname, checkmessage in failures.iteritems():
+                for checkname, checkmessage in six.iteritems(failures):
                     unitvalues.append((index, fileid, configid, checkname, checkmessage))
                     errornames.append("check-" + checkname)
         checker.setsuggestionstore(None)

--- a/translate/storage/trados.py
+++ b/translate/storage/trados.py
@@ -42,6 +42,7 @@ A Trados file looks like this:
 """
 
 import re
+import six
 import time
 
 try:
@@ -83,14 +84,14 @@ http://msdn.microsoft.com/en-us/library/aa140283(v=office.10).aspx
 
 def unescape(text):
     """Convert Trados text to normal Unicode string"""
-    for trados_escape, char in RTF_ESCAPES.iteritems():
+    for trados_escape, char in six.iteritems(RTF_ESCAPES):
         text = text.replace(trados_escape, char)
     return text
 
 
 def escape(text):
     """Convert Unicode string to Trodas escapes"""
-    for trados_escape, char in RTF_ESCAPES.iteritems():
+    for trados_escape, char in six.iteritems(RTF_ESCAPES):
         text = text.replace(char, trados_escape)
     return text
 

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -33,6 +33,7 @@ both.
 `2 <http://qt-project.org/doc/qt-5.0/qtcore/qstring.html#arg-2>`_
 """
 
+import six
 from lxml import etree
 
 from translate.lang import data
@@ -93,7 +94,7 @@ class tsunit(lisa.LISAunit):
         S_TRANSLATED: (state.UNREVIEWED, state.MAX),
     }
 
-    statemap_r = dict((i[1], i[0]) for i in statemap.iteritems())
+    statemap_r = dict((i[1], i[0]) for i in six.iteritems(statemap))
 
     def createlanguageNode(self, lang, text, purpose):
         """Returns an xml Element setup with given parameters."""

--- a/translate/storage/utx.py
+++ b/translate/storage/utx.py
@@ -45,6 +45,7 @@ Encoding
 """
 
 import csv
+import six
 import time
 
 from translate.storage import base
@@ -221,7 +222,7 @@ class UtxFile(base.TranslationStore):
                     "date": self._header["date_created"],
                  }
         items = []
-        for key, value in self._header.iteritems():
+        for key, value in six.iteritems(self._header):
             if key in ["version", "source_language",
                        "target_language", "date_created"]:
                 continue

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -23,6 +23,7 @@
 The official recommendation is to use the extention .xlf for XLIFF files.
 """
 
+import six
 from lxml import etree
 
 from translate.misc.multistring import multistring
@@ -74,7 +75,7 @@ class xliffunit(lisa.LISAunit):
                 "final": S_SIGNED_OFF + 1,
                 }
 
-    statemap_r = dict((i[1], i[0]) for i in statemap.iteritems())
+    statemap_r = dict((i[1], i[0]) for i in six.iteritems(statemap))
 
     STATE = {
         S_UNTRANSLATED: (state.EMPTY, state.NEEDS_WORK),

--- a/translate/storage/xml_extract/extract.py
+++ b/translate/storage/xml_extract/extract.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import six
 from contextlib import contextmanager
 
 from lxml import etree
@@ -382,7 +383,7 @@ def _walk_translatable_tree(translatables, store_adder, parent_translatable):
 
 
 def reverse_map(a_map):
-    return dict((value, key) for key, value in a_map.iteritems())
+    return dict((value, key) for key, value in six.iteritems(a_map))
 
 
 def build_idml_store(odf_file, store, parse_state, store_adder=None):

--- a/translate/storage/xml_extract/generate.py
+++ b/translate/storage/xml_extract/generate.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import six
 import lxml.etree as etree
 
 from translate.storage import base
@@ -45,7 +46,7 @@ def _get_tag_arrays(dom_node):
 
 def apply_translations(dom_node, unit_node, do_translate):
     tag_array = _get_tag_arrays(dom_node)
-    for unit_child_index, unit_child in unit_node.children.iteritems():
+    for unit_child_index, unit_child in six.iteritems(unit_node.children):
         tag, index = unit_child_index
         try:
             dom_child = tag_array[XmlNamer(dom_node).name(tag)][index]

--- a/translate/tools/poconflicts.py
+++ b/translate/tools/poconflicts.py
@@ -25,6 +25,7 @@ for examples and usage instructions.
 """
 
 import os
+import six
 import sys
 
 from translate.misc import optrecurse
@@ -145,7 +146,7 @@ class ConflictOptionParser(optrecurse.RecursiveOptionParser):
     def buildconflictmap(self):
         """work out which strings are conflicting"""
         self.conflictmap = {}
-        for source, translations in self.textmap.iteritems():
+        for source, translations in six.iteritems(self.textmap):
             source = self.flatten(source, " ")
             if len(source) <= 1:
                 continue
@@ -162,7 +163,7 @@ class ConflictOptionParser(optrecurse.RecursiveOptionParser):
         def str_len(x):
             return len(x)
 
-        for source, translations in self.conflictmap.iteritems():
+        for source, translations in six.iteritems(self.conflictmap):
             words = source.split()
             words.sort(key=str_len)
             source = words[-1]
@@ -172,9 +173,9 @@ class ConflictOptionParser(optrecurse.RecursiveOptionParser):
         for word in reducedmap:
             if word + "s" in reducedmap:
                 plurals[word] = word + "s"
-        for word, pluralword in plurals.iteritems():
+        for word, pluralword in six.iteritems(plurals):
             reducedmap[word].extend(reducedmap.pop(pluralword))
-        for source, translations in reducedmap.iteritems():
+        for source, translations in six.iteritems(reducedmap):
             flatsource = self.flatten(source, "-")
             fulloutputpath = os.path.join(options.output, flatsource + os.extsep + "po")
             conflictfile = po.pofile()

--- a/translate/tools/pocount.py
+++ b/translate/tools/pocount.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 
 import logging
 import os
+import six
 import sys
 from argparse import ArgumentParser
 
@@ -165,7 +166,7 @@ def summarize(title, stats, style=style_full, indent=8, incomplete_only=False):
               stats["translatedtargetwords"]))
         if "extended" in stats:
             print("")
-            for state, e_stats in stats["extended"].iteritems():
+            for state, e_stats in six.iteritems(stats["extended"]):
                 print("%s:    %5d (%3d%%) %10d (%3d%%) %15d" % (
                       state, e_stats["units"], percent(e_stats["units"], stats["total"]),
                       e_stats["sourcewords"], percent(e_stats["sourcewords"], stats["totalsourcewords"]),

--- a/translate/tools/poterminology.py
+++ b/translate/tools/poterminology.py
@@ -24,6 +24,7 @@ for examples and usage instructions.
 import logging
 import os
 import re
+import six
 import sys
 
 from translate.lang import factory as lang_factory
@@ -40,7 +41,7 @@ def create_termunit(term, unit, targets, locations, sourcenotes, transnotes, fil
         termunit.merge(unit, overwrite=False, comments=False)
     if len(targets.keys()) > 1:
         txt = '; '.join(["%s {%s}" % (target, ', '.join(files))
-                         for target, files in targets.iteritems()])
+                         for target, files in six.iteritems(targets)])
         if termunit.target.find('};') < 0:
             termunit.target = txt
             termunit.markfuzzy()
@@ -53,7 +54,7 @@ def create_termunit(term, unit, targets, locations, sourcenotes, transnotes, fil
         termunit.addnote(sourcenote, "developer")
     for transnote in transnotes:
         termunit.addnote(transnote, "translator")
-    for filename, count in filecounts.iteritems():
+    for filename, count in six.iteritems(filecounts):
         termunit.addnote("(poterminology) %s (%d)\n" % (filename, count), 'translator')
     return termunit
 
@@ -240,7 +241,7 @@ class TerminologyExtractor(object):
         terms = {}
         locre = re.compile(r":[0-9]+$")
         logger.info("%d terms from %d units", len(self.glossary), self.units)
-        for term, translations in self.glossary.iteritems():
+        for term, translations in six.iteritems(self.glossary):
             if len(translations) <= 1:
                 continue
             filecounts = {}


### PR DESCRIPTION
iteritems/iterkeys/itervalues do not exist in Python 3 as it's now
the default method used for iteration by items()/keys()/values().