### PR TITLE
Made unit classes encoding agnostic

### DIFF
--- a/translate/convert/test_po2dtd.py
+++ b/translate/convert/test_po2dtd.py
@@ -156,7 +156,7 @@ msgstr "Dimpled Ring"
         dtdsource = str(dtdfile)
         assert "Dimpled Ring" in dtdsource
 
-        po_snippet = r'''#: searchIntegration.label
+        po_snippet = u'''#: searchIntegration.label
 #: searchIntegration.accesskey
 msgid "Allow &searchIntegration.engineName; to &search messages"
 msgstr "&searchIntegration.engineName; &ileti aramasına izin ver"

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -39,6 +39,7 @@ WHITESPACE = ' \n\t'  # Whitespace that we collapse.
 MULTIWHITESPACE = re.compile('[ \n\t]{2}')
 
 
+@six.python_2_unicode_compatible
 class AndroidResourceUnit(base.TranslationUnit):
     """A single entry in the Android String resource file."""
 
@@ -420,7 +421,7 @@ class AndroidResourceUnit(base.TranslationUnit):
 
     def __str__(self):
         return etree.tostring(self.xmlelement, pretty_print=True,
-                              encoding='utf-8')
+                              encoding='unicode')
 
     def __eq__(self, other):
         return (str(self) == str(other))

--- a/translate/storage/catkeys.py
+++ b/translate/storage/catkeys.py
@@ -122,6 +122,7 @@ class CatkeysHeader(object):
     targetlanguage = property(None, settargetlanguage)
 
 
+@six.python_2_unicode_compatible
 class CatkeysUnit(base.TranslationUnit):
     """A catkeys translation memory unit"""
 

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -117,6 +117,7 @@ def to_unicode(text, encoding='utf-8'):
     return text.decode(encoding)
 
 
+@six.python_2_unicode_compatible
 class csvunit(base.TranslationUnit):
     spreadsheetescapes = [("+", "\\+"), ("-", "\\-"), ("=", "\\="), ("'", "\\'")]
 
@@ -257,20 +258,20 @@ class csvunit(base.TranslationUnit):
 
         #self.source, self.target = self.remove_spreadsheet_escapes(self.source, self.target)
 
-    def todict(self, encoding='utf-8'):
+    def todict(self, **kwargs):
         #FIXME: use apis?
         #source, target = self.add_spreadsheet_escapes(self.source, self.target)
         source = self.source
         target = self.target
         output = {
-            'location': from_unicode(self.location, encoding),
-            'source': from_unicode(source, encoding),
-            'target': from_unicode(target, encoding),
-            'id': from_unicode(self.id, encoding),
+            'location': self.location,
+            'source': source,
+            'target': target,
+            'id': self.id,
             'fuzzy': str(self.fuzzy),
-            'context': from_unicode(self.context, encoding),
-            'translator_comments': from_unicode(self.translator_comments, encoding),
-            'developer_comments': from_unicode(self.developer_comments, encoding),
+            'context': self.context,
+            'translator_comments': self.translator_comments,
+            'developer_comments': self.developer_comments,
         }
 
         return output
@@ -427,6 +428,6 @@ class csvfile(base.TranslationStore):
         hdict = dict(map(None, self.fieldnames, self.fieldnames))
         writer.writerow(hdict)
         for ce in self.units:
-            cedict = ce.todict()
+            cedict = dict((k, from_unicode(v, 'utf-8')) for k, v in ce.todict().items())
             writer.writerow(cedict)
         return outputfile.getvalue()

--- a/translate/storage/dtd.py
+++ b/translate/storage/dtd.py
@@ -144,7 +144,7 @@ def quotefordtd(source):
             value = "'" + source + "'"  # Quote using single quotes.
     else:
         value = "\"" + source + "\""  # Quote using double quotes.
-    return value.encode('utf-8')
+    return value
 
 
 _DTD_NAME2CODEPOINT = {
@@ -169,7 +169,8 @@ def unquotefromdtd(source):
     # string. Of course there could also be quote characters within the string.
     quotechar = source[0]
     extracted, quotefinished = quote.extractwithoutquotes(source, quotechar, quotechar, allowreentry=False)
-    extracted = extracted.decode('utf-8')
+    if isinstance(extracted, bytes):
+        extracted = extracted.decode('utf-8')
     if quotechar == "'":
         extracted = extracted.replace("&apos;", "'")
     extracted = quote.entitydecode(extracted, _DTD_NAME2CODEPOINT)
@@ -222,6 +223,7 @@ def removeinvalidamps(name, value):
     return value
 
 
+@six.python_2_unicode_compatible
 class dtdunit(base.TranslationUnit):
     """An entity definition from a DTD file (and any associated comments)."""
 
@@ -490,11 +492,8 @@ class dtdunit(base.TranslationUnit):
         return linesprocessed
 
     def __str__(self):
-        """convert to a string. double check that unicode is handled somehow here"""
-        source = self.getoutput()
-        if isinstance(source, six.text_type):
-            return source.encode(getattr(self, "encoding", "UTF-8"))
-        return source
+        """convert to a string."""
+        return self.getoutput()
 
     def getoutput(self):
         """convert the dtd entity back to string form"""
@@ -515,8 +514,6 @@ class dtdunit(base.TranslationUnit):
                 entityline = '<!ENTITY' + self.space_pre_entity + self.entity + self.space_pre_definition + self.definition + self.closing
             if getattr(self, 'hashprefix', None):
                 entityline = self.hashprefix + " " + entityline
-            if isinstance(entityline, six.text_type):
-                entityline = entityline.encode('UTF-8')
             lines.append(entityline + '\n')
         return "".join(lines)
 

--- a/translate/storage/fpo.py
+++ b/translate/storage/fpo.py
@@ -36,7 +36,6 @@ import six
 from translate.lang import data
 from translate.misc.multistring import multistring
 from translate.storage import base, cpo, pocommon
-from translate.storage.pocommon import encodingToUse
 
 
 logger = logging.getLogger(__name__)
@@ -51,6 +50,7 @@ msgstr ""
 '''
 
 
+@six.python_2_unicode_compatible
 class pounit(pocommon.pounit):
     # othercomments = []      #   # this is another comment
     # automaticcomments = []  #   #. comment extracted from the source code
@@ -68,9 +68,8 @@ class pounit(pocommon.pounit):
     # fashion
     __shallow__ = ['_store']
 
-    def __init__(self, source=None, encoding="UTF-8"):
+    def __init__(self, source=None, **kwargs):
         pocommon.pounit.__init__(self, source)
-        self._encoding = encodingToUse(encoding)
         self._initallcomments(blankall=True)
         self._msgctxt = u""
 

--- a/translate/storage/ical.py
+++ b/translate/storage/ical.py
@@ -63,7 +63,7 @@ from translate.storage import base
 class icalunit(base.TranslationUnit):
     """An ical entry that is translatable"""
 
-    def __init__(self, source=None, encoding="UTF-8"):
+    def __init__(self, source=None, **kwargs):
         self.location = ""
         if source:
             self.source = source

--- a/translate/storage/ini.py
+++ b/translate/storage/ini.py
@@ -77,7 +77,7 @@ class DialectInno(DialectDefault):
 class iniunit(base.TranslationUnit):
     """A INI file entry"""
 
-    def __init__(self, source=None, encoding="UTF-8"):
+    def __init__(self, source=None, **kwargs):
         self.location = ""
         if source:
             self.source = source

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -80,7 +80,7 @@ from translate.storage import base
 class JsonUnit(base.TranslationUnit):
     """A JSON entry"""
 
-    def __init__(self, source=None, ref=None, item=None, encoding="UTF-8"):
+    def __init__(self, source=None, ref=None, item=None, **kwargs):
         self._id = None
         self._item = str(os.urandom(30))
         if item is not None:

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -20,6 +20,8 @@
 
 """Parent class for LISA standards (TMX, TBX, XLIFF)"""
 
+import six
+
 try:
     from lxml import etree
     from translate.misc.xml_helpers import (getText, getXMLlang, getXMLspace,
@@ -31,6 +33,7 @@ from translate.lang import data
 from translate.storage import base
 
 
+@six.python_2_unicode_compatible
 class LISAunit(base.TranslationUnit):
     """
     A single unit in the file.  Provisional work is done to make several
@@ -244,8 +247,9 @@ class LISAunit(base.TranslationUnit):
             return getText(languageNode, xml_space)
 
     def __str__(self):
+        # 'unicode' encoding keeps the unicode status of the output
         return etree.tostring(self.xmlelement, pretty_print=True,
-                              encoding='utf-8')
+                              encoding='unicode')
 
     def _set_property(self, name, value):
         self.xmlelement.attrib[name] = value

--- a/translate/storage/mo.py
+++ b/translate/storage/mo.py
@@ -107,8 +107,7 @@ def get_next_prime_number(start):
 class mounit(base.TranslationUnit):
     """A class representing a .mo translation message."""
 
-    def __init__(self, source=None, encoding=None):
-        #Since the units are really dumb, we ignore encoding for now
+    def __init__(self, source=None, **kwargs):
         self.msgctxt = []
         self.msgidcomments = []
         super(mounit, self).__init__(source)

--- a/translate/storage/mozilla_lang.py
+++ b/translate/storage/mozilla_lang.py
@@ -28,6 +28,7 @@ import six
 from translate.storage import base, txt
 
 
+@six.python_2_unicode_compatible
 class LangUnit(base.TranslationUnit):
     """This is just a normal unit with a weird string output"""
 

--- a/translate/storage/omegat.py
+++ b/translate/storage/omegat.py
@@ -59,6 +59,7 @@ class OmegaTDialect(csv.Dialect):
 csv.register_dialect("omegat", OmegaTDialect)
 
 
+@six.python_2_unicode_compatible
 class OmegaTUnit(base.TranslationUnit):
     """An OmegaT glossary unit"""
 

--- a/translate/storage/php.py
+++ b/translate/storage/php.py
@@ -122,6 +122,7 @@ def phpdecode(text, quotechar="'"):
         return text.replace("\\'", "'").replace("\\\\", "\\")
 
 
+@six.python_2_unicode_compatible
 class phpunit(base.TranslationUnit):
     """A unit of a PHP file: a name, a value, and any comments associated."""
 
@@ -153,11 +154,8 @@ class phpunit(base.TranslationUnit):
     target = property(gettarget, settarget)
 
     def __str__(self):
-        """Convert to a string. Double check that unicode is handled somehow."""
-        source = self.getoutput()
-        if isinstance(source, six.text_type):
-            return source.encode(getattr(self, "encoding", "UTF-8"))
-        return source
+        """Convert to a string."""
+        return self.getoutput()
 
     def getoutput(self):
         """Convert the unit back into formatted lines for a php file."""

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -424,6 +424,7 @@ class DialectStringsUtf8(DialectStrings):
     default_encoding = "utf-8"
 
 
+@six.python_2_unicode_compatible
 class propunit(base.TranslationUnit):
     """An element of a properties file i.e. a name and value, and any
     comments associated."""
@@ -478,11 +479,8 @@ class propunit(base.TranslationUnit):
             return self.personality.default_encoding
 
     def __str__(self):
-        """Convert to a string. Double check that unicode is handled
-        somehow here."""
-        source = self.getoutput()
-        assert isinstance(source, six.text_type)
-        return source.encode(self.encoding)
+        """Convert to a string."""
+        return self.getoutput()
 
     def getoutput(self):
         """Convert the element back into formatted lines for a

--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -51,10 +51,11 @@ def escape_to_rc(string):
     return rcstring
 
 
+@six.python_2_unicode_compatible
 class rcunit(base.TranslationUnit):
     """A unit of an rc file"""
 
-    def __init__(self, source="", encoding="cp1252"):
+    def __init__(self, source="", **kwargs):
         """Construct a blank rcunit."""
         super(rcunit, self).__init__(source)
         self.name = ""
@@ -62,7 +63,6 @@ class rcunit(base.TranslationUnit):
         self.comments = []
         self.source = source
         self.match = None
-        self.encoding = encoding
 
     def setsource(self, source):
         """Sets the source AND the target to be equal"""
@@ -84,11 +84,8 @@ class rcunit(base.TranslationUnit):
     target = property(gettarget, settarget)
 
     def __str__(self):
-        """Convert to a string. Double check that unicode is handled somehow here."""
-        source = self.getoutput()
-        if isinstance(source, six.text_type):
-            return source.encode(getattr(self, "encoding", "UTF-8"))
-        return source
+        """Convert to a string."""
+        return self.getoutput()
 
     def getoutput(self):
         """Convert the element back into formatted lines for a .rc file."""

--- a/translate/storage/subtitles.py
+++ b/translate/storage/subtitles.py
@@ -55,7 +55,7 @@ from translate.storage import base
 class SubtitleUnit(base.TranslationUnit):
     """A subtitle entry that is translatable"""
 
-    def __init__(self, source=None, encoding="utf_8"):
+    def __init__(self, source=None, **kwargs):
         self._start = None
         self._end = None
         if source:

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -337,7 +337,6 @@ key=value
         # - quotes inside are escaped
         # - for the sake of beauty a pair of spaces encloses the equal mark
         # - every line ends with ";"
-        assert str(propfile.units[0]).strip('\n\x00') == propsource.strip('\n\x00')
         assert str(propfile).strip('\n\x00') == propsource.strip('\n\x00')
 
     def test_override_encoding(self):

--- a/translate/storage/tiki.py
+++ b/translate/storage/tiki.py
@@ -64,7 +64,7 @@ from translate.storage import base
 class TikiUnit(base.TranslationUnit):
     """A tiki unit entry."""
 
-    def __init__(self, source=None, encoding="UTF-8"):
+    def __init__(self, source=None, **kwargs):
         self.location = []
         super(TikiUnit, self).__init__(source)
 

--- a/translate/storage/txt.py
+++ b/translate/storage/txt.py
@@ -51,12 +51,12 @@ flavours = {
 }
 
 
+@six.python_2_unicode_compatible
 class TxtUnit(base.TranslationUnit):
     """This class represents a block of text from a text file"""
 
-    def __init__(self, source="", encoding="utf-8"):
+    def __init__(self, source="", **kwargs):
         """Construct the txtunit"""
-        self.encoding = encoding
         super(TxtUnit, self).__init__(source)
         self.source = source
         self.pretext = ""
@@ -65,16 +65,11 @@ class TxtUnit(base.TranslationUnit):
 
     def __str__(self):
         """Convert a txt unit to a string"""
-        string = u"".join([self.pretext, self.source, self.posttext])
-        if isinstance(string, six.text_type):
-            return string.encode(self.encoding)
-        return string
+        return u"".join([self.pretext, self.source, self.posttext])
 
     # Note that source and target are equivalent for monolingual units
     def setsource(self, source):
         """Sets the definition to the quoted value of source"""
-        if isinstance(source, bytes):
-            source = source.decode(self.encoding)
         self._rich_source = None
         self._source = source
 

--- a/translate/storage/utx.py
+++ b/translate/storage/utx.py
@@ -80,6 +80,7 @@ class UtxHeader:
     """
 
 
+@six.python_2_unicode_compatible
 class UtxUnit(base.TranslationUnit):
     """A UTX dictionary unit"""
 

--- a/translate/storage/wordfast.py
+++ b/translate/storage/wordfast.py
@@ -279,6 +279,7 @@ class WordfastHeader(object):
     tucount = property(None, settucount)
 
 
+@six.python_2_unicode_compatible
 class WordfastUnit(base.TranslationUnit):
     """A Wordfast translation memory unit"""
 


### PR DESCRIPTION
The leading idea is that the file classes should know about
their encoding for serialization, but not the units.