### PR TITLE
Checks: Python braces not needed for LibreOffice

### DIFF
--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -2058,6 +2058,11 @@ class LibreOfficeChecker(StandardChecker):
                     raise FilterFailure(u"There is no close tag for %s" % (opentags.pop()))
         return True
 
+    @critical
+    def pythonbraceformat(self, str1, str2):
+        """Not used in LibreOffice"""
+        return True
+
 
 mozillaconfig = CheckerConfig(
     accelmarkers=["&"],

--- a/translate/filters/test_checks.py
+++ b/translate/filters/test_checks.py
@@ -601,6 +601,8 @@ def test_pythonbraceformat():
     assert fails_serious(stdchecker.pythonbraceformat,    "String {}",           "Nommer {1}")
     assert fails_serious(stdchecker.pythonbraceformat,    "String {0}",          "Nommer {1}")
     assert fails_serious(stdchecker.pythonbraceformat,    "String {0} {}",       "Nommer {1}")
+    lochecker = checks.LibreOfficeChecker()
+    assert passes(lochecker.pythonbraceformat, "Time remaining: {[1] minutes }{[2] seconds}", "Tenpo che'l resta: {[1] minuti}{[2] secondi}")
 
     # Named formats
     assert passes(stdchecker.pythonbraceformat, "String {str} and number {num}", "Nommer {num} en string {str}")


### PR DESCRIPTION
Exclusion of checks should be easier than this.  But for now do it this way.