### PR TITLE
Removed unreachable KeyboardInterrupt catching

### DIFF
--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -503,9 +503,7 @@ class RecursiveOptionParser(optparse.OptionParser, object):
                 fulloutputpath = self.getfulloutputpath(options, outputpath)
                 if options.recursiveoutput and outputpath:
                     self.checkoutputsubdir(options, os.path.dirname(outputpath))
-            except Exception as error:
-                if isinstance(error, KeyboardInterrupt):
-                    raise
+            except Exception:
                 self.warning("Couldn't handle input file %s" %
                              inputpath, options, sys.exc_info())
                 continue
@@ -513,9 +511,7 @@ class RecursiveOptionParser(optparse.OptionParser, object):
                 success = self.processfile(fileprocessor, options,
                                            fullinputpath, fulloutputpath,
                                            fulltemplatepath)
-            except Exception as error:
-                if isinstance(error, KeyboardInterrupt):
-                    raise
+            except Exception:
                 self.warning("Error processing: input %s, output %s, template %s" %
                              (fullinputpath, fulloutputpath,
                               fulltemplatepath), options, sys.exc_info())

--- a/translate/tools/poconflicts.py
+++ b/translate/tools/poconflicts.py
@@ -97,9 +97,7 @@ class ConflictOptionParser(optrecurse.RecursiveOptionParser):
             fullinputpath = self.getfullinputpath(options, inputpath)
             try:
                 success = self.processfile(None, options, fullinputpath)
-            except Exception as error:
-                if isinstance(error, KeyboardInterrupt):
-                    raise
+            except Exception:
                 self.warning("Error processing: input %s" % (fullinputpath), options, sys.exc_info())
                 success = False
             self.reportprogress(inputpath, success)

--- a/translate/tools/porestructure.py
+++ b/translate/tools/porestructure.py
@@ -79,9 +79,8 @@ class SplitOptionParser(optrecurse.RecursiveOptionParser):
             fullinputpath = self.getfullinputpath(options, inputpath)
             try:
                 success = self.processfile(options, fullinputpath)
-            except Exception as error:
-                if isinstance(error, KeyboardInterrupt):
-                    raise self.warning("Error processing: input %s" % (fullinputpath), options, sys.exc_info())
+            except Exception:
+                self.warning("Error processing: input %s" % (fullinputpath), options, sys.exc_info())
                 success = False
             self.reportprogress(inputpath, success)
         del self.progressbar

--- a/translate/tools/poterminology.py
+++ b/translate/tools/poterminology.py
@@ -428,9 +428,7 @@ class TerminologyOptionParser(optrecurse.RecursiveOptionParser):
             success = True
             try:
                 self.processfile(None, options, fullinputpath)
-            except Exception as error:
-                if isinstance(error, KeyboardInterrupt):
-                    raise
+            except Exception:
                 self.warning("Error processing: input %s" % (fullinputpath), options, sys.exc_info())
                 success = False
             self.reportprogress(inputpath, success)


### PR DESCRIPTION
`except Exception` is not catching KeyboardInterrupt, so there is no use
examining the exception for it. Only bare excepts are catching it.