### PR TITLE
Fixed cpo error formatting

### DIFF
--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -84,8 +84,9 @@ class po_error_handler(Structure):
 # Callback functions for po_xerror_handler
 def xerror_cb(severity, message, filename, lineno, column, multiline_p,
               message_text):
-    logger.error("xerror_cb" + severity + message +
-                 filename + lineno + column + multiline_p + message_text)
+    logger.error("xerror_cb %s %s %s %s %s %s %s" % (
+        severity, message, filename, lineno, column, multiline_p, message_text
+    ))
     if severity >= 1:
         raise ValueError(message_text)
 
@@ -93,10 +94,11 @@ def xerror_cb(severity, message, filename, lineno, column, multiline_p,
 def xerror2_cb(severity, message1, filename1, lineno1, column1, multiline_p1,
                message_text1, message2, filename2, lineno2, column2,
                multiline_p2, message_text2):
-    logger.error("xerror2_cb" + severity +
-                 message1 +
-                 filename1 + lineno1 + column1 + multiline_p1 + message_text1,
-                 filename2 + lineno2 + column2 + multiline_p2 + message_text2)
+    logger.error("xerror2_cb %s %s %s %s %s %s %s %s %s %s %s %s" % (
+        severity, message1,
+        filename1, lineno1, column1, multiline_p1, message_text1,
+        filename2, lineno2, column2, multiline_p2, message_text2
+    ))
     if severity >= 1:
         raise ValueError(message_text1)
 


### PR DESCRIPTION
When testing with USECPO=1, this is fixing a bunch of errors from
the error callback function:
TypeError: cannot concatenate 'str' and 'int' objects