### PR TITLE
Fixed ordering issue in Greek punctuation conversion

### DIFF
--- a/translate/lang/el.py
+++ b/translate/lang/el.py
@@ -28,6 +28,7 @@ from __future__ import unicode_literals
 import re
 
 from translate.lang import common
+from translate.misc.dictutils import ordereddict
 
 
 class el(common.Common):
@@ -44,10 +45,10 @@ class el(common.Common):
         (?=[^a-zά-ώ\d])  # lookahead that next part starts with caps
         """ % sentenceend, re.VERBOSE | re.UNICODE)
 
-    puncdict = {
-        "?": ";",
-        ";": "·",
-    }
+    puncdict = ordereddict([
+        (";", "·"),
+        ("?", ";"),
+    ])
 
     # Valid latin characters for use as accelerators
     valid_latin_accel = ("abcdefghijklmnopqrstuvwxyz"

--- a/translate/misc/dictutils.py
+++ b/translate/misc/dictutils.py
@@ -96,7 +96,7 @@ class ordereddict(dict):
                             len(args))
         else:
             initarg = args[0]
-            apply(super(ordereddict, self).__init__, args)
+            super(ordereddict, self).__init__(*args)
             if hasattr(initarg, "keys"):
                 self.order = initarg.keys()
             else:


### PR DESCRIPTION
As recent Python version have hash randomization by default,
we had random failure with Greek test_punctranslate because depending
on the order of the dict, replacement could follow: "?" -> ";" -> "·".