### PR TITLE
Replaced unicode by six.text_type

### DIFF
--- a/tests/odf_xliff/test_odf_xliff.py
+++ b/tests/odf_xliff/test_odf_xliff.py
@@ -46,7 +46,7 @@ def args(src, tgt, **kwargs):
     arg_list = []
     arg_list.extend([u'--errorlevel=traceback', src, tgt])
     for flag, value in six.iteritems(kwargs):
-        value = unicode(value)
+        value = six.text_type(value)
         if len(flag) == 1:
             arg_list.append(u'-%s' % flag)
         else:

--- a/translate/convert/accesskey.py
+++ b/translate/convert/accesskey.py
@@ -19,6 +19,8 @@
 
 """functions used to manipulate access keys in strings"""
 
+import six
+
 from translate.storage.placeables.general import XMLEntityPlaceable
 
 
@@ -116,8 +118,8 @@ def extract(string, accesskey_marker=DEFAULT_ACCESSKEY_MARKER):
     :type accesskey_marker: Char
     :param accesskey_marker: The character that is used to prefix an access key
     """
-    assert isinstance(string, unicode)
-    assert isinstance(accesskey_marker, unicode)
+    assert isinstance(string, six.text_type)
+    assert isinstance(accesskey_marker, six.text_type)
     assert len(accesskey_marker) == 1
     if string == u"":
         return u"", u""
@@ -156,8 +158,8 @@ def combine(label, accesskey,
     :rtype: unicode or None
     :return: label+accesskey string or None if uncombineable
     """
-    assert isinstance(label, unicode)
-    assert isinstance(accesskey, unicode)
+    assert isinstance(label, six.text_type)
+    assert isinstance(accesskey, six.text_type)
 
     if len(accesskey) == 0:
         return None

--- a/translate/convert/factory.py
+++ b/translate/convert/factory.py
@@ -21,6 +21,7 @@
 """Factory methods to convert supported input files to supported translatable files."""
 
 import os
+import six
 
 
 #from translate.convert import prop2po, po2prop, odf2xliff, xliff2odf
@@ -39,6 +40,7 @@ converters = {}
 #        converters[extension].append(module.formats[extension])
 
 
+@six.python_2_unicode_compatible
 class UnknownExtensionError(Exception):
 
     def __init__(self, afile):
@@ -47,10 +49,8 @@ class UnknownExtensionError(Exception):
     def __str__(self):
         return 'Unable to find extension for file: %s' % (self.file)
 
-    def __unicode__(self):
-        return unicode(str(self))
 
-
+@six.python_2_unicode_compatible
 class UnsupportedConversionError(Exception):
 
     def __init__(self, in_ext=None, out_ext=None, templ_ext=None):
@@ -63,9 +63,6 @@ class UnsupportedConversionError(Exception):
         if self.templ_ext:
             msg += ' with template %s' % (self.templ_ext)
         return msg
-
-    def __unicode__(self):
-        return unicode(str(self))
 
 
 def get_extension(filename):

--- a/translate/convert/po2oo.py
+++ b/translate/convert/po2oo.py
@@ -93,7 +93,7 @@ class reoo:
                                key, len(self.index))
                 try:
                     sourceunitlines = str(unit)
-                    if isinstance(sourceunitlines, unicode):
+                    if isinstance(sourceunitlines, six.text_type):
                         sourceunitlines = sourceunitlines.encode("utf-8")
                     logger.warning(sourceunitlines)
                 except:
@@ -123,7 +123,7 @@ class reoo:
         # If there is no translation, we don't want to add a line
         if len(unquotedstr) == 0:
             return
-        if isinstance(unquotedstr, unicode):
+        if isinstance(unquotedstr, six.text_type):
             unquotedstr = unquotedstr.encode("UTF-8")
         # finally set the new definition in the oo, but not if its empty
         if len(unquotedstr) > 0:

--- a/translate/convert/po2php.py
+++ b/translate/convert/po2php.py
@@ -24,6 +24,8 @@ See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/command
 for examples and usage instructions.
 """
 
+import six
+
 from translate.convert import convert
 from translate.misc import quote
 from translate.storage import php, po
@@ -57,7 +59,7 @@ class rephp:
         return outputlines
 
     def convertline(self, line):
-        line = unicode(line, 'utf-8')
+        line = six.text_type(line, 'utf-8')
         returnline = ""
 
         # handle multiline msgid if we're in one
@@ -153,7 +155,7 @@ class rephp:
                 if endpos == -1 or line[endpos-1] == '\\':
                     self.inmultilinemsgid = True
 
-        if isinstance(returnline, unicode):
+        if isinstance(returnline, six.text_type):
             returnline = returnline.encode('utf-8')
 
         return returnline

--- a/translate/convert/po2prop.py
+++ b/translate/convert/po2prop.py
@@ -175,7 +175,7 @@ class reprop:
                     else:
                         value = self._handle_accesskeys(unit, key)
                     self.inecho = False
-                    assert isinstance(value, unicode)
+                    assert isinstance(value, six.text_type)
                     returnline = "%(key)s%(del)s%(value)s%(term)s%(eol)s" % {
                         "key": "%s%s%s" % (self.personality.key_wrap_char,
                                            key,
@@ -190,7 +190,7 @@ class reprop:
             else:
                 self.inecho = True
                 returnline = line + eol
-        assert isinstance(returnline, unicode)
+        assert isinstance(returnline, six.text_type)
         return returnline
 
 

--- a/translate/convert/po2rc.py
+++ b/translate/convert/po2rc.py
@@ -24,6 +24,8 @@ See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/command
 for examples and usage instructions.
 """
 
+import six
+
 from translate.convert import convert
 from translate.storage import po, rc
 
@@ -60,7 +62,7 @@ class rerc:
 
     def convertblock(self, block):
         newblock = block
-        if isinstance(newblock, unicode):
+        if isinstance(newblock, six.text_type):
             newblock = newblock.encode('utf-8')
         if newblock.startswith("LANGUAGE"):
             return "LANGUAGE %s, %s" % (self.lang, self.sublang)
@@ -71,7 +73,7 @@ class rerc:
                     newmatch = unit.match.group().replace(unit.match.groupdict()['value'],
                                                           self.inputdict[location])
                     newblock = newblock.replace(unit.match.group(), newmatch)
-        if isinstance(newblock, unicode):
+        if isinstance(newblock, six.text_type):
             newblock = newblock.encode(self.charset)
         return newblock
 

--- a/translate/convert/prop2mozfunny.py
+++ b/translate/convert/prop2mozfunny.py
@@ -21,6 +21,8 @@
 """Converts properties files to additional Mozilla format files.
 """
 
+import six
+
 from translate.convert import mozfunny2prop, po2prop
 from translate.misc.wStringIO import StringIO
 from translate.storage import properties
@@ -37,7 +39,7 @@ def prop2inc(pf):
             else:
                 for blank in pendingblanks:
                     yield blank
-                if isinstance(comment, unicode):
+                if isinstance(comment, six.text_type):
                     comment = comment.encode("UTF-8")
                 # TODO: could convert commented # x=y back to # #define x y
                 yield comment + "\n"
@@ -45,7 +47,7 @@ def prop2inc(pf):
             pendingblanks.append("\n")
         else:
             definition = "#define %s %s\n" % (unit.name, unit.value.replace("\n", "\\n"))
-            if isinstance(definition, unicode):
+            if isinstance(definition, six.text_type):
                 definition = definition.encode("UTF-8")
             for blank in pendingblanks:
                 yield blank
@@ -66,7 +68,7 @@ def prop2it(pf):
             yield ""
         else:
             definition = "%s=%s\n" % (unit.name, unit.value)
-            if isinstance(definition, unicode):
+            if isinstance(definition, six.text_type):
                 definition = definition.encode("UTF-8")
             yield definition
 

--- a/translate/convert/test_accesskey.py
+++ b/translate/convert/test_accesskey.py
@@ -20,6 +20,8 @@
 """Test the various functions for combining and extracting accesskeys and
 labels"""
 
+import six
+
 from translate.convert import accesskey
 
 
@@ -53,7 +55,7 @@ def test_unicode():
     assert accesskey.extract(u"E_ḓiṱ", u"_") == (u"Eḓiṱ", u"ḓ")
     label, akey = accesskey.extract(u"E&ḓiṱ")
     assert label, akey == (u"Eḓiṱ", u"ḓ")
-    assert isinstance(label, unicode) and isinstance(akey, unicode)
+    assert isinstance(label, six.text_type) and isinstance(akey, six.text_type)
     assert accesskey.combine(u"Eḓiṱ", u"ḓ") == (u"E&ḓiṱ")
 
 

--- a/translate/convert/test_html2po.py
+++ b/translate/convert/test_html2po.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import six
 from pytest import mark
 
 from translate.convert import html2po, po2html, test_convert
@@ -38,7 +39,7 @@ class TestHTML2PO:
             unitnumber = unitnumber - 1
         print('unit source: ' + pofile.units[unitnumber].source.encode('utf-8') + '|')
         print('expected: ' + expected.encode('utf-8') + '|')
-        assert unicode(pofile.units[unitnumber].source) == unicode(expected)
+        assert six.text_type(pofile.units[unitnumber].source) == six.text_type(expected)
 
     def check_single(self, markup, itemtext):
         """checks that converting this markup produces a single element with value itemtext"""
@@ -420,7 +421,7 @@ ghi ?>'''
         pofile = self.html2po('<!-- comment outside block --><p><!-- a comment -->A paragraph<!-- with another comment -->.</p>', keepcomments=True)
         self.compareunit(pofile, 1, 'A paragraph.')
         notes = pofile.getunits()[-1].getnotes()
-        assert unicode(notes) == ' a comment \n with another comment '
+        assert six.text_type(notes) == ' a comment \n with another comment '
 
 
 class TestHTML2POCommand(test_convert.TestConvertCommand, TestHTML2PO):

--- a/translate/convert/xliff2oo.py
+++ b/translate/convert/xliff2oo.py
@@ -92,7 +92,7 @@ class reoo:
                                key, len(self.index))
                 try:
                     sourceunitlines = str(unit)
-                    if isinstance(sourceunitlines, unicode):
+                    if isinstance(sourceunitlines, six.text_type):
                         sourceunitlines = sourceunitlines.encode("utf-8")
                     logger.warning(sourceunitlines)
                 except:
@@ -122,7 +122,7 @@ class reoo:
         # If there is no translation, we don't want to add a line
         if len(unquotedstr.strip()) == 0:
             return
-        if isinstance(unquotedstr, unicode):
+        if isinstance(unquotedstr, six.text_type):
             unquotedstr = unquotedstr.encode("UTF-8")
         # finally set the new definition in the oo, but not if its empty
         if len(unquotedstr) > 0:

--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -135,6 +135,7 @@ def tagproperties(strings, ignore):
     return properties
 
 
+@six.python_2_unicode_compatible
 class FilterFailure(Exception):
     """This exception signals that a Filter didn't pass, and gives an
     explanation or a comment.
@@ -144,15 +145,12 @@ class FilterFailure(Exception):
         if not isinstance(messages, list):
             messages = [messages]
 
-        assert isinstance(messages[0], unicode)  # Assumption: all of same type
+        assert isinstance(messages[0], six.text_type)  # Assumption: all of same type
 
         self.messages = messages
 
-    def __unicode__(self):
-        return unicode(u", ".join(self.messages))
-
     def __str__(self):
-        return str(u", ".join(self.messages))
+        return u", ".join(self.messages)
 
 
 class SeriousFilterFailure(FilterFailure):
@@ -450,7 +448,7 @@ class UnitChecker(object):
                 filterresult = self.run_test(filterfunction, unit)
             except FilterFailure as e:
                 filterresult = False
-                filtermessage = unicode(e)
+                filtermessage = six.text_type(e)
             except Exception as e:
                 if self.errorhandler is None:
                     raise ValueError("error in filter %s: %r, %r, %s" %
@@ -508,7 +506,7 @@ class TranslationChecker(UnitChecker):
 
             for pluralform in unit.target.strings:
                 try:
-                    if not test(self.str1, unicode(pluralform)):
+                    if not test(self.str1, six.text_type(pluralform)):
                         filterresult = False
                 except FilterFailure as e:
                     filterresult = False
@@ -1526,11 +1524,11 @@ class StandardChecker(TranslationChecker):
         # serves no purpose to get sourcelang.sentenceend
         str1 = re.sub(u"[^%s]( I )" % self.config.sourcelang.sentenceend, u" i ", str1)
 
-        capitals1 = helpers.filtercount(str1, unicode.isupper)
-        capitals2 = helpers.filtercount(str2, unicode.isupper)
+        capitals1 = helpers.filtercount(str1, six.text_type.isupper)
+        capitals2 = helpers.filtercount(str2, six.text_type.isupper)
 
-        alpha1 = helpers.filtercount(str1, unicode.isalpha)
-        alpha2 = helpers.filtercount(str2, unicode.isalpha)
+        alpha1 = helpers.filtercount(str1, six.text_type.isalpha)
+        alpha2 = helpers.filtercount(str2, six.text_type.isalpha)
 
         # Capture the all caps case
         if capitals1 == alpha1:

--- a/translate/filters/decoration.py
+++ b/translate/filters/decoration.py
@@ -21,6 +21,7 @@
 """functions to get decorative/informative text out of strings..."""
 
 import re
+import six
 import unicodedata
 
 from translate.lang import data
@@ -93,8 +94,8 @@ def isvalidaccelerator(accelerator, acceptlist=None):
     :rtype: Boolean
     :return: True if the supplied character is an acceptable accelerator
     """
-    assert isinstance(accelerator, unicode)
-    assert isinstance(acceptlist, unicode) or acceptlist is None
+    assert isinstance(accelerator, six.text_type)
+    assert isinstance(acceptlist, six.text_type) or acceptlist is None
     if len(accelerator) == 0:
         return False
     if acceptlist is not None:
@@ -225,7 +226,7 @@ def getvariables(startmarker, endmarker):
 def getnumbers(str1):
     """returns any numbers that are in the string"""
     # TODO: handle locale-based periods e.g. 2,5 for Afrikaans
-    assert isinstance(str1, unicode)
+    assert isinstance(str1, six.text_type)
     numbers = []
     innumber = False
     degreesign = u'\xb0'

--- a/translate/filters/prefilters.py
+++ b/translate/filters/prefilters.py
@@ -36,7 +36,7 @@ def removekdecomments(str1):
 
       "_: comment\n"
     """
-    assert isinstance(str1, unicode)
+    assert isinstance(str1, six.text_type)
     iskdecomment = False
     lines = str1.split("\n")
     removelines = []
@@ -167,7 +167,7 @@ def filterwordswithpunctuation(str1):
         occurrences.extend([(pos, word, replacement) for pos in quote.find_all(str1, word)])
     for match in word_with_apos_re.finditer(str1):
         word = match.group()
-        replacement = filter(unicode.isalnum, word)
+        replacement = filter(six.text_type.isalnum, word)
         occurrences.append((match.start(), word, replacement))
     occurrences.sort()
     if occurrences:

--- a/translate/filters/spelling.py
+++ b/translate/filters/spelling.py
@@ -22,6 +22,7 @@
 """An API to provide spell checking for use in checks or elsewhere."""
 
 import logging
+import six
 
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,7 @@ try:
         spellchecker = _get_checker(lang)
         if not spellchecker:
             return
-        spellchecker.set_text(unicode(text))
+        spellchecker.set_text(six.text_type(text))
         for err in spellchecker:
             yield err.word, err.wordpos, err.suggest()
 
@@ -59,7 +60,7 @@ try:
         spellchecker = _get_checker(lang)
         if not spellchecker:
             return
-        spellchecker.set_text(unicode(text))
+        spellchecker.set_text(six.text_type(text))
         for err in spellchecker:
             yield err.word
 

--- a/translate/lang/data.py
+++ b/translate/lang/data.py
@@ -272,6 +272,7 @@ import gettext
 import locale
 import os
 import re
+import six
 
 
 iso639 = {}
@@ -404,7 +405,7 @@ def forceunicode(string):
         encoding = getattr(string, "encoding", "utf-8")
         string = string.decode(encoding)
     elif isinstance(string, StringElem):
-        string = unicode(string)
+        string = six.text_type(string)
     return string
 
 

--- a/translate/misc/autoencode.py
+++ b/translate/misc/autoencode.py
@@ -21,38 +21,33 @@
 """Supports a hybrid Unicode string that knows which encoding is preferable,
 and uses this when converting to a string."""
 
-
-# Python 3 compatibility
-try:
-    unicode
-except NameError:
-    unicode = str
+import six
 
 
-class autoencode(unicode):
+class autoencode(six.text_type):
 
     def __new__(newtype, string=u"", encoding=None, errors=None):
-        if isinstance(string, unicode):
+        if isinstance(string, six.text_type):
             if errors is None:
-                newstring = unicode.__new__(newtype, string)
+                newstring = six.text_type.__new__(newtype, string)
             else:
-                newstring = unicode.__new__(newtype, string, errors=errors)
+                newstring = six.text_type.__new__(newtype, string, errors=errors)
             if encoding is None and isinstance(string, autoencode):
                 newstring.encoding = string.encoding
             else:
                 newstring.encoding = encoding
         else:
             if errors is None and encoding is None:
-                newstring = unicode.__new__(newtype, string)
+                newstring = six.text_type.__new__(newtype, string)
             elif errors is None:
                 try:
-                    newstring = unicode.__new__(newtype, string, encoding)
+                    newstring = six.text_type.__new__(newtype, string, encoding)
                 except LookupError as e:
                     raise ValueError(str(e))
             elif encoding is None:
-                newstring = unicode.__new__(newtype, string, errors)
+                newstring = six.text_type.__new__(newtype, string, errors)
             else:
-                newstring = unicode.__new__(newtype, string, encoding, errors)
+                newstring = six.text_type.__new__(newtype, string, encoding, errors)
             newstring.encoding = encoding
         return newstring
 

--- a/translate/misc/multistring.py
+++ b/translate/misc/multistring.py
@@ -21,6 +21,8 @@
 """Supports a hybrid Unicode string that can also have a list of alternate
 strings in the strings attribute"""
 
+import six
+
 from translate.misc import autoencode
 
 
@@ -54,8 +56,8 @@ class multistring(autoencode.autoencode):
                 return cmp(self.strings[1:], otherstring.strings[1:])
         elif isinstance(otherstring, autoencode.autoencode):
             return cmp(autoencode.autoencode(self), otherstring)
-        elif isinstance(otherstring, unicode):
-            return cmp(unicode(self), otherstring)
+        elif isinstance(otherstring, six.text_type):
+            return cmp(six.text_type(self), otherstring)
         elif isinstance(otherstring, str):
             return cmp(str(self), otherstring)
         elif isinstance(otherstring, list) and otherstring:

--- a/translate/misc/test_autoencode.py
+++ b/translate/misc/test_autoencode.py
@@ -18,8 +18,8 @@ class TestAutoencode:
 
     def test_uniqueness(self):
         """tests constructor creates unique objects"""
-        s1 = unicode(u'unicode string')
-        s2 = unicode(u'unicode string')
+        s1 = u'unicode string'
+        s2 = u'unicode string'
         assert s1 == s2
         assert s1 is s2
         s1 = self.type2test(u'unicode string', 'utf-8')

--- a/translate/misc/wStringIO.py
+++ b/translate/misc/wStringIO.py
@@ -29,7 +29,7 @@ class StringIO(BytesIO):
     def __init__(self, buf=''):
         if not isinstance(buf, six.string_types):
             buf = str(buf)
-        if isinstance(buf, unicode):
+        if isinstance(buf, six.text_type):
             buf = buf.encode('utf-8')
         super(StringIO, self).__init__(buf)
 

--- a/translate/misc/xml_helpers.py
+++ b/translate/misc/xml_helpers.py
@@ -21,6 +21,7 @@
 """Helper functions for working with XML."""
 
 import re
+import six
 
 from lxml import etree
 
@@ -46,9 +47,9 @@ def getText(node, xml_space="preserve"):
     an optional default to use in case nothing is specified in this node."""
     xml_space = getXMLspace(node, xml_space)
     if xml_space == "default":
-        return unicode(string_xpath_normalized(node))  # specific to lxml.etree
+        return six.text_type(string_xpath_normalized(node))  # specific to lxml.etree
     else:
-        return unicode(string_xpath(node))  # specific to lxml.etree
+        return six.text_type(string_xpath(node))  # specific to lxml.etree
 
     # If we want to normalise space and only preserve it when the directive
     # xml:space="preserve" is given in node or in parents, consider this code:

--- a/translate/search/indexing/CommonIndexer.py
+++ b/translate/search/indexing/CommonIndexer.py
@@ -177,8 +177,8 @@ class CommonDatabase(object):
             elif isinstance(query, tuple):
                 field, value = query
                 # perform unicode normalization
-                field = translate.lang.data.normalize(unicode(field))
-                value = translate.lang.data.normalize(unicode(value))
+                field = translate.lang.data.normalize(six.text_type(field))
+                value = translate.lang.data.normalize(six.text_type(value))
                 # check for the choosen match type
                 if analyzer is None:
                     analyzer = self.get_field_analyzers(field)
@@ -189,7 +189,7 @@ class CommonDatabase(object):
                 if analyzer is None:
                     analyzer = self.analyzer
                 # perform unicode normalization
-                query = translate.lang.data.normalize(unicode(query))
+                query = translate.lang.data.normalize(six.text_type(query))
                 result.append(self._create_query_for_string(query,
                         require_all=require_all, analyzer=analyzer))
             else:
@@ -567,11 +567,11 @@ class CommonDatabase(object):
         unicode normalization."""
         if isinstance(text, str):
             try:
-                result = unicode(text.decode("UTF-8"))
-            except UnicodeEncodeError as e:
-                result = unicode(text.decode("charmap"))
-        elif not isinstance(text, unicode):
-            result = unicode(text)
+                result = text.decode("UTF-8")
+            except UnicodeDecodeError:
+                result = text.decode("charmap")
+        elif not isinstance(text, six.text_type):
+            result = six.text_type(text)
         else:
             result = text
         # perform unicode normalization

--- a/translate/search/match.py
+++ b/translate/search/match.py
@@ -23,6 +23,7 @@ translation units."""
 
 import heapq
 import re
+import six
 from six.moves import filter as ifilter
 
 from translate.misc.multistring import multistring
@@ -111,8 +112,8 @@ class matcher(object):
                 if len(candidate.source.strings) > 1:
                     simpleunit.orig_source = candidate.source
                     simpleunit.orig_target = candidate.target
-                simpleunit.source = unicode(candidate.source)
-                simpleunit.target = unicode(candidate.target)
+                simpleunit.source = six.text_type(candidate.source)
+                simpleunit.target = six.text_type(candidate.target)
             else:
                 simpleunit.source = candidate.source
                 simpleunit.target = candidate.target

--- a/translate/services/tmserver.py
+++ b/translate/services/tmserver.py
@@ -23,6 +23,7 @@ with clients using JSON over HTTP."""
 
 import json
 import logging
+import six
 from argparse import ArgumentParser
 from io import BytesIO
 from urlparse import parse_qs
@@ -36,7 +37,7 @@ class TMServer(object):
 
     def __init__(self, tmdbfile, tmfiles, max_candidates=3, min_similarity=75,
             max_length=1000, prefix="", source_lang=None, target_lang=None):
-        if not isinstance(tmdbfile, unicode):
+        if not isinstance(tmdbfile, six.text_type):
             import sys
             tmdbfile = tmdbfile.decode(sys.getfilesystemencoding())
 
@@ -74,7 +75,7 @@ class TMServer(object):
     def translate_unit(self, environ, start_response, uid, slang, tlang):
         start_response("200 OK", [('Content-type', 'text/plain')])
         candidates = self.tmdb.translate_unit(uid, slang, tlang)
-        logging.debug("candidates: %s", unicode(candidates))
+        logging.debug("candidates: %s", six.text_type(candidates))
         response = json.dumps(candidates, indent=4)
         params = parse_qs(environ.get('QUERY_STRING', ''))
         try:

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -160,7 +160,7 @@ class TranslationUnit(object):
            >>> TranslationUnit.rich_to_multistring(rich)
            multistring(u'foo bar')
         """
-        return multistring([unicode(elem) for elem in elem_list])
+        return multistring([six.text_type(elem) for elem in elem_list])
 
     def multistring_to_rich(self, mulstring):
         """Convert a multistring to a list of "rich" string trees:
@@ -764,7 +764,7 @@ class TranslationStore(object):
 
         for encoding in encodings:
             try:
-                r_text = unicode(text, encoding)
+                r_text = six.text_type(text, encoding)
                 r_encoding = encoding
                 break
             except UnicodeDecodeError:

--- a/translate/storage/catkeys.py
+++ b/translate/storage/catkeys.py
@@ -51,6 +51,7 @@ Escaping
 """
 
 import csv
+import six
 
 from translate.lang import data
 from translate.storage import base
@@ -155,7 +156,7 @@ class CatkeysUnit(base.TranslationUnit):
     def _set_source_or_target(self, key, newvalue):
         if newvalue is None:
             self._dict[key] = None
-        if isinstance(newvalue, unicode):
+        if isinstance(newvalue, six.text_type):
             newvalue = newvalue.encode('utf-8')
         newvalue = _escape(newvalue)
         if not key in self._dict or newvalue != self._dict[key]:

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -279,7 +279,7 @@ class pounit(pocommon.pounit):
     def setsource(self, source):
         if isinstance(source, multistring):
             source = source.strings
-        if isinstance(source, unicode):
+        if isinstance(source, six.text_type):
             source = source.encode(self.CPO_ENC)
         if isinstance(source, list):
             gpo.po_message_set_msgid(self._gpo_message, source[0].encode(self.CPO_ENC))
@@ -336,7 +336,7 @@ class pounit(pocommon.pounit):
         if isinstance(target, list):
             for i in range(len(target)):
                 targetstring = target[i]
-                if isinstance(targetstring, unicode):
+                if isinstance(targetstring, six.text_type):
                     targetstring = targetstring.encode(self.CPO_ENC)
                 gpo.po_message_set_msgstr_plural(self._gpo_message, i, targetstring)
         # add the values of a dict
@@ -345,7 +345,7 @@ class pounit(pocommon.pounit):
                 gpo.po_message_set_msgstr_plural(self._gpo_message, i, targetstring)
         # add a single string
         else:
-            if isinstance(target, unicode):
+            if isinstance(target, six.text_type):
                 target = target.encode(self.CPO_ENC)
             if target is None:
                 gpo.po_message_set_msgstr(self._gpo_message, "")
@@ -538,7 +538,7 @@ class pounit(pocommon.pounit):
             if locline == -1:
                 locstring = locname
             else:
-                locstring = locname + u":" + unicode(locline)
+                locstring = locname + u":" + six.text_type(locline)
             locations.append(pocommon.unquote_plus(locstring))
             i += 1
             location = gpo.po_message_filepos(self._gpo_message, i)

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -104,7 +104,7 @@ csv.register_dialect('default', DefaultDialect)
 def from_unicode(text, encoding='utf-8'):
     if encoding == 'auto':
         encoding = 'utf-8'
-    if isinstance(text, unicode):
+    if isinstance(text, six.text_type):
         return text.encode(encoding)
     return text
 
@@ -112,7 +112,7 @@ def from_unicode(text, encoding='utf-8'):
 def to_unicode(text, encoding='utf-8'):
     if encoding == 'auto':
         encoding = 'utf-8'
-    if isinstance(text, unicode):
+    if isinstance(text, six.text_type):
         return text
     return text.decode(encoding)
 
@@ -377,7 +377,7 @@ class csvfile(base.TranslationStore):
         sniffer = csv.Sniffer()
         # FIXME: maybe we should sniff a smaller sample
         sample = csvsrc[:1024]
-        if isinstance(sample, unicode):
+        if isinstance(sample, six.text_type):
             sample = sample.encode('utf-8')
 
         try:
@@ -412,7 +412,7 @@ class csvfile(base.TranslationStore):
     def __str__(self):
         """convert to a string. double check that unicode is handled somehow here"""
         source = self.getoutput()
-        if not isinstance(source, unicode):
+        if not isinstance(source, six.text_type):
             source = source.decode('utf-8')
         if not self.encoding or self.encoding == 'auto':
             encoding = 'utf-8'

--- a/translate/storage/dtd.py
+++ b/translate/storage/dtd.py
@@ -85,6 +85,7 @@ Escaping in Android DTD
 """
 
 import re
+import six
 import warnings
 from io import BytesIO
 try:
@@ -491,7 +492,7 @@ class dtdunit(base.TranslationUnit):
     def __str__(self):
         """convert to a string. double check that unicode is handled somehow here"""
         source = self.getoutput()
-        if isinstance(source, unicode):
+        if isinstance(source, six.text_type):
             return source.encode(getattr(self, "encoding", "UTF-8"))
         return source
 
@@ -514,7 +515,7 @@ class dtdunit(base.TranslationUnit):
                 entityline = '<!ENTITY' + self.space_pre_entity + self.entity + self.space_pre_definition + self.definition + self.closing
             if getattr(self, 'hashprefix', None):
                 entityline = self.hashprefix + " " + entityline
-            if isinstance(entityline, unicode):
+            if isinstance(entityline, six.text_type):
                 entityline = entityline.encode('UTF-8')
             lines.append(entityline + '\n')
         return "".join(lines)
@@ -570,7 +571,7 @@ class dtdfile(base.TranslationStore):
         if not self._valid_store():
             warnings.warn("DTD file '%s' does not validate" % self.filename)
             return None
-        if isinstance(source, unicode):
+        if isinstance(source, six.text_type):
             return source.encode(getattr(self, "encoding", "UTF-8"))
         return source
 

--- a/translate/storage/fpo.py
+++ b/translate/storage/fpo.py
@@ -95,7 +95,7 @@ class pounit(pocommon.pounit):
         source = source or u""
         if isinstance(source, multistring):
             self._source = source
-        elif isinstance(source, unicode):
+        elif isinstance(source, six.text_type):
             self._source = source
         else:
             #unicode, list, dict
@@ -209,8 +209,8 @@ class pounit(pocommon.pounit):
         """
 
         def mergelists(list1, list2, split=False):
-            #decode where necessary
-            if unicode in [type(item) for item in list2] + [type(item) for item in list1]:
+            # Decode where necessary (either all bytestrings or all unicode)
+            if six.text_type in [type(item) for item in list2] + [type(item) for item in list1]:
                 for position, item in enumerate(list1):
                     if isinstance(item, str):
                         list1[position] = item.decode("utf-8")

--- a/translate/storage/mo.py
+++ b/translate/storage/mo.py
@@ -42,6 +42,7 @@ in very small files.
 
 import array
 import re
+import six
 import struct
 
 from translate.misc.multistring import multistring
@@ -202,7 +203,7 @@ class mofile(poheader.poheader, base.TranslationStore):
             # TODO: We don't do any encoding detection from the PO Header
             add_to_hash_table(id, i)
             string = MESSAGES[id]  # id already encoded for use as dictionary key
-            if isinstance(string, unicode):
+            if isinstance(string, six.text_type):
                 string = string.encode('utf-8')
             offsets.append((len(ids), len(id), len(strs), len(string)))
             ids = ids + id + '\0'

--- a/translate/storage/mozilla_lang.py
+++ b/translate/storage/mozilla_lang.py
@@ -23,6 +23,8 @@
 
 """A class to manage Mozilla .lang files."""
 
+import six
+
 from translate.storage import base, txt
 
 
@@ -107,6 +109,6 @@ class LangStore(txt.TxtFile):
         ret_string = ""
         if self.is_active or self.mark_active:
             ret_string += "## active ##\n"
-        ret_string += u"\n\n\n".join([unicode(unit) for unit in self.units]).encode('utf-8')
+        ret_string += u"\n\n\n".join([six.text_type(unit) for unit in self.units]).encode('utf-8')
         ret_string += "\n"
         return ret_string

--- a/translate/storage/omegat.py
+++ b/translate/storage/omegat.py
@@ -41,6 +41,7 @@ Encoding
 
 import csv
 import locale
+import six
 
 from translate.storage import base
 
@@ -92,7 +93,7 @@ class OmegaTUnit(base.TranslationUnit):
     def _set_field(self, key, newvalue):
         if newvalue is None:
             self._dict[key] = None
-        if isinstance(newvalue, unicode):
+        if isinstance(newvalue, six.text_type):
             newvalue = newvalue.encode('utf-8')
         if not key in self._dict or newvalue != self._dict[key]:
             self._dict[key] = newvalue

--- a/translate/storage/oo.py
+++ b/translate/storage/oo.py
@@ -162,7 +162,7 @@ def unescape_help_text(text):
 
 def encode_if_needed_utf8(text):
     """Encode a Unicode string the the specified encoding"""
-    if isinstance(text, unicode):
+    if isinstance(text, six.text_type):
         return text.encode('UTF-8')
     return text
 

--- a/translate/storage/php.py
+++ b/translate/storage/php.py
@@ -57,6 +57,7 @@ implemented as outlined in the PHP documentation for the
 
 import logging
 import re
+import six
 
 from translate.storage import base
 
@@ -154,7 +155,7 @@ class phpunit(base.TranslationUnit):
     def __str__(self):
         """Convert to a string. Double check that unicode is handled somehow."""
         source = self.getoutput()
-        if isinstance(source, unicode):
+        if isinstance(source, six.text_type):
             return source.encode(getattr(self, "encoding", "UTF-8"))
         return source
 

--- a/translate/storage/placeables/general.py
+++ b/translate/storage/placeables/general.py
@@ -24,6 +24,7 @@ fit into any other sub-category.
 """
 
 import re
+import six
 
 from translate.storage.placeables.base import G, Ph, StringElem
 
@@ -322,7 +323,7 @@ def to_general_placeables(tree, classmap={
 
     for baseclass, gclasslist in classmap.items():
         if isinstance(tree, baseclass):
-            gclass = [c for c in gclasslist if c.parse(unicode(tree))]
+            gclass = [c for c in gclasslist if c.parse(six.text_type(tree))]
             if gclass:
                 newtree = gclass[0]()
 

--- a/translate/storage/placeables/lisa.py
+++ b/translate/storage/placeables/lisa.py
@@ -89,12 +89,12 @@ def make_placeable(node, xml_space):
 
 
 def as_unicode(string):
-    if isinstance(string, unicode):
+    if isinstance(string, six.text_type):
         return string
     elif isinstance(string, StringElem):
-        return unicode(string)
+        return six.text_type(string)
     else:
-        return unicode(string.decode('utf-8'))
+        return string.decode('utf-8')
 
 
 def xml_to_strelem(dom_node, xml_space="preserve"):
@@ -110,15 +110,15 @@ def xml_to_strelem(dom_node, xml_space="preserve"):
             continue
         sub.append(make_placeable(child_dom_node, xml_space))
         if child_dom_node.tail:
-            sub.append(StringElem(unicode(child_dom_node.tail)))
+            sub.append(StringElem(six.text_type(child_dom_node.tail)))
 
     # This is just a strange way of inserting the first text and avoiding a
     # call to .prune() which is very expensive. We assume the tree is optimal.
     node_text = dom_node.text
     if sub and node_text:
-        sub.insert(0, StringElem(unicode(node_text)))
+        sub.insert(0, StringElem(six.text_type(node_text)))
     elif node_text:
-        sub.append(unicode(node_text))
+        sub.append(six.text_type(node_text))
     return result
 
 # ==========================================================
@@ -178,19 +178,19 @@ _placeable_dictionary = {
 def xml_append_string(node, string):
     if not len(node):
         if not node.text:
-            node.text = unicode(string)
+            node.text = six.text_type(string)
         else:
-            node.text += unicode(string)
+            node.text += six.text_type(string)
     else:
         lastchild = node.getchildren()[-1]
         if lastchild.tail is None:
             lastchild.tail = ''
-        lastchild.tail += unicode(string)
+        lastchild.tail += six.text_type(string)
     return node
 
 
 def strelem_to_xml(parent_node, elem):
-    if isinstance(elem, unicode):
+    if isinstance(elem, six.text_type):
         return xml_append_string(parent_node, elem)
     if not isinstance(elem, StringElem):
         return parent_node

--- a/translate/storage/placeables/parse.py
+++ b/translate/storage/placeables/parse.py
@@ -23,6 +23,8 @@ Contains the ``parse`` function that parses normal strings into StringElem-
 based "rich" string element trees.
 """
 
+import six
+
 from translate.storage.placeables import StringElem, base
 
 
@@ -47,7 +49,7 @@ def parse(tree, parse_funcs):
                         form the original string. If nothing could be
                         parsed, it should return ``None``.
     """
-    if isinstance(tree, unicode):
+    if isinstance(tree, six.text_type):
         tree = StringElem(tree)
     if not parse_funcs:
         return tree
@@ -60,7 +62,7 @@ def parse(tree, parse_funcs):
         if not leaf.istranslatable:
             continue
 
-        unileaf = unicode(leaf)
+        unileaf = six.text_type(leaf)
         if not unileaf:
             continue
 
@@ -69,7 +71,7 @@ def parse(tree, parse_funcs):
             if (len(subleaves) == 1 and isinstance(subleaves[0], type(leaf)) and
                 leaf == subleaves[0]):
                 pass
-            elif isinstance(leaf, unicode):
+            elif isinstance(leaf, six.text_type):
                 parent = tree.get_parent_elem(leaf)
                 if parent is not None:
                     if len(parent.sub) == 1:

--- a/translate/storage/placeables/strelem.py
+++ b/translate/storage/placeables/strelem.py
@@ -33,6 +33,7 @@ class ElementNotFoundError(ValueError):
     pass
 
 
+@six.python_2_unicode_compatible
 class StringElem(object):
     """
     This class represents a sub-tree of a string parsed into a rich structure.
@@ -62,11 +63,11 @@ class StringElem(object):
     def __init__(self, sub=None, id=None, rid=None, xid=None, **kwargs):
         if sub is None:
             self.sub = []
-        elif isinstance(sub, (unicode, StringElem)):
+        elif isinstance(sub, (six.text_type, StringElem)):
             self.sub = [sub]
         else:
             for elem in sub:
-                if not isinstance(elem, (unicode, StringElem)):
+                if not isinstance(elem, (six.text_type, StringElem)):
                     raise ValueError(elem)
             self.sub = sub
             self.prune()
@@ -83,11 +84,11 @@ class StringElem(object):
     # SPECIAL METHODS #
     def __add__(self, rhs):
         """Emulate the ``unicode`` class."""
-        return unicode(self) + rhs
+        return six.text_type(self) + rhs
 
     def __contains__(self, item):
         """Emulate the ``unicode`` class."""
-        return item in unicode(self)
+        return item in six.text_type(self)
 
     def __eq__(self, rhs):
         """:returns: ``True`` if (and only if) all members as well as sub-trees
@@ -106,19 +107,19 @@ class StringElem(object):
 
     def __ge__(self, rhs):
         """Emulate the ``unicode`` class."""
-        return unicode(self) >= rhs
+        return six.text_type(self) >= rhs
 
     def __getitem__(self, i):
         """Emulate the ``unicode`` class."""
-        return unicode(self)[i]
+        return six.text_type(self)[i]
 
     def __getslice__(self, i, j):
         """Emulate the ``unicode`` class."""
-        return unicode(self)[i:j]
+        return six.text_type(self)[i:j]
 
     def __gt__(self, rhs):
         """Emulate the ``unicode`` class."""
-        return unicode(self) > rhs
+        return six.text_type(self) > rhs
 
     def __iter__(self):
         """Create an iterator of this element's sub-elements."""
@@ -127,19 +128,19 @@ class StringElem(object):
 
     def __le__(self, rhs):
         """Emulate the ``unicode`` class."""
-        return unicode(self) <= rhs
+        return six.text_type(self) <= rhs
 
     def __len__(self):
         """Emulate the ``unicode`` class."""
-        return len(unicode(self))
+        return len(six.text_type(self))
 
     def __lt__(self, rhs):
         """Emulate the ``unicode`` class."""
-        return unicode(self) < rhs
+        return six.text_type(self) < rhs
 
     def __mul__(self, rhs):
         """Emulate the ``unicode`` class."""
-        return unicode(self) * rhs
+        return six.text_type(self) * rhs
 
     def __ne__(self, rhs):
         return not self.__eq__(rhs)
@@ -163,16 +164,11 @@ class StringElem(object):
         }
 
     def __str__(self):
-        if not self.isvisible:
-            return ''
-        return ''.join([unicode(elem).encode('utf-8') for elem in self.sub])
-
-    def __unicode__(self):
         if callable(self.renderer):
             return self.renderer(self)
         if not self.isvisible:
             return u''
-        return u''.join([unicode(elem) for elem in self.sub])
+        return u''.join([six.text_type(elem) for elem in self.sub])
 
     # METHODS #
     def apply_to_strings(self, f):
@@ -406,7 +402,7 @@ class StringElem(object):
 
     def encode(self, encoding=sys.getdefaultencoding()):
         """More ``unicode`` class emulation."""
-        return unicode(self).encode(encoding)
+        return six.text_type(self).encode(encoding)
 
     def elem_offset(self, elem):
         """Find the offset of ``elem`` in the current tree.
@@ -432,10 +428,10 @@ class StringElem(object):
             if e.isleaf():
                 leafoffset = 0
                 for s in e.sub:
-                    if unicode(s) == unicode(elem):
+                    if six.text_type(s) == six.text_type(elem):
                         return offset + leafoffset
                     else:
-                        leafoffset += len(unicode(s))
+                        leafoffset += len(six.text_type(s))
                 offset += len(e)
         return -1
 
@@ -458,14 +454,14 @@ class StringElem(object):
         """Find sub-string ``x`` in this string tree and return the position
             at which it starts."""
         if isinstance(x, six.string_types):
-            return unicode(self).find(x)
+            return six.text_type(self).find(x)
         if isinstance(x, StringElem):
-            return unicode(self).find(unicode(x))
+            return six.text_type(self).find(six.text_type(x))
         return None
 
     def find_elems_with(self, x):
         """Find all elements in the current sub-tree containing ``x``."""
-        return [elem for elem in self.flatten() if x in unicode(elem)]
+        return [elem for elem in self.flatten() if x in six.text_type(elem)]
 
     def flatten(self, filter=None):
         """Flatten the tree by returning a depth-first search over the
@@ -526,7 +522,7 @@ class StringElem(object):
 
         def checkleaf(elem, text):
             if elem.isleaf() and type(text) is StringElem and text.isleaf():
-                return unicode(text)
+                return six.text_type(text)
             return text
 
         # There are 4 general cases (including specific cases) where text can
@@ -592,11 +588,11 @@ class StringElem(object):
                 #logging.debug('Case 3')
                 eoffset = offset - self.elem_offset(oelem)
                 if oelem.isleaf():
-                    s = unicode(oelem)  # Collapse all sibling strings into one
+                    s = six.text_type(oelem)  # Collapse all sibling strings into one
                     head = s[:eoffset]
                     tail = s[eoffset:]
                     if type(text) is StringElem and text.isleaf():
-                        oelem.sub = [head + unicode(text) + tail]
+                        oelem.sub = [head + six.text_type(text) + tail]
                     else:
                         oelem.sub = [StringElem(head), text, StringElem(tail)]
                     return True
@@ -682,7 +678,7 @@ class StringElem(object):
                 raise ValueError('"left" and "right" refer to the same element and is not empty.')
             if not left.iseditable:
                 return False
-        if isinstance(text, unicode):
+        if isinstance(text, six.text_type):
             text = StringElem(text)
 
         if left is right:
@@ -832,7 +828,7 @@ class StringElem(object):
             manner."""
         indent_prefix = " " * indent * 2
         out = (u"%s%s [%s]" % (indent_prefix, self.__class__.__name__,
-                               unicode(self))).encode('utf-8')
+                               six.text_type(self))).encode('utf-8')
         if verbose:
             out += u' ' + repr(self)
 

--- a/translate/storage/placeables/test_base.py
+++ b/translate/storage/placeables/test_base.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import six
 from pytest import mark
 
 from translate.storage.placeables import StringElem, base, general, parse, xliff
@@ -31,14 +32,14 @@ class TestStringElem:
         self.elem = parse(self.ORIGSTR, general.parsers)
 
     def test_parse(self):
-        assert unicode(self.elem) == self.ORIGSTR
+        assert six.text_type(self.elem) == self.ORIGSTR
 
     def test_tree(self):
         assert len(self.elem.sub) == 4
-        assert unicode(self.elem.sub[0]) == u'Ģët '
-        assert unicode(self.elem.sub[1]) == u'<a href="http://www.example.com" alt="Ģët &brand;!">'
-        assert unicode(self.elem.sub[2]) == u'&brandLong;'
-        assert unicode(self.elem.sub[3]) == u'</a>'
+        assert six.text_type(self.elem.sub[0]) == u'Ģët '
+        assert six.text_type(self.elem.sub[1]) == u'<a href="http://www.example.com" alt="Ģët &brand;!">'
+        assert six.text_type(self.elem.sub[2]) == u'&brandLong;'
+        assert six.text_type(self.elem.sub[3]) == u'</a>'
 
         assert len(self.elem.sub[0].sub) == 1 and self.elem.sub[0].sub[0] == u'Ģët '
         assert len(self.elem.sub[1].sub) == 1 and self.elem.sub[1].sub[0] == u'<a href="http://www.example.com" alt="Ģët &brand;!">'
@@ -92,7 +93,7 @@ class TestStringElem:
         assert len(self.elem.find_elems_with('a')) == 3
 
     def test_flatten(self):
-        assert u''.join([unicode(i) for i in self.elem.flatten()]) == self.ORIGSTR
+        assert u''.join([six.text_type(i) for i in self.elem.flatten()]) == self.ORIGSTR
 
     def test_delete_range_case1(self):
         # Case 1: Entire string #
@@ -127,7 +128,7 @@ class TestStringElem:
         assert parent is None
         assert offset is None
         assert len(elem.sub) == 2
-        assert unicode(elem) == u'Ģët <a href="http://www.example.com" alt="Ģët &brand;!">'
+        assert six.text_type(elem) == u'Ģët <a href="http://www.example.com" alt="Ģët &brand;!">'
 
         # A separate test case where the delete range include elements between
         # the start- and end elements.
@@ -138,34 +139,34 @@ class TestStringElem:
         assert deleted == origelem
         assert parent is None
         assert offset is None
-        assert unicode(elem) == 'foobar'
+        assert six.text_type(elem) == 'foobar'
 
     def test_insert(self):
         # Test inserting at the beginning
         elem = self.elem.copy()
         elem.insert(0, u'xxx')
-        assert unicode(elem.sub[0]) == u'xxx' + unicode(self.elem.sub[0])
+        assert six.text_type(elem.sub[0]) == u'xxx' + six.text_type(self.elem.sub[0])
 
         # Test inserting at the end
         elem = self.elem.copy()
         elem.insert(len(elem), u'xxx')
         assert elem.flatten()[-1] == StringElem(u'xxx')
-        assert unicode(elem).endswith('&brandLong;</a>xxx')
+        assert six.text_type(elem).endswith('&brandLong;</a>xxx')
 
         elem = self.elem.copy()
         elem.insert(len(elem), u">>>", preferred_parent=elem.sub[-1])
-        assert unicode(elem.flatten()[-1]) == u'</a>>>>'
-        assert unicode(elem).endswith('&brandLong;</a>>>>')
+        assert six.text_type(elem.flatten()[-1]) == u'</a>>>>'
+        assert six.text_type(elem).endswith('&brandLong;</a>>>>')
 
         # Test inserting in the middle of an existing string
         elem = self.elem.copy()
         elem.insert(2, u'xxx')
-        assert unicode(elem.sub[0]) == u'Ģëxxxt '
+        assert six.text_type(elem.sub[0]) == u'Ģëxxxt '
 
         # Test inserting between elements
         elem = self.elem.copy()
         elem.insert(56, u'xxx')
-        assert unicode(elem)[56:59] == u'xxx'
+        assert six.text_type(elem)[56:59] == u'xxx'
 
     def test_isleaf(self):
         for child in self.elem.sub:
@@ -189,7 +190,7 @@ class TestConverters:
         # The following asserts say that, even though tree and newtree represent the same string
         # (the unicode() results are the same), they are composed of different classes (and so
         # their repr()s are different
-        assert unicode(self.elem) == unicode(basetree)
+        assert six.text_type(self.elem) == six.text_type(basetree)
         assert repr(self.elem) != repr(basetree)
 
     @mark.xfail(reason="Test needs fixing, disabled for now")
@@ -202,14 +203,14 @@ class TestConverters:
     def test_to_xliff_placeables(self):
         basetree = base.to_base_placeables(self.elem)
         xliff_from_base = xliff.to_xliff_placeables(basetree)
-        assert unicode(xliff_from_base) != unicode(self.elem)
+        assert six.text_type(xliff_from_base) != six.text_type(self.elem)
         assert repr(xliff_from_base) != repr(self.elem)
 
         xliff_from_gen = xliff.to_xliff_placeables(self.elem)
-        assert unicode(xliff_from_gen) != unicode(self.elem)
+        assert six.text_type(xliff_from_gen) != six.text_type(self.elem)
         assert repr(xliff_from_gen) != repr(self.elem)
 
-        assert unicode(xliff_from_base) == unicode(xliff_from_gen)
+        assert six.text_type(xliff_from_base) == six.text_type(xliff_from_gen)
         assert repr(xliff_from_base) == repr(xliff_from_gen)
 
 

--- a/translate/storage/placeables/test_terminology.py
+++ b/translate/storage/placeables/test_terminology.py
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import six
 from io import BytesIO
 
 from translate.search.match import terminologymatcher
@@ -58,8 +59,8 @@ msgstr "lêernaam"
         term = tree.sub[3].sub[1]
 
         assert isinstance(term, TerminologyPlaceable)
-        assert unicode(term) == self.term_po.getunits()[2].source
-        assert term.translate() == unicode(self.term_po.getunits()[2].target)
+        assert six.text_type(term) == self.term_po.getunits()[2].source
+        assert term.translate() == six.text_type(self.term_po.getunits()[2].target)
 
 
 if __name__ == '__main__':

--- a/translate/storage/pocommon.py
+++ b/translate/storage/pocommon.py
@@ -19,6 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import re
+import six
 from six.moves.urllib import parse
 
 from translate.storage import base, poheader
@@ -47,7 +48,7 @@ def quote_plus(text):
 def unquote_plus(text):
     """unquote('%7e/abc+def') -> '~/abc def'"""
     try:
-        if isinstance(text, unicode):
+        if isinstance(text, six.text_type):
             text = text.encode('utf-8')
         return parse.unquote_plus(text).decode('utf-8')
     except UnicodeEncodeError as e:

--- a/translate/storage/poxliff.py
+++ b/translate/storage/poxliff.py
@@ -25,6 +25,7 @@ This way the API supports plurals as if it was a PO file, for example.
 """
 
 import re
+import six
 
 from lxml import etree
 
@@ -388,7 +389,7 @@ class PoXliffFile(xliff.xlifffile, poheader.poheader):
 
         for entry in singularunits:
             term = self.UnitClass.createfromxmlElement(entry, namespace=self.namespace)
-            if nextplural and unicode(term.getid()) == ("%s[0]" % nextplural.getid()):
+            if nextplural and six.text_type(term.getid()) == ("%s[0]" % nextplural.getid()):
                 self.addunit(nextplural, new=False)
                 nextplural = next(pluralunit_iter, None)
             else:

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -481,7 +481,7 @@ class propunit(base.TranslationUnit):
         """Convert to a string. Double check that unicode is handled
         somehow here."""
         source = self.getoutput()
-        assert isinstance(source, unicode)
+        assert isinstance(source, six.text_type)
         return source.encode(self.encoding)
 
     def getoutput(self):

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -414,8 +414,8 @@ class pounit(pocommon.pounit):
         """
 
         def mergelists(list1, list2, split=False):
-            #decode where necessary
-            if unicode in [type(item) for item in list2] + [type(item) for item in list1]:
+            # Decode where necessary (either all bytestrings or all unicode)
+            if six.text_type in [type(item) for item in list2] + [type(item) for item in list1]:
                 for position, item in enumerate(list1):
                     if isinstance(item, str):
                         list1[position] = item.decode("utf-8")
@@ -627,7 +627,7 @@ class pounit(pocommon.pounit):
 
     def _encodeifneccessary(self, output):
         """Encodes unicode strings and returns other strings unchanged"""
-        if isinstance(output, unicode):
+        if isinstance(output, six.text_type):
             encoding = encodingToUse(getattr(self, "_encoding", "UTF-8"))
             return output.encode(encoding)
         return output
@@ -839,7 +839,7 @@ class pofile(pocommon.pofile):
         """Convert to a string. Double check that unicode is handled somehow
         here"""
         output = self._getoutput()
-        if isinstance(output, unicode):
+        if isinstance(output, six.text_type):
             try:
                 return output.encode(getattr(self, "_encoding", "UTF-8"))
             except UnicodeEncodeError as e:
@@ -870,7 +870,7 @@ class pofile(pocommon.pofile):
         if encoding is None or encoding.lower() == "charset":
             encoding = 'UTF-8'
         for line in lines:
-            if isinstance(line, unicode):
+            if isinstance(line, six.text_type):
                 line = line.encode(encoding)
             newlines.append(line)
         return newlines

--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -28,6 +28,7 @@
 """
 
 import re
+import six
 
 from translate.storage import base
 
@@ -85,7 +86,7 @@ class rcunit(base.TranslationUnit):
     def __str__(self):
         """Convert to a string. Double check that unicode is handled somehow here."""
         source = self.getoutput()
-        if isinstance(source, unicode):
+        if isinstance(source, six.text_type):
             return source.encode(getattr(self, "encoding", "UTF-8"))
         return source
 

--- a/translate/storage/statistics.py
+++ b/translate/storage/statistics.py
@@ -141,7 +141,7 @@ class Statistics(object):
         #TODO: we don't handle checking plurals at all yet, as this is tricky...
         source = unit.source
         target = unit.target
-        if isinstance(source, str) and isinstance(target, unicode):
+        if isinstance(source, str) and isinstance(target, six.text_type):
             source = source.decode(getattr(unit, "encoding", "utf-8"))
         #TODO: decoding should not be done here
 #        checkresult = self.checker.run_filters(unit, source, target)

--- a/translate/storage/statsdb.py
+++ b/translate/storage/statsdb.py
@@ -404,7 +404,7 @@ class StatsCache(object):
         store can be a TranslationFile object or a callback that returns one.
         """
         if isinstance(filename, str):
-            filename = unicode(filename, sys.getfilesystemencoding())
+            filename = six.text_type(filename, sys.getfilesystemencoding())
         realpath = os.path.realpath(filename)
         self.cur.execute("""SELECT fileid, st_mtime, st_size FROM files
                 WHERE path=?;""", (realpath,))

--- a/translate/storage/test_base.py
+++ b/translate/storage/test_base.py
@@ -21,6 +21,7 @@
 """tests for storage base classes"""
 
 import os
+import six
 import warnings
 
 import pytest
@@ -181,15 +182,15 @@ class TestTranslationUnit:
             assert len(elems[0].sub) == 1
             assert len(elems[1].sub) == 3
 
-            assert unicode(elems[0]) == target_mstr.strings[0]
-            assert unicode(elems[1]) == target_mstr.strings[1]
+            assert six.text_type(elems[0]) == target_mstr.strings[0]
+            assert six.text_type(elems[1]) == target_mstr.strings[1]
 
-            assert unicode(elems[1].sub[0]) == u'<b>'
-            assert unicode(elems[1].sub[1]) == u'string'
-            assert unicode(elems[1].sub[2]) == u'</b>'
+            assert six.text_type(elems[1].sub[0]) == u'<b>'
+            assert six.text_type(elems[1].sub[1]) == u'string'
+            assert six.text_type(elems[1].sub[2]) == u'</b>'
         else:
             assert len(elems[0].sub) == 1
-            assert unicode(elems[0]) == target_mstr.strings[0]
+            assert six.text_type(elems[0]) == target_mstr.strings[0]
 
     def test_rich_set(self):
         """Basic test for converting from multistrings to StringElem trees."""

--- a/translate/storage/test_po.py
+++ b/translate/storage/test_po.py
@@ -293,7 +293,7 @@ msgstr[1] "Kóeie"
         pofile = self.poparse(posource)
         unit = pofile.units[0]
         assert isinstance(unit.source, multistring)
-        assert isinstance(unit.source.strings[1], unicode)
+        assert isinstance(unit.source.strings[1], six.text_type)
 
     def test_nongettext_location(self):
         """test that we correctly handle a non-gettext (file:linenumber) location"""
@@ -305,7 +305,7 @@ msgstr[1] "Kóeie"
         print(locations)
         assert len(locations) == 1
         assert locations[0] == u"programming/C/programming.xml:44(para)"
-        assert isinstance(locations[0], unicode)
+        assert isinstance(locations[0], six.text_type)
 
     @mark.xfail(reason="Not Implemented")
     def test_kde_plurals(self):
@@ -764,7 +764,7 @@ msgstr "b"
 '''
         pofile = self.poparse(posource)
         for line in pofile.units[0].getnotes():
-            assert isinstance(line, unicode)
+            assert isinstance(line, six.text_type)
 
     def test_non_ascii_header_comments(self):
         posource = r'''

--- a/translate/storage/test_tiki.py
+++ b/translate/storage/test_tiki.py
@@ -4,6 +4,9 @@
 # tiki unit tests
 # Author: Wil Clouser <wclouser@mozilla.com>
 # Date: 2008-12-01
+
+import six
+
 from translate.storage import tiki
 
 
@@ -19,12 +22,12 @@ class TestTikiUnit:
     def test_to_unicode(self):
         unit = tiki.TikiUnit("one")
         unit.settarget('two')
-        assert unicode(unit) == '"one" => "two",\n'
+        assert six.text_type(unit) == '"one" => "two",\n'
 
         unit2 = tiki.TikiUnit("one")
         unit2.settarget('two')
         unit2.addlocation('untranslated')
-        assert unicode(unit2) == '// "one" => "two",\n'
+        assert six.text_type(unit2) == '// "one" => "two",\n'
 
 
 class TestTikiStore:

--- a/translate/storage/tiki.py
+++ b/translate/storage/tiki.py
@@ -54,11 +54,13 @@ As far as I know no detailed documentation exists for the tiki language.php file
 
 import datetime
 import re
+import six
 
 from translate.misc import wStringIO
 from translate.storage import base
 
 
+@six.python_2_unicode_compatible
 class TikiUnit(base.TranslationUnit):
     """A tiki unit entry."""
 
@@ -66,7 +68,7 @@ class TikiUnit(base.TranslationUnit):
         self.location = []
         super(TikiUnit, self).__init__(source)
 
-    def __unicode__(self):
+    def __str__(self):
         """Returns a string formatted to be inserted into a tiki language.php file."""
         ret = u'"%s" => "%s",' % (self.source, self.target)
         if self.location == ["untranslated"]:
@@ -123,18 +125,18 @@ class TikiStore(base.TranslationStore):
 
         output += "// ### Start of unused words\n"
         for unit in _unused:
-            output += unicode(unit)
+            output += six.text_type(unit)
         output += "// ### end of unused words\n\n"
         output += "// ### start of untranslated words\n"
         for unit in _untranslated:
-            output += unicode(unit)
+            output += six.text_type(unit)
         output += "// ### end of untranslated words\n\n"
         output += "// ### start of possibly untranslated words\n"
         for unit in _possiblyuntranslated:
-            output += unicode(unit)
+            output += six.text_type(unit)
         output += "// ### end of possibly untranslated words\n\n"
         for unit in _translated:
-            output += unicode(unit)
+            output += six.text_type(unit)
 
         output += self._tiki_footer()
         return output.encode('UTF-8')

--- a/translate/storage/tmdb.py
+++ b/translate/storage/tmdb.py
@@ -24,6 +24,7 @@
 import logging
 import math
 import re
+import six
 import threading
 import time
 from sqlite3 import dbapi2
@@ -54,8 +55,8 @@ class TMDB(object):
         self.min_similarity = min_similarity
         self.max_length = max_length
 
-        if not isinstance(db_file, unicode):
-            db_file = unicode(db_file)  # don't know which encoding
+        if not isinstance(db_file, six.text_type):
+            db_file = six.text_type(db_file)  # don't know which encoding
         self.db_file = db_file
         # share connections to same database file between different instances
         if db_file not in self._tm_dbs:
@@ -275,7 +276,7 @@ DROP TRIGGER IF EXISTS sources_delete_trig;
     def translate_unit(self, unit_source, source_langs, target_langs):
         """return TM suggestions for unit_source"""
         if isinstance(unit_source, str):
-            unit_source = unicode(unit_source, "utf-8")
+            unit_source = six.text_type(unit_source, "utf-8")
         if isinstance(source_langs, list):
             source_langs = [data.normalize_code(lang) for lang in source_langs]
             source_langs = ','.join(source_langs)
@@ -325,7 +326,7 @@ DROP TRIGGER IF EXISTS sources_delete_trig;
                 })
         results.sort(key=lambda match: match['quality'], reverse=True)
         results = results[:self.max_candidates]
-        logging.debug("results: %s", unicode(results))
+        logging.debug("results: %s", six.text_type(results))
         return results
 
 

--- a/translate/storage/txt.py
+++ b/translate/storage/txt.py
@@ -28,6 +28,7 @@ Supported formats are
 """
 
 import re
+import six
 
 from translate.storage import base
 
@@ -65,7 +66,7 @@ class TxtUnit(base.TranslationUnit):
     def __str__(self):
         """Convert a txt unit to a string"""
         string = u"".join([self.pretext, self.source, self.posttext])
-        if isinstance(string, unicode):
+        if isinstance(string, six.text_type):
             return string.encode(self.encoding)
         return string
 
@@ -153,7 +154,7 @@ class TxtFile(base.TranslationStore):
 
     def __str__(self):
         source = self.getoutput()
-        if isinstance(source, unicode):
+        if isinstance(source, six.text_type):
             return source.encode(getattr(self, "encoding", "UTF-8"))
         return source
 

--- a/translate/storage/utx.py
+++ b/translate/storage/utx.py
@@ -115,7 +115,7 @@ class UtxUnit(base.TranslationUnit):
         # FIXME update the header date
         if newvalue is None:
             self._dict[key] = None
-        if isinstance(newvalue, unicode):
+        if isinstance(newvalue, six.text_type):
             newvalue = newvalue.encode('utf-8')
         if not key in self._dict or newvalue != self._dict[key]:
             self._dict[key] = newvalue

--- a/translate/storage/wordfast.py
+++ b/translate/storage/wordfast.py
@@ -317,7 +317,7 @@ class WordfastUnit(base.TranslationUnit):
     def _set_source_or_target(self, key, newvalue):
         if newvalue is None:
             self._dict[key] = None
-        if isinstance(newvalue, unicode):
+        if isinstance(newvalue, six.text_type):
             newvalue = newvalue.encode('utf-8')
         newvalue = _char_to_wf(newvalue)
         if not key in self._dict or newvalue != self._dict[key]:

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -425,14 +425,14 @@ class xliffunit(lisa.LISAunit):
             # unit has no proper file ancestor, probably newly created
             pass
         # hide the fact that we sanitize ID_SEPERATOR
-        uid += unicode(self.xmlelement.get("id") or u"").replace(ID_SEPARATOR_SAFE, ID_SEPARATOR)
+        uid += six.text_type(self.xmlelement.get("id") or u"").replace(ID_SEPARATOR_SAFE, ID_SEPARATOR)
         return uid
 
     def addlocation(self, location):
         self.setid(location)
 
     def getlocations(self):
-        id_attr = unicode(self.xmlelement.get("id") or u"")
+        id_attr = six.text_type(self.xmlelement.get("id") or u"")
         # XLIFF files downloaded from PO projects in Pootle
         # might have id equal to .source, so let's avoid
         # that:
@@ -521,7 +521,7 @@ class xliffunit(lisa.LISAunit):
     def rich_to_multistring(cls, elem_list):
         """Override :meth:`TranslationUnit.rich_to_multistring` which is used
         by the ``rich_source`` and ``rich_target`` properties."""
-        return multistring([unicode(elem) for elem in elem_list])
+        return multistring([six.text_type(elem) for elem in elem_list])
 
 
 class xlifffile(lisa.LISAfile):

--- a/translate/storage/xml_extract/extract.py
+++ b/translate/storage/xml_extract/extract.py
@@ -52,7 +52,7 @@ class Translatable(object):
         If not, then there's nothing to translate.
         """
         for chunk in self.source:
-            if isinstance(chunk, unicode) and chunk.strip() != u"":
+            if isinstance(chunk, six.text_type) and chunk.strip() != u"":
                 return True
         return False
 
@@ -105,13 +105,13 @@ def process_translatable(dom_node, state):
 
     Any translatable content present in a child node is treated as a placeable.
     """
-    source = [unicode(dom_node.text or u"")]
+    source = [six.text_type(dom_node.text or u"")]
 
     # Append Translatable objects and unicode strings for the translatable
     # content for all the children.
     for child in dom_node:
         source.append(_process_placeable(child, state))
-        source.append(unicode(child.tail or u""))
+        source.append(six.text_type(child.tail or u""))
 
     translatable = Translatable(state.placeable_name,
                                 state.xpath_breadcrumb.xpath, dom_node, source,
@@ -156,7 +156,7 @@ def _retrieve_idml_placeables(dom_node, state):
                                        False))
 
             if child.tail is not None and child.tail.strip():
-                source.append(unicode(child.tail))
+                source.append(six.text_type(child.tail))
 
             continue
 
@@ -170,7 +170,7 @@ def _retrieve_idml_placeables(dom_node, state):
             nested_stuff = []
 
             if child.text is not None and child.text.strip():
-                nested_stuff = [unicode(child.text)]
+                nested_stuff = [six.text_type(child.text)]
 
             nested_stuff.extend(_retrieve_idml_placeables(child, state))
 
@@ -179,7 +179,7 @@ def _retrieve_idml_placeables(dom_node, state):
                                        nested_stuff, state.is_inline))
 
             if child.tail is not None and child.tail.strip():
-                source.append(unicode(child.tail))
+                source.append(six.text_type(child.tail))
 
     return source
 
@@ -288,10 +288,10 @@ def _to_placeables(parent_translatable, translatable, id_maker):
     """
     result = []
     for chunk in translatable.source:
-        if isinstance(chunk, unicode):
+        if isinstance(chunk, six.text_type):
             result.append(chunk)
         else:
-            id = unicode(id_maker.get_id(chunk))
+            id = six.text_type(id_maker.get_id(chunk))
             if chunk.is_inline:
                 sub = _to_placeables(parent_translatable, chunk, id_maker)
                 result.append(xliff.G(id=id, sub=sub))

--- a/translate/storage/xml_extract/misc.py
+++ b/translate/storage/xml_extract/misc.py
@@ -19,13 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import re
-
-
-# Python 3 compatibility
-try:
-    unicode
-except NameError:
-    unicode = str
+import six
 
 
 def reduce_tree(f, parent_unit_node, unit_node, get_children, *state):
@@ -83,8 +77,8 @@ def parse_tag(full_tag):
         ret = []
         for k in ("namespace", "tag"):
             value = match.groupdict()[k] or ""
-            if not isinstance(value, unicode):
-                value = unicode(value, encoding="utf-8")
+            if not isinstance(value, six.text_type):
+                value = six.text_type(value, encoding="utf-8")
             ret.append(value)
         return ret[0], ret[1]
     else:

--- a/translate/tools/podebug.py
+++ b/translate/tools/podebug.py
@@ -26,6 +26,7 @@ for examples and usage instructions.
 
 import os
 import re
+import six
 from hashlib import md5
 
 from translate.convert import dtd2po
@@ -73,11 +74,11 @@ class podebug:
         if not isinstance(string, StringElem):
             string = StringElem(string)
         string.sub.insert(0, prepend)
-        if unicode(string).endswith(u'\n'):
+        if six.text_type(string).endswith(u'\n'):
             # Try and remove the last character from the tree
             try:
                 lastnode = string.flatten()[-1]
-                if isinstance(lastnode.sub[-1], unicode):
+                if isinstance(lastnode.sub[-1], six.text_type):
                     lastnode.sub[-1] = lastnode.sub[-1].rstrip(u'\n')
             except IndexError:
                 pass

--- a/translate/tools/pogrep.py
+++ b/translate/tools/pogrep.py
@@ -30,6 +30,7 @@ for examples and usage instructions.
 
 import locale
 import re
+import six
 
 from translate.lang import data
 from translate.misc import optrecurse
@@ -138,7 +139,7 @@ class GrepFilter:
             invertmatch=False, keeptranslations=False, accelchar=None, encoding='utf-8',
             max_matches=0):
         """builds a checkfilter using the given checker"""
-        if isinstance(searchstring, unicode):
+        if isinstance(searchstring, six.text_type):
             self.searchstring = searchstring
         else:
             self.searchstring = searchstring.decode(encoding)

--- a/translate/tools/test_podebug.py
+++ b/translate/tools/test_podebug.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import six
+
 from translate.storage import base, po, xliff
 from translate.tools import podebug
 
@@ -68,16 +70,16 @@ class TestPODebug:
 
     def test_rewrite_unicode(self):
         """Test the unicode rewrite function"""
-        assert unicode(self.debug.rewrite_unicode(u"Test")) == u"Ŧḗşŧ"
+        assert six.text_type(self.debug.rewrite_unicode(u"Test")) == u"Ŧḗşŧ"
 
     def test_rewrite_flipped(self):
         """Test the unicode rewrite function"""
-        assert unicode(self.debug.rewrite_flipped(u"Test")) == u"\u202e⊥ǝsʇ"
+        assert six.text_type(self.debug.rewrite_flipped(u"Test")) == u"\u202e⊥ǝsʇ"
         # alternative with reversed string and no RTL override:
         #assert unicode(self.debug.rewrite_flipped("Test")) == u"ʇsǝ⊥"
         # Chars < ! and > z are returned as is
-        assert unicode(self.debug.rewrite_flipped(u" ")) == u"\u202e "
-        assert unicode(self.debug.rewrite_flipped(u"©")) == u"\u202e©"
+        assert six.text_type(self.debug.rewrite_flipped(u" ")) == u"\u202e "
+        assert six.text_type(self.debug.rewrite_flipped(u"©")) == u"\u202e©"
 
     def test_rewrite_chef(self):
         """Test the chef rewrite function


### PR DESCRIPTION
"unicode" does not exist any longer in Python 3 (as literals are
unicode by default).