### PR TITLE
Transformed iterators to lists when needed

### DIFF
--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -431,7 +431,7 @@ class UnitChecker(object):
         priorityfunctionnames = self.preconditions.keys()
         otherfunctionnames = filter(lambda functionname: functionname not in self.preconditions, functionnames)
 
-        for functionname in priorityfunctionnames + otherfunctionnames:
+        for functionname in list(priorityfunctionnames) + list(otherfunctionnames):
             if functionname in ignores:
                 continue
 
@@ -2366,7 +2366,7 @@ class StandardUnitChecker(UnitChecker):
             nplurals = self.config.lang.nplurals
 
             if nplurals > 0:
-                return len(filter(None, unit.target.strings)) == nplurals
+                return len(list(filter(None, unit.target.strings))) == nplurals
 
         return True
 

--- a/translate/filters/helpers.py
+++ b/translate/filters/helpers.py
@@ -46,7 +46,7 @@ def funcsmatch(str1, str2, funclist):
 
 def filtercount(str1, func):
     """returns the number of characters in str1 that pass func"""
-    return len(filter(func, str1))
+    return len(list(filter(func, str1)))
 
 
 def filtertestmethod(testmethod, strfilter):

--- a/translate/filters/prefilters.py
+++ b/translate/filters/prefilters.py
@@ -151,7 +151,7 @@ def filtervariables(startmarker, endmarker, varfilter):
 # all apostrophes in the middle of the word are handled already
 wordswithpunctuation = ["'n", "'t",]  # Afrikaans
 # map all the words to their non-punctified equivalent
-wordswithpunctuation = dict([(word, filter(str.isalnum, word)) for word in wordswithpunctuation])
+wordswithpunctuation = dict([(word, ''.join(filter(str.isalnum, word))) for word in wordswithpunctuation])
 
 word_with_apos_re = re.compile("(?u)\w+'\w+")
 
@@ -167,7 +167,7 @@ def filterwordswithpunctuation(str1):
         occurrences.extend([(pos, word, replacement) for pos in quote.find_all(str1, word)])
     for match in word_with_apos_re.finditer(str1):
         word = match.group()
-        replacement = filter(six.text_type.isalnum, word)
+        replacement = ''.join(filter(six.text_type.isalnum, word))
         occurrences.append((match.start(), word, replacement))
     occurrences.sort()
     if occurrences:

--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -285,7 +285,7 @@ class RecursiveOptionParser(optparse.OptionParser, object):
         }
         progressoption = optparse.Option(None, "--progress", dest="progress",
                 default="bar",
-                choices=self.progresstypes.keys(), metavar="PROGRESS",
+                choices=list(self.progresstypes.keys()), metavar="PROGRESS",
                 help="show progress as: %s" % (", ".join(self.progresstypes)))
         self.define_option(progressoption)
 
@@ -301,9 +301,7 @@ class RecursiveOptionParser(optparse.OptionParser, object):
 
     def getformathelp(self, formats):
         """Make a nice help string for describing formats..."""
-        formats = sorted(formats)
-        if None in formats:
-            formats = filter(lambda format: format is not None, formats)
+        formats = sorted([f for f in formats if f is not None])
         if len(formats) == 0:
             return ""
         elif len(formats) == 1:

--- a/translate/search/match.py
+++ b/translate/search/match.py
@@ -197,10 +197,7 @@ class matcher(object):
                     stoplength = self.getstoplength(min_similarity, text)
 
         #Remove the empty ones:
-        def notzero(item):
-            score = item[0]
-            return score != 0
-        bestcandidates = filter(notzero, bestcandidates)
+        bestcandidates = [item for item in bestcandidates if item[0] != 0]
         #Sort for use as a general list, and reverse so the best one is at index 0
         bestcandidates.sort(reverse=True)
         return self.buildunits(bestcandidates)

--- a/translate/storage/mo.py
+++ b/translate/storage/mo.py
@@ -191,9 +191,8 @@ class mofile(poheader.poheader, base.TranslationStore):
                 MESSAGES[source.encode("utf-8")] = target
         # using "I" works for 32- and 64-bit systems, but not for 16-bit!
         hash_table = array.array("I", [0] * hash_size)
-        keys = MESSAGES.keys()
         # the keys are sorted in the .mo file
-        keys.sort()
+        keys = sorted(MESSAGES.keys())
         offsets = []
         ids = strs = ''
         for i, id in enumerate(keys):

--- a/translate/storage/poxliff.py
+++ b/translate/storage/poxliff.py
@@ -381,7 +381,7 @@ class PoXliffFile(xliff.xlifffile, poheader.poheader):
         pluralgroups = filter(ispluralgroup, groups)
         termEntries = root_node.iterdescendants(self.namespaced(self.UnitClass.rootNode))
 
-        singularunits = filter(isnonpluralunit, termEntries)
+        singularunits = list(filter(isnonpluralunit, termEntries))
         if len(singularunits) == 0:
             return
         pluralunit_iter = pluralunits(pluralgroups)

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -57,8 +57,7 @@ def escapeforpo(line):
     special_locations = []
     for special_key in po_escape_map:
         special_locations.extend(quote.find_all(line, special_key))
-    special_locations = dict.fromkeys(special_locations).keys()
-    special_locations.sort()
+    special_locations = sorted(dict.fromkeys(special_locations).keys())
     escaped_line = ""
     last_location = 0
     for location in special_locations:
@@ -276,7 +275,7 @@ class pounit(pocommon.pounit):
     def gettarget(self):
         """Returns the unescaped msgstr"""
         if isinstance(self.msgstr, dict):
-            return multistring(map(unquotefrompo, self.msgstr.values()), self._encoding)
+            return multistring(list(map(unquotefrompo, self.msgstr.values())), self._encoding)
         else:
             return unquotefrompo(self.msgstr)
 
@@ -584,8 +583,7 @@ class pounit(pocommon.pounit):
 
     def _getmsgpartstr(self, partname, partlines, partcomments=""):
         if isinstance(partlines, dict):
-            partkeys = partlines.keys()
-            partkeys.sort()
+            partkeys = sorted(partlines.keys())
             return "".join([self._getmsgpartstr("%s[%d]" % (partname, partkey), partlines[partkey], partcomments) for partkey in partkeys])
         partstr = partname + " "
         partstartline = 0

--- a/translate/storage/qph.py
+++ b/translate/storage/qph.py
@@ -61,11 +61,7 @@ class QphUnit(lisa.LISAunit):
 
     def getlanguageNodes(self):
         """We override this to get source and target nodes."""
-
-        def not_none(node):
-            return not node is None
-
-        return filter(not_none, [self._getsourcenode(), self._gettargetnode()])
+        return [n for n in [self._getsourcenode(), self._gettargetnode()] if n is not None]
 
     def addnote(self, text, origin=None, position="append"):
         """Add a note specifically in a "definition" tag"""

--- a/translate/storage/test_base.py
+++ b/translate/storage/test_base.py
@@ -33,7 +33,7 @@ from translate.storage.placeables import general, parse as rich_parse
 
 def headerless_len(units):
     """return count of translatable (non header) units"""
-    return len(filter(lambda x: not x.isheader(), units))
+    return len(list(filter(lambda x: not x.isheader(), units)))
 
 
 def first_translatable(store):

--- a/translate/storage/tmdb.py
+++ b/translate/storage/tmdb.py
@@ -295,7 +295,7 @@ DROP TRIGGER IF EXISTS sources_delete_trig;
         # split source into words, remove punctuation and special
         # chars, keep words that are at least 3 chars long
         unit_words = STRIP_REGEXP.sub(' ', unit_source).split()
-        unit_words = filter(lambda word: len(word) > 2, unit_words)
+        unit_words = list(filter(lambda word: len(word) > 2, unit_words))
 
         if self.fulltext and len(unit_words) > 3:
             logging.debug("fulltext matching")

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -117,10 +117,7 @@ class tsunit(lisa.LISAunit):
 
     def getlanguageNodes(self):
         """We override this to get source and target nodes."""
-
-        def not_none(node):
-            return not node is None
-        return filter(not_none, [self._getsourcenode(), self._gettargetnode()])
+        return [n for n in [self._getsourcenode(), self._gettargetnode()] if n is not None]
 
     def getsource(self):
         # TODO: support <byte>. See bug 528.

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -610,7 +610,7 @@ class xlifffile(lisa.LISAfile):
         """returns all filenames in this XLIFF file"""
         filenodes = self.document.getroot().iterchildren(self.namespaced("file"))
         filenames = [self.getfilename(filenode) for filenode in filenodes]
-        filenames = filter(None, filenames)
+        filenames = list(filter(None, filenames))
         if len(filenames) == 1 and filenames[0] == '':
             filenames = []
         return filenames


### PR DESCRIPTION
Several constructs in Python 3 do not return lists any longer, but
iterators instead, like filter(), map(), .keys(), .values(), etc.
When iterating, this is not a problem, but where we need a list,
the iterator has to be consumed in a list.