### PR TITLE
__str__ to serialize()

### DIFF
--- a/docs/formats/base_classes.rst
+++ b/docs/formats/base_classes.rst
@@ -158,12 +158,12 @@ what we discussed is related to the above.  A quick summary:
     of duplicate code in them). Ideally conversion should be as simple as::
 
       >>> po_store = POStore(filecontent)
-      >>> print(str(po_store))
+      >>> print(po_store.serialize())
       msgid "bleep"
       msgstr "blorp"
        
       >>> xliff_store = XliffStore(po_store)
-      >>> print(str(xliff_store))
+      >>> print(xliff_store.serialize())
       <xliff>
         <file>
           <trans-unit>

--- a/tests/odf_xliff/test_odf_xliff.py
+++ b/tests/odf_xliff/test_odf_xliff.py
@@ -63,7 +63,7 @@ xliff.xlifffile.__eq__ = xliff___eq__
 
 
 def print_diff(store1, store2):
-    for line in difflib.unified_diff(str(store1).split('\n'), str(store2).split('\n')):
+    for line in difflib.unified_diff(store1.serialize().split('\n'), store2.serialize().split('\n')):
         print(line)
 
 SOURCE_ODF = u'test_2.odt'
@@ -128,7 +128,7 @@ class ODF(object):
                     return False
         return True
 
-    def __str__(self):
+    def serialize(self):
         return self._get_doc_root('content.xml')
 
 

--- a/translate/convert/csv2po.py
+++ b/translate/convert/csv2po.py
@@ -220,7 +220,7 @@ def convertcsv(inputfile, outputfile, templatefile, charset=None,
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
         return 0
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/csv2tbx.py
+++ b/translate/convert/csv2tbx.py
@@ -66,7 +66,7 @@ def convertcsv(inputfile, outputfile, templatefile, charset=None,
     outputstore = convertor.convertfile(inputstore)
     if len(outputstore.units) == 0:
         return 0
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/dtd2po.py
+++ b/translate/convert/dtd2po.py
@@ -299,7 +299,7 @@ def convertdtd(inputfile, outputfile, templatefile, pot=False,
         outputstore = convertor.mergestore(templatestore, inputstore)
     if outputstore.isempty():
         return 0
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/html2po.py
+++ b/translate/convert/html2po.py
@@ -56,7 +56,7 @@ def converthtml(inputfile, outputfile, templates, includeuntagged=False,
                                         includeuntagged,
                                         duplicatestyle=duplicatestyle,
                                         keepcomments=keepcomments)
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/ical2po.py
+++ b/translate/convert/ical2po.py
@@ -100,7 +100,7 @@ def convertical(input_file, output_file, template_file, pot=False, duplicatestyl
         output_store = convertor.merge_store(template_store, input_store, blankmsgstr=pot, duplicatestyle=duplicatestyle)
     if output_store.isempty():
         return 0
-    output_file.write(str(output_store))
+    output_file.write(output_store.serialize())
     return 1
 
 

--- a/translate/convert/ini2po.py
+++ b/translate/convert/ini2po.py
@@ -111,7 +111,7 @@ def convertini(input_file, output_file, template_file, pot=False,
                                              duplicatestyle=duplicatestyle)
     if output_store.isempty():
         return 0
-    output_file.write(str(output_store))
+    output_file.write(output_store.serialize())
     return 1
 
 

--- a/translate/convert/json2po.py
+++ b/translate/convert/json2po.py
@@ -112,7 +112,7 @@ def convertjson(input_file, output_file, template_file, pot=False,
                                              duplicatestyle=duplicatestyle)
     if output_store.isempty():
         return 0
-    output_file.write(str(output_store))
+    output_file.write(output_store.serialize())
     return 1
 
 

--- a/translate/convert/mozlang2po.py
+++ b/translate/convert/mozlang2po.py
@@ -62,7 +62,7 @@ def convertlang(inputfile, outputfile, templates, pot=False,
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
         return 0
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/oo2po.py
+++ b/translate/convert/oo2po.py
@@ -156,7 +156,7 @@ def convertoo(inputfile, outputfile, templates, pot=False, sourcelanguage=None, 
     outputstore = convertor.convertstore(inputstore, duplicatestyle)
     if outputstore.isempty():
         return 0
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/oo2xliff.py
+++ b/translate/convert/oo2xliff.py
@@ -154,7 +154,7 @@ def convertoo(inputfile, outputfile, templates, pot=False, sourcelanguage=None, 
     outputstore = convertor.convertstore(inputstore, duplicatestyle)
     if outputstore.isempty():
         return 0
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/php2po.py
+++ b/translate/convert/php2po.py
@@ -108,7 +108,7 @@ def convertphp(inputfile, outputfile, templatefile, pot=False,
                                            duplicatestyle=duplicatestyle)
     if outputstore.isempty():
         return 0
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/po2csv.py
+++ b/translate/convert/po2csv.py
@@ -85,7 +85,7 @@ def convertcsv(inputfile, outputfile, templatefile, columnorder=None):
         return 0
     convertor = po2csv()
     outputstore = convertor.convertstore(inputstore, columnorder)
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/po2dtd.py
+++ b/translate/convert/po2dtd.py
@@ -187,7 +187,7 @@ def convertdtd(inputfile, outputfile, templatefile, includefuzzy=False,
         convertor = redtd(templatestore, android=android_dtd,
                           remove_untranslated=remove_untranslated)
     outputstore = convertor.convertstore(inputstore, includefuzzy)
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/po2ical.py
+++ b/translate/convert/po2ical.py
@@ -48,7 +48,7 @@ class reical:
                         unit.target = inputunit.target
                 else:
                     unit.target = unit.source
-        return str(self.templatestore)
+        return self.templatestore.serialize()
 
 
 def convertical(inputfile, outputfile, templatefile, includefuzzy=False,

--- a/translate/convert/po2ini.py
+++ b/translate/convert/po2ini.py
@@ -49,7 +49,7 @@ class reini:
                         unit.target = inputunit.target
                 else:
                     unit.target = unit.source
-        return str(self.templatestore)
+        return self.templatestore.serialize()
 
 
 def convertini(inputfile, outputfile, templatefile, includefuzzy=False,

--- a/translate/convert/po2json.py
+++ b/translate/convert/po2json.py
@@ -47,7 +47,7 @@ class rejson:
                     unit.target = inputunit.target
             else:
                 unit.target = unit.source
-        return str(self.templatestore)
+        return self.templatestore.serialize()
 
 
 def convertjson(inputfile, outputfile, templatefile, includefuzzy=False,

--- a/translate/convert/po2mozlang.py
+++ b/translate/convert/po2mozlang.py
@@ -66,7 +66,7 @@ def convertlang(inputfile, outputfile, templates, includefuzzy=False, mark_activ
 
     convertor = po2lang(mark_active=mark_active)
     outputstore = convertor.convertstore(inputstore, includefuzzy)
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return True
 
 

--- a/translate/convert/po2resx.py
+++ b/translate/convert/po2resx.py
@@ -53,7 +53,7 @@ class po2resx:
             if inputunit is not None:
                 self.addcomments(inputunit, unit)
 
-        return str(self.templatestore)
+        return self.templatestore.serialize()
 
     def addcomments(self, inputunit, unit):
         comments = []

--- a/translate/convert/po2sub.py
+++ b/translate/convert/po2sub.py
@@ -49,7 +49,7 @@ class resub:
                         unit.target = inputunit.target
                 else:
                     unit.target = unit.source
-        return str(self.templatestore)
+        return self.templatestore.serialize()
 
 
 def convertsub(inputfile, outputfile, templatefile, includefuzzy=False,

--- a/translate/convert/po2tiki.py
+++ b/translate/convert/po2tiki.py
@@ -67,7 +67,7 @@ def convertpo(inputfile, outputfile, template=None):
         return False
     convertor = po2tiki()
     outputstore = convertor.convertstore(inputstore)
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return True
 
 

--- a/translate/convert/po2tmx.py
+++ b/translate/convert/po2tmx.py
@@ -109,7 +109,7 @@ class TmxOptionParser(convert.ArchiveConvertOptionParser):
         super(TmxOptionParser, self).recursiveprocess(options)
         with open(options.output, 'wb') as self.output:
             options.outputarchive.tmxfile.setsourcelanguage(options.sourcelanguage)
-            self.output.write(str(options.outputarchive.tmxfile))
+            self.output.write(options.outputarchive.tmxfile.serialize())
 
 
 def main(argv=None):

--- a/translate/convert/po2wordfast.py
+++ b/translate/convert/po2wordfast.py
@@ -87,7 +87,7 @@ class WfOptionParser(convert.ArchiveConvertOptionParser):
         super(WfOptionParser, self).recursiveprocess(options)
         with open(options.output, 'wb') as self.output:
             #options.outputarchive.wffile.setsourcelanguage(options.sourcelanguage)
-            self.output.write(str(options.outputarchive.wffile))
+            self.output.write(options.outputarchive.wffile.serialize())
 
 
 def main(argv=None):

--- a/translate/convert/po2xliff.py
+++ b/translate/convert/po2xliff.py
@@ -87,7 +87,7 @@ class po2xliff:
             if inputunit.isblank():
                 continue
             transunitnode = self.convertunit(outputstore, inputunit, filename)
-        return str(outputstore)
+        return outputstore.serialize()
 
 
 def convertpo(inputfile, outputfile, templatefile):

--- a/translate/convert/poreplace.py
+++ b/translate/convert/poreplace.py
@@ -47,7 +47,7 @@ class poreplace:
         outputstore = self.convertfile(inputstore)
         if outputstore.isempty():
             return 0
-        outputfile.write(str(outputstore))
+        outputfile.write(outputstore.serialize())
         return 1
 
 

--- a/translate/convert/pot2po.py
+++ b/translate/convert/pot2po.py
@@ -52,7 +52,7 @@ def convertpot(input_file, output_file, template_file, tm=None,
 
     output_store = convert_stores(input_store, template_store, temp_store, tm,
                                   min_similarity, fuzzymatching, **kwargs)
-    output_file.write(str(output_store))
+    output_file.write(output_store.serialize())
 
     return 1
 

--- a/translate/convert/prop2po.py
+++ b/translate/convert/prop2po.py
@@ -319,7 +319,7 @@ def convertprop(inputfile, outputfile, templatefile, personality="java",
         outputstore = convertor.mergestore(templatestore, inputstore)
     if outputstore.isempty():
         return 0
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/rc2po.py
+++ b/translate/convert/rc2po.py
@@ -103,7 +103,7 @@ def convertrc(input_file, output_file, template_file, pot=False, duplicatestyle=
         output_store = convertor.merge_store(template_store, input_store, blankmsgstr=pot, duplicatestyle=duplicatestyle)
     if output_store.isempty():
         return 0
-    output_file.write(str(output_store))
+    output_file.write(output_store.serialize())
     return 1
 
 

--- a/translate/convert/resx2po.py
+++ b/translate/convert/resx2po.py
@@ -131,7 +131,7 @@ def convert_resx(input_file, output_file, template_file, pot=False, duplicatesty
                                              duplicatestyle=duplicatestyle)
     if output_store.isempty():
         return 0
-    output_file.write(str(output_store))
+    output_file.write(output_store.serialize())
     return 1
 
 

--- a/translate/convert/sub2po.py
+++ b/translate/convert/sub2po.py
@@ -108,7 +108,7 @@ def convertsub(input_file, output_file, template_file=None, pot=False,
                                    duplicatestyle=duplicatestyle)
     if output_store.isempty():
         return 0
-    output_file.write(str(output_store))
+    output_file.write(output_store.serialize())
     return 1
 
 

--- a/translate/convert/symb2po.py
+++ b/translate/convert/symb2po.py
@@ -104,7 +104,7 @@ def convert_symbian(input_file, output_file, template_file, pot=False, duplicate
     if output_store.isempty():
         return 0
     else:
-        output_file.write(str(output_store))
+        output_file.write(output_store.serialize())
         return 1
 
 

--- a/translate/convert/test_csv2po.py
+++ b/translate/convert/test_csv2po.py
@@ -30,7 +30,7 @@ class TestCSV2PO:
 
     def singleelement(self, storage):
         """checks that the pofile contains a single non-header element, and returns it"""
-        print(str(storage))
+        print(storage.serialize())
         assert headerless_len(storage.units) == 1
         return first_translatable(storage)
 
@@ -90,12 +90,12 @@ wat lank aanhou"
 ,"Use \"".","Gebruik \""."'''
         print(minicsv)
         csvfile = csvl10n.csvfile(wStringIO.StringIO(minicsv))
-        print(str(csvfile))
+        print(csvfile.serialize())
         pofile = self.csv2po(minicsv)
         unit = first_translatable(pofile)
         assert unit.source == 'Hello "Everyone"'
         assert pofile.findunit('Hello "Everyone"').target == 'Good day "All"'
-        print(str(pofile))
+        print(pofile.serialize())
         for unit in pofile.units:
             print(unit.source)
             print(unit.target)

--- a/translate/convert/test_dtd2po.py
+++ b/translate/convert/test_dtd2po.py
@@ -121,7 +121,7 @@ class TestDTD2PO:
 <!ENTITY alwaysCheckDefault.height  "3em">
 '''
         pofile = self.dtd2po(dtdsource)
-        posource = str(pofile)
+        posource = pofile.serialize()
         print(posource)
         assert posource.count('#.') == 5  # 1 Header extracted from, 3 comment lines, 1 autoinserted comment
 
@@ -156,7 +156,7 @@ class TestDTD2PO:
         dtdsource = '<!--LOCALIZATION NOTE (editorCheck.label): DONT_TRANSLATE -->\n' + \
             '<!ENTITY editorCheck.label "Composer">\n<!ENTITY editorCheck.accesskey "c">\n'
         pofile = self.dtd2po(dtdsource)
-        posource = str(pofile)
+        posource = pofile.serialize()
         # we need to decided what we're going to do here - see the comments in bug 30
         # this tests the current implementation which is that the DONT_TRANSLATE string is removed, but the other remains
         assert 'editorCheck.label' not in posource

--- a/translate/convert/test_html2po.py
+++ b/translate/convert/test_html2po.py
@@ -367,7 +367,7 @@ years has helped to bridge the digital divide to a limited extent.</p> \r
         # Translate and convert back:
         pofile.units[2].target = 'Projekte'
         pofile.units[3].target = 'Tuisblad'
-        htmlresult = self.po2html(str(pofile), htmlsource).replace('\n', ' ').replace('= "', '="').replace('> <', '><')
+        htmlresult = self.po2html(pofile.serialize(), htmlsource).replace('\n', ' ').replace('= "', '="').replace('> <', '><')
         snippet = '<td width="96%"><strong><font class="headingwhite">Projekte</font></strong></td>'
         assert snippet in htmlresult
         snippet = '<td width="96%"><a href="index.html">Tuisblad</a></td>'

--- a/translate/convert/test_json2po.py
+++ b/translate/convert/test_json2po.py
@@ -17,7 +17,7 @@ class TestJson2PO:
 
     def singleelement(self, storage):
         """checks that the pofile contains a single non-header element, and returns it"""
-        print(str(storage))
+        print(storage.serialize())
         assert len(storage.units) == 1
         return storage.units[0]
 

--- a/translate/convert/test_php2po.py
+++ b/translate/convert/test_php2po.py
@@ -94,7 +94,7 @@ $lang['prefPanel-smime'] = 'Security';'''
         pounit = self.singleelement(pofile)
         assert pounit.getlocations() == ["$lang['credit']"]
         assert pounit.getcontext() == "$lang['credit']"
-        assert "#. /* comment" in str(pofile)
+        assert "#. /* comment" in pofile.serialize()
         assert pounit.source == ""
 
     def test_hash_comment_with_equals(self):
@@ -103,7 +103,7 @@ $lang['prefPanel-smime'] = 'Security';'''
         pofile = self.php2po(phpsource)
         pounit = self.singleelement(pofile)
         assert pounit.getlocations() == ["$variable"]
-        assert "#. # inside alt= stuffies" in str(pofile)
+        assert "#. # inside alt= stuffies" in pofile.serialize()
         assert pounit.source == "stringy"
 
     def test_emptyentry_translated(self):

--- a/translate/convert/test_po2csv.py
+++ b/translate/convert/test_po2csv.py
@@ -65,7 +65,7 @@ msgstr "Eerste lyn\nTweede lyn"
         unit = self.singleelement(csvfile)
         assert unit.source == "First line\nSecond line"
         assert unit.target == "Eerste lyn\nTweede lyn"
-        pofile = self.csv2po(str(csvfile))
+        pofile = self.csv2po(csvfile.serialize())
         unit = self.singleelement(pofile)
         assert unit.source == "First line\nSecond line"
         assert unit.target == "Eerste lyn\nTweede lyn"
@@ -107,12 +107,12 @@ msgstr "Vind\\Opsies"
         """Tests that single quotes are preserved correctly"""
         minipo = '''msgid "source 'source'"\nmsgstr "target 'target'"\n'''
         csvfile = self.po2csv(minipo)
-        print(str(csvfile))
+        print(csvfile.serialize())
         assert csvfile.findunit("source 'source'").target == "target 'target'"
         # Make sure we don't mess with start quotes until writing
         minipo = '''msgid "'source'"\nmsgstr "'target'"\n'''
         csvfile = self.po2csv(minipo)
-        print(str(csvfile))
+        print(csvfile.serialize())
         assert csvfile.findunit(r"'source'").target == r"'target'"
         # TODO check that we escape on writing not in the internal representation
 

--- a/translate/convert/test_po2dtd.py
+++ b/translate/convert/test_po2dtd.py
@@ -91,14 +91,14 @@ class TestPO2DTD:
         """tests that po lines are joined seamlessly (bug 16)"""
         multilinepo = '''#: pref.menuPath\nmsgid ""\n"<span>Tools &gt; Options</"\n"span>"\nmsgstr ""\n'''
         dtdfile = self.po2dtd(multilinepo)
-        dtdsource = str(dtdfile)
+        dtdsource = dtdfile.serialize()
         assert "</span>" in dtdsource
 
     def test_escapedstr(self):
         """tests that \n in msgstr is escaped correctly in dtd"""
         multilinepo = '''#: pref.menuPath\nmsgid "Hello\\nEveryone"\nmsgstr "Good day\\nAll"\n'''
         dtdfile = self.po2dtd(multilinepo)
-        dtdsource = str(dtdfile)
+        dtdsource = dtdfile.serialize()
         assert "Good day\nAll" in dtdsource
 
     def test_missingaccesskey(self):
@@ -153,7 +153,7 @@ msgstr "Dimpled Ring"
         """tests that invalid ampersands are fixed in the dtd"""
         simplestring = '''#: simple.string\nmsgid "Simple String"\nmsgstr "Dimpled &Ring"\n'''
         dtdfile = self.po2dtd(simplestring)
-        dtdsource = str(dtdfile)
+        dtdsource = dtdfile.serialize()
         assert "Dimpled Ring" in dtdsource
 
         po_snippet = u'''#: searchIntegration.label
@@ -164,7 +164,7 @@ msgstr "&searchIntegration.engineName; &ileti aramasına izin ver"
         dtd_snippet = r'''<!ENTITY searchIntegration.accesskey      "s">
 <!ENTITY searchIntegration.label       "Allow &searchIntegration.engineName; to search messages">'''
         dtdfile = self.merge2dtd(dtd_snippet, po_snippet)
-        dtdsource = str(dtdfile)
+        dtdsource = dtdfile.serialize()
         print(dtdsource)
         assert '"&searchIntegration.engineName; ileti aramasına izin ver"' in dtdsource
 
@@ -178,7 +178,7 @@ msgstr "Ileti"
         dtd_snippet = r'''<!ENTITY key.accesskey      "S">
 <!ENTITY key.label       "Ileti">'''
         dtdfile = self.merge2dtd(dtd_snippet, po_snippet)
-        dtdsource = str(dtdfile)
+        dtdsource = dtdfile.serialize()
         print(dtdsource)
         assert '"Ileti"' in dtdsource
         assert '""' not in dtdsource
@@ -196,7 +196,7 @@ msgstr "Lig en Kleur"
         dtd_snippet = r'''<!ENTITY key.accesskey      "L">
 <!ENTITY key.label       "Colour &amp; Light">'''
         dtdfile = self.merge2dtd(dtd_snippet, po_snippet)
-        dtdsource = str(dtdfile)
+        dtdsource = dtdfile.serialize()
         print(dtdsource)
         assert '"Lig en Kleur"' in dtdsource
         assert '"L"' in dtdsource
@@ -213,7 +213,7 @@ msgstr "Lig en &Kleur"
         dtd_snippet = r'''<!ENTITY key.accesskey      "L">
 <!ENTITY key.label       "Colour &amp; Light">'''
         dtdfile = self.merge2dtd(dtd_snippet, po_snippet)
-        dtdsource = str(dtdfile)
+        dtdsource = dtdfile.serialize()
         print(dtdsource)
         assert '"Lig en Kleur"' in dtdsource
         assert '"K"' in dtdsource
@@ -231,7 +231,7 @@ msgstr "Lig & &Kleur"
         dtd_snippet = r'''<!ENTITY key.accesskey      "L">
 <!ENTITY key.label       "Colour &amp; Light">'''
         dtdfile = self.merge2dtd(dtd_snippet, po_snippet)
-        dtdsource = str(dtdfile)
+        dtdsource = dtdfile.serialize()
         print(dtdsource)
         assert '"Lig &amp; Kleur"' in dtdsource
         assert '"K"' in dtdsource
@@ -240,21 +240,21 @@ msgstr "Lig & &Kleur"
         """test the error ouput when we find two entities"""
         simplestring = '''#: simple.string second.string\nmsgid "Simple String"\nmsgstr "Dimpled Ring"\n'''
         dtdfile = self.po2dtd(simplestring)
-        dtdsource = str(dtdfile)
+        dtdsource = dtdfile.serialize()
         assert "CONVERSION NOTE - multiple entities" in dtdsource
 
     def test_entities(self):
         """tests that entities are correctly idnetified in the dtd"""
         simplestring = '''#: simple.string\nmsgid "Simple String"\nmsgstr "Dimpled Ring"\n'''
         dtdfile = self.po2dtd(simplestring)
-        dtdsource = str(dtdfile)
+        dtdsource = dtdfile.serialize()
         assert dtdsource.startswith("<!ENTITY simple.string")
 
     def test_comments_translator(self):
         """tests for translator comments"""
         simplestring = '''# Comment1\n# Comment2\n#: simple.string\nmsgid "Simple String"\nmsgstr "Dimpled Ring"\n'''
         dtdfile = self.po2dtd(simplestring)
-        dtdsource = str(dtdfile)
+        dtdsource = dtdfile.serialize()
         assert dtdsource.startswith("<!-- Comment1 -->")
 
     def test_retains_hashprefix(self):
@@ -262,7 +262,7 @@ msgstr "Lig & &Kleur"
         hashpo = '''#: lang.version\nmsgid "__MOZILLA_LOCALE_VERSION__"\nmsgstr "__MOZILLA_LOCALE_VERSION__"\n'''
         hashdtd = '#expand <!ENTITY lang.version "__MOZILLA_LOCALE_VERSION__">\n'
         dtdfile = self.merge2dtd(hashdtd, hashpo)
-        regendtd = str(dtdfile)
+        regendtd = dtdfile.serialize()
         assert regendtd == hashdtd
 
     def test_convertdtd(self):
@@ -330,8 +330,8 @@ msgstr "simple string four"
 <!ENTITY simple.label3 "Simple string 3">
 '''
         newdtd = self.po2dtd(posource, remove_untranslated=True)
-        print(newdtd)
-        assert str(newdtd) == dtdexpected
+        print(newdtd.serialize())
+        assert newdtd.serialize() == dtdexpected
 
     def test_blank_source(self):
         """test removing of untranslated entries where source is blank"""
@@ -363,8 +363,8 @@ msgstr "Simple string 3"
         print(newdtd_with_template)
         assert newdtd_with_template == dtdexpected_with_template
         newdtd_no_template = self.po2dtd(posource, remove_untranslated=True)
-        print(newdtd_no_template)
-        assert str(newdtd_no_template) == dtdexpected_no_template
+        print(newdtd_no_template.serialize())
+        assert newdtd_no_template.serialize() == dtdexpected_no_template
 
     def test_newlines_escapes(self):
         """check that we can handle a \n in the PO file"""
@@ -372,8 +372,8 @@ msgstr "Simple string 3"
         dtdtemplate = '<!ENTITY  simple.label "A hard coded newline.\n">\n'
         dtdexpected = '''<!ENTITY  simple.label "Hart gekoeerde nuwe lyne\n">\n'''
         dtdfile = self.merge2dtd(dtdtemplate, posource)
-        print(dtdfile)
-        assert str(dtdfile) == dtdexpected
+        print(dtdfile.serialize())
+        assert dtdfile.serialize() == dtdexpected
 
     def test_roundtrip_simple(self):
         """checks that simple strings make it through a dtd->po->dtd roundtrip"""
@@ -440,8 +440,8 @@ msgstr "Simple string 3"
           '                                          next lines.">\n'
         dtdexpected = '<!ENTITY simple.label "Eerste lyne en dan volgende lyne.">\n'
         dtdfile = self.merge2dtd(dtdtemplate, posource)
-        print(dtdfile)
-        assert str(dtdfile) == dtdexpected
+        print(dtdfile.serialize())
+        assert dtdfile.serialize() == dtdexpected
 
     def test_preserving_spaces(self):
         """ensure that we preseve spaces between entity and value. Bug 1662"""
@@ -449,8 +449,8 @@ msgstr "Simple string 3"
         dtdtemplate = '<!ENTITY     simple.label         "One">\n'
         dtdexpected = '<!ENTITY     simple.label         "Een">\n'
         dtdfile = self.merge2dtd(dtdtemplate, posource)
-        print(dtdfile)
-        assert str(dtdfile) == dtdexpected
+        print(dtdfile.serialize())
+        assert dtdfile.serialize() == dtdexpected
 
     def test_preserving_spaces_after_value(self):
         """Preseve spaces after value. Bug 1662"""
@@ -459,22 +459,22 @@ msgstr "Simple string 3"
         dtdtemplate = '<!ENTITY simple.label "One" >\n'
         dtdexpected = '<!ENTITY simple.label "Een" >\n'
         dtdfile = self.merge2dtd(dtdtemplate, posource)
-        print(dtdfile)
-        assert str(dtdfile) == dtdexpected
+        print(dtdfile.serialize())
+        assert dtdfile.serialize() == dtdexpected
         # Space after >
         dtdtemplate = '<!ENTITY simple.label "One"> \n'
         dtdexpected = '<!ENTITY simple.label "Een"> \n'
         dtdfile = self.merge2dtd(dtdtemplate, posource)
         print(dtdfile)
-        assert str(dtdfile) == dtdexpected
+        assert dtdfile.serialize() == dtdexpected
 
     def test_comments(self):
         """test that we preserve comments, bug 351"""
         posource = '''#: name\nmsgid "Text"\nmsgstr "Teks"'''
         dtdtemplate = '''<!ENTITY name "%s">\n<!-- \n\nexample -->\n'''
         dtdfile = self.merge2dtd(dtdtemplate % "Text", posource)
-        print(dtdfile)
-        assert str(dtdfile) == dtdtemplate % "Teks"
+        print(dtdfile.serialize())
+        assert dtdfile.serialize() == dtdtemplate % "Teks"
 
     def test_duplicates(self):
         """test that we convert duplicates back correctly to their respective entries."""
@@ -504,8 +504,8 @@ msgstr "Dipukutshwayo3"
 <!ENTITY bookmarksButton.label "Dipukutshwayo3">
 '''
         dtdfile = self.merge2dtd(dtdtemplate, posource)
-        print(dtdfile)
-        assert str(dtdfile) == dtdexpected
+        print(dtdfile.serialize())
+        assert dtdfile.serialize() == dtdexpected
 
 
 class TestPO2DTDCommand(test_convert.TestConvertCommand, TestPO2DTD):

--- a/translate/convert/test_po2mozlang.py
+++ b/translate/convert/test_po2mozlang.py
@@ -21,32 +21,32 @@ class TestPO2Lang:
         posource = '''#: prop\nmsgid "Source"\nmsgstr "Target"\n'''
         propexpected = ''';Source\nTarget\n'''
         langfile = self.po2lang(posource)
-        print(langfile)
-        assert str(langfile) == propexpected
+        print(langfile.serialize())
+        assert langfile.serialize() == propexpected
 
     def test_comment(self):
         """Simple # comments"""
         posource = '''#. Comment\n#: prop\nmsgid "Source"\nmsgstr "Target"\n'''
         propexpected = '''# Comment\n;Source\nTarget\n'''
         langfile = self.po2lang(posource)
-        print(langfile)
-        assert str(langfile) == propexpected
+        print(langfile.serialize())
+        assert langfile.serialize() == propexpected
 
     def test_fuzzy(self):
         """What happens with a fuzzy string"""
         posource = '''#. Comment\n#: prop\n#, fuzzy\nmsgid "Source"\nmsgstr "Target"\n'''
         propexpected = '''# Comment\n;Source\nSource\n'''
         langfile = self.po2lang(posource)
-        print(langfile)
-        assert str(langfile) == propexpected
+        print(langfile.serialize())
+        assert langfile.serialize() == propexpected
 
     def test_ok_marker(self):
         """The {ok} marker"""
         posource = '''#: prop\nmsgid "Same"\nmsgstr "Same"\n'''
         propexpected = ''';Same\nSame {ok}\n'''
         langfile = self.po2lang(posource)
-        print(langfile)
-        assert str(langfile) == propexpected
+        print(langfile.serialize())
+        assert langfile.serialize() == propexpected
 
 
 class TestPO2LangCommand(test_convert.TestConvertCommand, TestPO2Lang):

--- a/translate/convert/test_po2tmx.py
+++ b/translate/convert/test_po2tmx.py
@@ -42,10 +42,10 @@ msgstr "Toepassings"
 """
         tmx = self.po2tmx(minipo)
         print("The generated xml:")
-        print(str(tmx))
+        print(tmx.serialize())
         assert tmx.translate("Applications") == "Toepassings"
         assert tmx.translate("bla") is None
-        xmltext = str(tmx)
+        xmltext = tmx.serialize()
         assert xmltext.index('creationtool="Translate Toolkit - po2tmx"')
         assert xmltext.index('adminlang')
         assert xmltext.index('creationtoolversion')
@@ -58,7 +58,7 @@ msgstr "Toepassings"
         minipo = 'msgid "String"\nmsgstr "String"\n'
         tmx = self.po2tmx(minipo, sourcelanguage="xh")
         print("The generated xml:")
-        print(str(tmx))
+        print(tmx.serialize())
         header = tmx.document.find("header")
         assert header.get("srclang") == "xh"
 
@@ -66,7 +66,7 @@ msgstr "Toepassings"
         minipo = 'msgid "String"\nmsgstr "String"\n'
         tmx = self.po2tmx(minipo, targetlanguage="xh")
         print("The generated xml:")
-        print(str(tmx))
+        print(tmx.serialize())
         tuv = tmx.document.findall(".//%s" % tmx.namespaced("tuv"))[1]
         #tag[0] will be the source, we want the target tuv
         assert tuv.get("{%s}lang" % XML_NS) == "xh"
@@ -79,7 +79,7 @@ msgstr "Eerste deel "
 "en ekstra"'''
         tmx = self.po2tmx(minipo)
         print("The generated xml:")
-        print(str(tmx))
+        print(tmx.serialize())
         assert tmx.translate('First part and extra') == 'Eerste deel en ekstra'
 
     def test_escapednewlines(self):
@@ -89,7 +89,7 @@ msgstr "Eerste lyn\nTweede lyn"
 '''
         tmx = self.po2tmx(minipo)
         print("The generated xml:")
-        print(str(tmx))
+        print(tmx.serialize())
         assert tmx.translate("First line\nSecond line") == "Eerste lyn\nTweede lyn"
 
     def test_escapedtabs(self):
@@ -99,7 +99,7 @@ msgstr "Eerste kolom\tTweede kolom"
 '''
         tmx = self.po2tmx(minipo)
         print("The generated xml:")
-        print(str(tmx))
+        print(tmx.serialize())
         assert tmx.translate("First column\tSecond column") == "Eerste kolom\tTweede kolom"
 
     def test_escapedquotes(self):
@@ -112,7 +112,7 @@ msgstr "Gebruik \\\"."
 '''
         tmx = self.po2tmx(minipo)
         print("The generated xml:")
-        print(str(tmx))
+        print(tmx.serialize())
         assert tmx.translate('Hello "Everyone"') == 'Good day "All"'
         assert tmx.translate(r'Use \".') == r'Gebruik \".'
 
@@ -130,8 +130,8 @@ msgstr "Drie"
 '''
         tmx = self.po2tmx(minipo)
         print("The generated xml:")
-        print(str(tmx))
-        assert "<tu" not in str(tmx)
+        print(tmx.serialize())
+        assert "<tu" not in tmx.serialize()
         assert len(tmx.units) == 0
 
     def test_nonascii(self):
@@ -140,7 +140,7 @@ msgstr "Drie"
 msgstr "Bézier-kurwe"
 '''
         tmx = self.po2tmx(minipo)
-        print(str(tmx))
+        print(tmx.serialize())
         assert tmx.translate(u"Bézier curve") == u"Bézier-kurwe"
 
     def test_nonecomments(self):
@@ -150,7 +150,7 @@ msgid "Bézier curve"
 msgstr "Bézier-kurwe"
 '''
         tmx = self.po2tmx(minipo)
-        print(str(tmx))
+        print(tmx.serialize())
         unit = tmx.findunits(u"Bézier curve")
         assert len(unit[0].getnotes()) == 0
 
@@ -161,7 +161,7 @@ msgid "Bézier curve"
 msgstr "Bézier-kurwe"
 '''
         tmx = self.po2tmx(minipo, comment='others')
-        print(str(tmx))
+        print(tmx.serialize())
         unit = tmx.findunits(u"Bézier curve")
         assert unit[0].getnotes() == u"My comment rules"
 
@@ -172,7 +172,7 @@ msgid "Bézier curve"
 msgstr "Bézier-kurwe"
 '''
         tmx = self.po2tmx(minipo, comment='source')
-        print(str(tmx))
+        print(tmx.serialize())
         unit = tmx.findunits(u"Bézier curve")
         assert unit[0].getnotes() == u"../PuzzleFourSided.h:45"
 
@@ -183,7 +183,7 @@ msgid "Bézier curve"
 msgstr "Bézier-kurwe"
 '''
         tmx = self.po2tmx(minipo, comment='type')
-        print(str(tmx))
+        print(tmx.serialize())
         unit = tmx.findunits(u"Bézier curve")
         assert unit[0].getnotes() == u"csharp-format"
 

--- a/translate/convert/test_po2xliff.py
+++ b/translate/convert/test_po2xliff.py
@@ -24,7 +24,7 @@ class TestPO2XLIFF:
         minipo = '''msgid "red"\nmsgstr "rooi"\n'''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        print(str(xliff))
+        print(xliff.serialize())
         assert len(xliff.units) == 1
         assert xliff.translate("red") == "rooi"
         assert xliff.translate("bla") is None
@@ -51,10 +51,10 @@ msgstr "Toepassings"
 """
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        print(str(xliff))
+        print(xliff.serialize())
         assert xliff.translate("Applications") == "Toepassings"
         assert xliff.translate("bla") is None
-        xmltext = str(xliff)
+        xmltext = xliff.serialize()
         assert xmltext.index('<xliff ') >= 0
         assert xmltext.index(' version="1.1"') >= 0
         assert xmltext.index('<file')
@@ -69,7 +69,7 @@ msgstr "Eerste deel "
 "en ekstra"'''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        print(str(xliff))
+        print(xliff.serialize())
         assert xliff.translate('First part and extra') == 'Eerste deel en ekstra'
 
     def test_escapednewlines(self):
@@ -79,7 +79,7 @@ msgstr "Eerste lyn\nTweede lyn"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = str(xliff)
+        xmltext = xliff.serialize()
         print(xmltext)
         assert xliff.translate("First line\nSecond line") == "Eerste lyn\nTweede lyn"
         assert xliff.translate("First line\\nSecond line") is None
@@ -95,7 +95,7 @@ msgstr "Eerste kolom\tTweede kolom"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = str(xliff)
+        xmltext = xliff.serialize()
         print(xmltext)
         assert xliff.translate("First column\tSecond column") == "Eerste kolom\tTweede kolom"
         assert xliff.translate("First column\\tSecond column") is None
@@ -114,7 +114,7 @@ msgstr "Gebruik \\\"."
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = str(xliff)
+        xmltext = xliff.serialize()
         print(xmltext)
         assert xliff.translate('Hello "Everyone"') == 'Good day "All"'
         assert xliff.translate(r'Use \".') == r'Gebruik \".'
@@ -134,7 +134,7 @@ msgstr "kunye"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = str(xliff)
+        xmltext = xliff.serialize()
         print(xmltext)
         assert xliff.translate("one") == "kunye"
         assert len(xliff.units) == 1
@@ -155,7 +155,7 @@ msgstr "kunye"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = str(xliff)
+        xmltext = xliff.serialize()
         print(xmltext)
         assert xliff.translate("one") == "kunye"
         assert len(xliff.units) == 1
@@ -178,7 +178,7 @@ msgstr "kunye"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = str(xliff)
+        xmltext = xliff.serialize()
         print(xmltext)
         assert xliff.translate("one") == "kunye"
         assert len(xliff.units) == 1
@@ -201,7 +201,7 @@ msgstr ""
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = str(xliff)
+        xmltext = xliff.serialize()
         print(xmltext)
         assert len(xliff.units) == 1
         unit = xliff.units[0]
@@ -221,7 +221,7 @@ msgstr "raro"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = str(xliff)
+        xmltext = xliff.serialize()
         print(xmltext)
         assert len(xliff.units) == 2
         assert xliff.units[0].isfuzzy()
@@ -235,7 +235,7 @@ msgstr[1] "iinkomo"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = str(xliff)
+        xmltext = xliff.serialize()
         print(xmltext)
         assert len(xliff.units) == 1
         assert xliff.translate("cow") == "inkomo"
@@ -249,7 +249,7 @@ msgstr[2] "iiinkomo"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = str(xliff)
+        xmltext = xliff.serialize()
         print(xmltext)
         assert len(xliff.units) == 1
         assert xliff.translate("cow") == "inkomo"
@@ -282,7 +282,7 @@ msgstr ""
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = str(xliff)
+        xmltext = xliff.serialize()
         print(xmltext)
         assert len(xliff.units) == 3
         assert xliff.units[0].xmlelement.get("approved") != "yes"

--- a/translate/convert/test_pot2po.py
+++ b/translate/convert/test_pot2po.py
@@ -286,7 +286,7 @@ msgstr "Sertifikate"
         posource = '# Some comment\n#. Extracted comment\n#: obsoleteme:10\nmsgid "One"\nmsgstr "Een"\n'
         expected = '# Some comment\n#~ msgid "One"\n#~ msgstr "Een"\n'
         newpo = self.convertpot(potsource, posource)
-        print(str(newpo))
+        print(newpo.serialize())
         newpounit = self.singleunit(newpo)
         assert str(newpounit) == expected
 
@@ -296,7 +296,7 @@ msgstr "Sertifikate"
         potsource = 'msgid ""\nmsgstr ""\n'
         posource = '#: obsoleteme:10\nmsgid "One"\nmsgstr ""\n'
         newpo = self.convertpot(potsource, posource)
-        print(str(newpo))
+        print(newpo.serialize())
         # We should only have the header
         assert len(newpo.units) == 1
 
@@ -394,7 +394,7 @@ msgstr ""
         newpo = self.convertpot(potsource, posource)
         print('Output Header:\n%s' % newpo)
         print('Expected Header:\n%s' % expected)
-        assert str(newpo) == expected
+        assert newpo.serialize() == expected
 
     def test_merging_comments(self):
         """Test that we can merge comments correctly"""
@@ -462,7 +462,7 @@ msgstr "teks"
 """
         newpo = self.convertpot(potsource, posource)
         print(newpo)
-        assert poexpected in str(newpo)
+        assert poexpected in newpo.serialize()
 
     def test_msgctxt_multiline(self):
         """Test multiline msgctxt fields."""
@@ -775,7 +775,7 @@ msgstr ""
         newpo = self.convertpot(potsource, posource)
         print('Output:\n%s' % newpo)
         print('Expected:\n%s' % expected)
-        assert str(newpo) == expected
+        assert newpo.serialize() == expected
 
 
 class TestPOT2POCommand(test_convert.TestConvertCommand, TestPOT2PO):

--- a/translate/convert/test_prop2po.py
+++ b/translate/convert/test_prop2po.py
@@ -133,9 +133,9 @@ prefPanel-smime=Security'''
 prefPanel-smime=
 '''
         pofile = self.prop2po(propsource)
-        print(str(pofile))
+        print(pofile.serialize())
         #header comments:
-        assert "#. # Comment\n#. # commenty 2" in str(pofile)
+        assert "#. # Comment\n#. # commenty 2" in pofile.serialize()
         pounit = self.singleelement(pofile)
         assert pounit.getnotes("developer") == "## @name GENERIC_ERROR\n## @loc none"
 
@@ -165,7 +165,7 @@ do=translate me
             assert pounit.getlocations() == ["credit"]
             assert pounit.getcontext() == "credit"
             assert 'msgctxt "credit"' in str(pounit)
-            assert "#. # comment" in str(pofile)
+            assert "#. # comment" in pofile.serialize()
             assert pounit.source == ""
 
     def test_emptyproperty_translated(self):
@@ -211,14 +211,14 @@ do=translate me
         propsource = '''prop=value\n'''
 
         outputpo = self.prop2po(propsource, personality="mozilla")
-        assert "X-Accelerator-Marker" in str(outputpo)
-        assert "X-Merge-On" in str(outputpo)
+        assert "X-Accelerator-Marker" in outputpo.serialize()
+        assert "X-Merge-On" in outputpo.serialize()
 
         # Even though the gaia flavour inherrits from mozilla, it should not
         # get the header
         outputpo = self.prop2po(propsource, personality="gaia")
-        assert "X-Accelerator-Marker" not in str(outputpo)
-        assert "X-Merge-On" not in str(outputpo)
+        assert "X-Accelerator-Marker" not in outputpo.serialize()
+        assert "X-Merge-On" not in outputpo.serialize()
 
     def test_gaia_plurals(self):
         """Test conversion of gaia plural units."""

--- a/translate/convert/test_ts2po.py
+++ b/translate/convert/test_ts2po.py
@@ -12,7 +12,7 @@ class TestTS2PO:
         tsfile = wStringIO.StringIO(tssource)
         outputpo = converter.convertfile(tsfile)
         print("The generated po:")
-        print(str(outputpo))
+        print(outputpo.serialize())
         return outputpo
 
     def test_blank(self):

--- a/translate/convert/test_txt2po.py
+++ b/translate/convert/test_txt2po.py
@@ -17,7 +17,7 @@ class TestTxt2PO:
 
     def singleelement(self, storage):
         """checks that the pofile contains a single non-header element, and returns it"""
-        print(str(storage))
+        print(storage.serialize())
         assert len(storage.units) == 1
         return storage.units[0]
 
@@ -72,7 +72,7 @@ class TestDoku2po:
 
     def singleelement(self, storage):
         """checks that the pofile contains a single non-header element, and returns it"""
-        print(str(storage))
+        print(storage.serialize())
         assert len(storage.units) == 1
         return storage.units[0]
 

--- a/translate/convert/test_xliff2po.py
+++ b/translate/convert/test_xliff2po.py
@@ -25,7 +25,7 @@ class TestXLIFF2PO:
         outputpo = convertor.convertstore(inputfile)
         print("The generated po:")
         print(type(outputpo))
-        print(str(outputpo))
+        print(outputpo.serialize())
         return outputpo
 
     def test_minimal(self):
@@ -63,7 +63,7 @@ Content-Transfer-Encoding: 8bit'''
         pofile = self.xliff2po(minixlf)
         assert pofile.translate("gras") == "utshani"
         assert pofile.translate("bla") is None
-        potext = str(pofile)
+        potext = pofile.serialize()
         assert potext.index('# Zulu translation of program ABC') == 0
         assert potext.index('msgid "gras"\n')
         assert potext.index('msgstr "utshani"\n')
@@ -86,7 +86,7 @@ it</note>
         assert pofile.translate("bla") is None
         unit = first_translatable(pofile)
         assert unit.getnotes("translator") == "Couldn't do it"
-        potext = str(pofile)
+        potext = pofile.serialize()
         assert potext.index("# Couldn't do it\n") >= 0
 
         minixlf = self.xliffskeleton % '''<trans-unit xml:space="preserve">
@@ -104,7 +104,7 @@ it</note>
         assert pofile.translate("bla") is None
         unit = first_translatable(pofile)
         assert unit.getnotes("translator") == "Couldn't do\nit"
-        potext = str(pofile)
+        potext = pofile.serialize()
         assert potext.index("# Couldn't do\n# it\n") >= 0
 
     def test_autocomment(self):
@@ -124,7 +124,7 @@ garbage</note>
         assert pofile.translate("bla") is None
         unit = first_translatable(pofile)
         assert unit.getnotes("developer") == "Note that this is garbage"
-        potext = str(pofile)
+        potext = pofile.serialize()
         assert potext.index("#. Note that this is garbage\n") >= 0
 
         minixlf = self.xliffskeleton % '''<trans-unit xml:space="preserve">
@@ -142,7 +142,7 @@ garbage</note>
         assert pofile.translate("bla") is None
         unit = first_translatable(pofile)
         assert unit.getnotes("developer") == "Note that this is\ngarbage"
-        potext = str(pofile)
+        potext = pofile.serialize()
         assert potext.index("#. Note that this is\n#. garbage\n") >= 0
 
     def test_locations(self):
@@ -204,8 +204,8 @@ garbage</note>
         </trans-unit>
 </group>'''
         pofile = self.xliff2po(minixlf)
-        print(str(pofile))
-        potext = str(pofile)
+        print(pofile.serialize())
+        potext = pofile.serialize()
         assert headerless_len(pofile.units) == 1
         assert potext.index('msgid_plural "cows"')
         assert potext.index('msgstr[0] "inkomo"')

--- a/translate/convert/tiki2po.py
+++ b/translate/convert/tiki2po.py
@@ -73,7 +73,7 @@ def converttiki(inputfile, outputfile, template=None, includeunused=False):
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
         return False
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return True
 
 

--- a/translate/convert/ts2po.py
+++ b/translate/convert/ts2po.py
@@ -77,7 +77,7 @@ def convertts(inputfile, outputfile, templates, pot=False, duplicatestyle="msgct
     outputstore = convertor.convertfile(inputfile)
     if outputstore.isempty():
         return 0
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/txt2po.py
+++ b/translate/convert/txt2po.py
@@ -55,7 +55,7 @@ def converttxt(inputfile, outputfile, templates, duplicatestyle="msgctxt",
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
         return 0
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/web2py2po.py
+++ b/translate/convert/web2py2po.py
@@ -73,7 +73,7 @@ def convertpy(inputfile, outputfile, encoding="UTF-8"):
     if outputstore.isempty():
         return 0
 
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/convert/xliff2po.py
+++ b/translate/convert/xliff2po.py
@@ -102,7 +102,7 @@ def convertxliff(inputfile, outputfile, templates, duplicatestyle="msgctxt"):
     outputstore = convertor.convertstore(inputfile, duplicatestyle)
     if outputstore.isempty():
         return 0
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/filters/pofilter.py
+++ b/translate/filters/pofilter.py
@@ -220,7 +220,7 @@ def runfilter(inputfile, outputfile, templatefile, checkfilter=None):
     if tofile.isempty():
         return 0
 
-    outputfile.write(str(tofile))
+    outputfile.write(tofile.serialize())
 
     return 1
 

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -693,7 +693,17 @@ class TranslationStore(object):
             self.fileobj = open(self.filename)
 
     def __str__(self):
-        """Converts to a string representation that can be parsed back using
+        # This allows the old str(store) method for serialization to be kept
+        # for compatibility purpose.
+        if six.PY2:
+            return self.serialize()
+        return super(TranslationStore, self).__str__()
+
+    def __bytes__(self):
+        return self.serialize()
+
+    def serialize(self):
+        """Converts to a bytes representation that can be parsed back using
         :meth:`~.TranslationStore.parsestring`."""
         # We can't pickle fileobj if it is there, so let's hide it for a while.
         fileobj = getattr(self, "fileobj", None)

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -790,7 +790,7 @@ class TranslationStore(object):
 
     def savefile(self, storefile):
         """Write the string representation to the given file (or filename)."""
-        storestring = str(self)
+        storestring = self.serialize()
         if isinstance(storefile, six.string_types):
             storefile = open(storefile, 'wb')
         self.fileobj = storefile

--- a/translate/storage/catkeys.py
+++ b/translate/storage/catkeys.py
@@ -260,7 +260,7 @@ class CatkeysFile(base.TranslationStore):
             newunit.dict = line
             self.addunit(newunit)
 
-    def __str__(self):
+    def serialize(self):
         output = csv.StringIO()
         writer = csv.DictWriter(output, fieldnames=FIELDNAMES_HEADER, dialect="catkeys")
         writer.writerow(self.header._header_dict)

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -701,7 +701,7 @@ class pofile(pocommon.pofile):
         self._gpo_memory_file = new_gpo_memory_file
         self.units = uniqueunits
 
-    def __str__(self):
+    def serialize(self):
 
         def obsolete_workaround():
             # Remove all items that are not output by msgmerge when a unit is obsolete.  This is a work

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -410,8 +410,8 @@ class csvfile(base.TranslationStore):
                 self.addunit(newce)
             first_row = False
 
-    def __str__(self):
-        """convert to a string. double check that unicode is handled somehow here"""
+    def serialize(self):
+        """convert to bytes. double check that unicode is handled somehow here"""
         source = self.getoutput()
         if not isinstance(source, six.text_type):
             source = source.decode('utf-8')

--- a/translate/storage/dtd.py
+++ b/translate/storage/dtd.py
@@ -562,8 +562,8 @@ class dtdfile(base.TranslationStore):
                     warnings.warn("%s\nError occured between lines %d and %d:\n%s" % (e, start + 1, end, "\n".join(lines[start:end])))
                 start += linesprocessed
 
-    def __str__(self):
-        """convert to a string. double check that unicode is handled somehow here"""
+    def serialize(self):
+        """convert to bytes. double check that unicode is handled somehow here"""
         source = self.getoutput()
         if not self._valid_store():
             warnings.warn("DTD file '%s' does not validate" % self.filename)

--- a/translate/storage/fpo.py
+++ b/translate/storage/fpo.py
@@ -522,8 +522,8 @@ class pofile(pocommon.pofile):
                 uniqueunits.append(thepo)
         self.units = uniqueunits
 
-    def __str__(self):
-        """Convert to a string. double check that unicode is handled somehow here"""
+    def serialize(self):
+        """Convert to bytes. double check that unicode is handled somehow here"""
         self._cpo_store = cpo.pofile(encoding=self._encoding, noheader=True)
         try:
             self._build_cpo_from_self()
@@ -531,6 +531,6 @@ class pofile(pocommon.pofile):
             self._encoding = "utf-8"
             self.updateheader(add=True, Content_Type="text/plain; charset=UTF-8")
             self._build_cpo_from_self()
-        output = str(self._cpo_store)
+        output = self._cpo_store.serialize()
         del self._cpo_store
         return output

--- a/translate/storage/ical.py
+++ b/translate/storage/ical.py
@@ -90,7 +90,7 @@ class icalfile(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def __str__(self):
+    def serialize(self):
         _outicalfile = self._icalfile
         for unit in self.units:
             for location in unit.getlocations():

--- a/translate/storage/ini.py
+++ b/translate/storage/ini.py
@@ -105,7 +105,7 @@ class inifile(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def __str__(self):
+    def serialize(self):
         _outinifile = self._inifile
         for unit in self.units:
             for location in unit.getlocations():
@@ -114,7 +114,7 @@ class inifile(base.TranslationStore):
         if _outinifile:
             return str(_outinifile)
         else:
-            return ""
+            return b""
 
     def parse(self, input):
         """Parse the given file or file source string."""

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -154,7 +154,7 @@ class JsonFile(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def __str__(self):
+    def serialize(self):
         units = {}
         for unit in self.unit_iter():
             path = unit.getid().lstrip('.')

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -328,7 +328,7 @@ class LISAfile(base.TranslationStore):
         if new:
             self.body.append(unit.xmlelement)
 
-    def __str__(self):
+    def serialize(self):
         """Converts to a string containing the file's XML"""
         return etree.tostring(self.document, pretty_print=True,
                               xml_declaration=True, encoding='utf-8')

--- a/translate/storage/mo.py
+++ b/translate/storage/mo.py
@@ -3,7 +3,7 @@
 #
 # Copyright 2007 Zuza Software Foundation
 #
-# the function "__str__" was derived from Python v2.4
+# the function "serialize" was derived from Python v2.4
 #       (Tools/i18n/msgfmt.py - function "generate"):
 #   Written by Martin v. Löwis <loewis@informatik.hu-berlin.de>
 #   Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006 Python Software Foundation.
@@ -144,7 +144,7 @@ class mofile(poheader.poheader, base.TranslationStore):
         if inputfile is not None:
             self.parsestring(inputfile)
 
-    def __str__(self):
+    def serialize(self):
         """Output a string representation of the MO data file"""
         # check the header of this file for the copyright note of this function
 

--- a/translate/storage/mozilla_lang.py
+++ b/translate/storage/mozilla_lang.py
@@ -106,10 +106,10 @@ class LangStore(txt.TxtFile):
                     u.addnote(comment[:-1], 'developer')
                     comment = ""
 
-    def __str__(self):
-        ret_string = ""
+    def serialize(self):
+        ret_string = b""
         if self.is_active or self.mark_active:
-            ret_string += "## active ##\n"
+            ret_string += b"## active ##\n"
         ret_string += u"\n\n\n".join([six.text_type(unit) for unit in self.units]).encode('utf-8')
-        ret_string += "\n"
+        ret_string += b"\n"
         return ret_string

--- a/translate/storage/omegat.py
+++ b/translate/storage/omegat.py
@@ -180,7 +180,7 @@ class OmegaTFile(base.TranslationStore):
             newunit.dict = line
             self.addunit(newunit)
 
-    def __str__(self):
+    def serialize(self):
         output = csv.StringIO()
         writer = csv.DictWriter(output, fieldnames=OMEGAT_FIELDNAMES,
                                 dialect="omegat")

--- a/translate/storage/oo.py
+++ b/translate/storage/oo.py
@@ -308,7 +308,12 @@ class oofile:
             thisline = ooline(parts)
             self.addline(thisline)
 
-    def __str__(self, skip_source=False, fallback_lang=None):
+    def __str__(self, *args, **kwargs):
+        if six.PY2:
+            return self.serialize(*args, **kwargs)
+        return super(oofile, self).__str__()
+
+    def serialize(self, skip_source=False, fallback_lang=None):
         """convert to a string. double check that unicode is handled"""
         return encode_if_needed_utf8(self.getoutput(skip_source, fallback_lang))
 

--- a/translate/storage/php.py
+++ b/translate/storage/php.py
@@ -208,12 +208,12 @@ class phpfile(base.TranslationStore):
             inputfile.close()
             self.parse(phpsrc)
 
-    def __str__(self):
+    def serialize(self):
         """Convert the units back to lines."""
         lines = []
         for unit in self.units:
             lines.append(str(unit))
-        return "".join(lines)
+        return ("".join(lines)).encode(self._encoding)
 
     def parse(self, phpsrc):
         """Read the source of a PHP file in and include them as units."""

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -636,13 +636,14 @@ class propfile(base.TranslationStore):
         if inmultilinevalue or len(newunit.comments) > 0:
             self.addunit(newunit)
 
-    def __str__(self):
+    def serialize(self):
         """Convert the units back to lines."""
         lines = []
         for unit in self.units:
             lines.append(unit.getoutput())
         uret = u"".join(lines)
         return uret.encode(self.encoding)
+
 
 class javafile(propfile):
     Name = "Java Properties"

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -833,8 +833,8 @@ class pofile(pocommon.pofile):
                 uniqueunits.append(thepo)
         self.units = uniqueunits
 
-    def __str__(self):
-        """Convert to a string. Double check that unicode is handled somehow
+    def serialize(self):
+        """Convert to bytes. Double check that unicode is handled somehow
         here"""
         output = self._getoutput()
         if isinstance(output, six.text_type):

--- a/translate/storage/qm.py
+++ b/translate/storage/qm.py
@@ -101,7 +101,7 @@ class qmfile(base.TranslationStore):
         if inputfile is not None:
             self.parsestring(inputfile)
 
-    def __str__(self):
+    def serialize(self):
         """Output a string representation of the .qm data file"""
         raise Exception("Writing of .qm files is not supported yet")
 

--- a/translate/storage/qph.py
+++ b/translate/storage/qph.py
@@ -138,7 +138,7 @@ class QphFile(lisa.LISAfile):
         if targetlanguage:
             self.header.set('language', targetlanguage)
 
-    def __str__(self):
+    def serialize(self):
         """Converts to a string containing the file's XML.
 
         We have to override this to ensure mimic the Qt convention:

--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -233,6 +233,6 @@ class rcfile(base.TranslationStore):
                     newunit.match = match
                     self.addunit(newunit)
 
-    def __str__(self):
+    def serialize(self):
         """Convert the units back to lines."""
-        return "".join(self.blocks)
+        return ("".join(self.blocks)).encode(self.encoding)

--- a/translate/storage/subtitles.py
+++ b/translate/storage/subtitles.py
@@ -90,7 +90,7 @@ class SubtitleFile(base.TranslationStore):
         if inputfile is not None:
             self._parsefile(inputfile)
 
-    def __str__(self):
+    def serialize(self):
         subtitles = []
         for unit in self.units:
             subtitle = Subtitle()

--- a/translate/storage/test_base.py
+++ b/translate/storage/test_base.py
@@ -236,7 +236,7 @@ class TestTranslationStore(object):
         store = self.StoreClass()
         unit = store.addsourceunit("Test String")
         print(str(unit))
-        print(str(store))
+        print(store.serialize())
         assert headerless_len(store.units) == 1
         assert unit.source == "Test String"
 
@@ -261,7 +261,7 @@ class TestTranslationStore(object):
 
     def reparse(self, store):
         """converts the store to a string and back to a store again"""
-        storestring = str(store)
+        storestring = store.serialize()
         newstore = self.StoreClass.parsestring(storestring)
         return newstore
 
@@ -274,9 +274,9 @@ class TestTranslationStore(object):
             if not match:
                 print("match failed between elements %d of %d" % ((n + 1), headerless_len(store1.units)))
                 print("store1:")
-                print(str(store1))
+                print(store1.serialize())
                 print("store2:")
-                print(str(store2))
+                print(store2.serialize())
                 print("store1.units[%d].__dict__:" % n, store1unit.__dict__)
                 print("store2.units[%d].__dict__:" % n, store2unit.__dict__)
                 assert store1unit == store2unit
@@ -332,7 +332,7 @@ class TestTranslationStore(object):
             answer = answer.decode("utf-8")
         assert answer == u"Beziér-kurwe"
         #Just test that __str__ doesn't raise exception:
-        src = str(store)
+        src = store.serialize()
 
     def test_extensions(self):
         """Test that the factory knows the extensions for this class."""

--- a/translate/storage/test_cpo.py
+++ b/translate/storage/test_cpo.py
@@ -97,7 +97,7 @@ class TestCPOFile(test_po.TestPOFile):
         print("Blah", thepo.source)
         assert thepo.source == "test me"
         thepo.msgidcomment = "second comment"
-        assert str(pofile).count("_:") == 1
+        assert pofile.serialize().count("_:") == 1
 
     @mark.xfail(reason="Were disabled during port of Pypo to cPO - they might work")
     def test_merge_duplicates_msgctxt(self):
@@ -152,13 +152,13 @@ class TestCPOFile(test_po.TestPOFile):
         assert po.unquotefrompo(pofile.units[1].msgidcomments) == ""
 
     def test_output_str_unicode(self):
-        """checks that we can str(pofile) which is in unicode"""
+        """checks that we can serialize pofile, unit content is in unicode"""
         posource = u'''#: nb\nmsgid "Norwegian Bokm\xe5l"\nmsgstr ""\n'''
         pofile = self.StoreClass(wStringIO.StringIO(posource.encode("UTF-8")), encoding="UTF-8")
         assert len(pofile.units) == 1
-        print(str(pofile))
+        print(pofile.serialize())
         thepo = pofile.units[0]
-#        assert str(pofile) == posource.encode("UTF-8")
+#        assert pofile.serialize() == posource.encode("UTF-8")
         # extra test: what if we set the msgid to a unicode? this happens in prop2po etc
         thepo.source = u"Norwegian Bokm\xe5l"
 #        assert str(thepo) == posource.encode("UTF-8")
@@ -166,9 +166,9 @@ class TestCPOFile(test_po.TestPOFile):
         # this is an escaped half character (1/2)
         halfstr = "\xbd ...".decode("latin-1")
         thepo.target = halfstr
-#        assert halfstr in str(pofile).decode("UTF-8")
+#        assert halfstr in pofile.serialize().decode("UTF-8")
         thepo.target = halfstr.encode("UTF-8")
-#        assert halfstr.encode("UTF-8") in str(pofile)
+#        assert halfstr.encode("UTF-8") in pofile.serialize()
 
     def test_posections(self):
         """checks the content of all the expected sections of a PO message"""
@@ -176,18 +176,18 @@ class TestCPOFile(test_po.TestPOFile):
         pofile = self.poparse(posource)
         print(pofile)
         assert len(pofile.units) == 1
-        assert str(pofile) == posource
+        assert pofile.serialize() == posource
 
     def test_multiline_obsolete(self):
         """Tests for correct output of mulitline obsolete messages"""
         posource = '#~ msgid ""\n#~ "Old thing\\n"\n#~ "Second old thing"\n#~ msgstr ""\n#~ "Ou ding\\n"\n#~ "Tweede ou ding"\n'
         pofile = self.poparse(posource)
         print("Source:\n%s" % posource)
-        print("Output:\n%s" % str(pofile))
+        print("Output:\n%s" % pofile.serialize())
         assert len(pofile.units) == 1
         assert pofile.units[0].isobsolete()
         assert not pofile.units[0].istranslatable()
-        assert str(pofile) == posource
+        assert pofile.serialize() == posource
 
     def test_unassociated_comments(self):
         """tests behaviour of unassociated comments."""
@@ -195,4 +195,4 @@ class TestCPOFile(test_po.TestPOFile):
         oldfile = self.poparse(oldsource)
         print("serialize", oldfile.serialize())
         assert len(oldfile.units) == 1
-        assert str(oldfile).find("# old lonesome comment\nmsgid") >= 0
+        assert oldfile.serialize().find("# old lonesome comment\nmsgid") >= 0

--- a/translate/storage/test_cpo.py
+++ b/translate/storage/test_cpo.py
@@ -193,6 +193,6 @@ class TestCPOFile(test_po.TestPOFile):
         """tests behaviour of unassociated comments."""
         oldsource = '# old lonesome comment\n\nmsgid "one"\nmsgstr "een"\n'
         oldfile = self.poparse(oldsource)
-        print("__str__", str(oldfile))
+        print("serialize", oldfile.serialize())
         assert len(oldfile.units) == 1
         assert str(oldfile).find("# old lonesome comment\nmsgid") >= 0

--- a/translate/storage/test_csvl10n.py
+++ b/translate/storage/test_csvl10n.py
@@ -20,4 +20,4 @@ class TestCSV(test_base.TestTranslationStore):
         newstore = self.reparse(store)
         self.check_equality(store, newstore)
         assert store.units[2] == newstore.units[2]
-        assert str(store) == str(newstore)
+        assert store.serialize() == newstore.serialize()

--- a/translate/storage/test_dtd.py
+++ b/translate/storage/test_dtd.py
@@ -197,7 +197,7 @@ class TestDTD(test_monolingual.TestMonolingualStore):
 
     def dtdregen(self, dtdsource):
         """helper that converts dtd source to dtdfile object and back"""
-        return str(self.dtdparse(dtdsource))
+        return self.dtdparse(dtdsource).serialize()
 
     def test_simpleentity(self):
         """checks that a simple dtd entity definition is parsed correctly"""
@@ -326,7 +326,7 @@ class TestDTD(test_monolingual.TestMonolingualStore):
         assert len(dtdfile.units) == 1
         dtdunit = dtdfile.units[0]
         assert dtdunit.definition == '"bananas for sale"'
-        assert str(dtdfile) == '<!ENTITY test.me "bananas for sale">\n'
+        assert dtdfile.serialize() == '<!ENTITY test.me "bananas for sale">\n'
 
     def test_missing_quotes(self, recwarn):
         """test that we fail graacefully when a message without quotes is found (bug #161)"""
@@ -408,7 +408,7 @@ class TestAndroidDTD(test_monolingual.TestMonolingualStore):
         in-memory store and writing back to an Android DTD file without really
         having a real file.
         """
-        return str(self.dtdparse(dtdsource))
+        return self.dtdparse(dtdsource).serialize()
 
     # Test for bug #2480
     def test_android_single_quote_escape(self):

--- a/translate/storage/test_monolingual.py
+++ b/translate/storage/test_monolingual.py
@@ -43,9 +43,9 @@ class TestMonolingualStore(test_base.TestTranslationStore):
             if str(store1unit) != str(store2unit):
                 print("match failed between elements %d of %d" % (n+1, len(store1.units)))
                 print("store1:")
-                print(str(store1))
+                print(store1.serialize())
                 print("store2:")
-                print(str(store2))
+                print(store2.serialize())
                 print("store1.units[%d].__dict__:" % n, store1unit.__dict__)
                 print("store2.units[%d].__dict__:" % n, store2unit.__dict__)
                 assert str(store1unit) == str(store2unit)

--- a/translate/storage/test_mozilla_lang.py
+++ b/translate/storage/test_mozilla_lang.py
@@ -58,7 +58,7 @@ class TestMozLangFile(test_base.TestTranslationStore):
         assert unit.source == "Source"
         assert unit.target == "Target"
         assert "Comment" in unit.getnotes()
-        assert str(store) == lang
+        assert store.serialize() == lang
 
     def test_active_flag(self):
         """Test the ## active ## flag"""
@@ -67,7 +67,7 @@ class TestMozLangFile(test_base.TestTranslationStore):
                 "Target\n")
         store = self.StoreClass.parsestring(lang)
         assert store.is_active
-        assert str(store) == lang
+        assert store.serialize() == lang
 
     def test_multiline_comments(self):
         """Ensure we can handle and preserve miltiline comments"""
@@ -78,7 +78,7 @@ class TestMozLangFile(test_base.TestTranslationStore):
                 ";Source\n"
                 "Target\n")
         store = self.StoreClass.parsestring(lang)
-        assert str(store) == lang
+        assert store.serialize() == lang
 
     def test_template(self):
         """A template should have source == target, though it could be blank"""
@@ -88,7 +88,7 @@ class TestMozLangFile(test_base.TestTranslationStore):
         unit = store.units[0]
         assert unit.source == "Source"
         assert unit.target == ""
-        assert str(store) == lang
+        assert store.serialize() == lang
         lang2 = (";Source\n"
                 "\n"
                 ";Source2\n")

--- a/translate/storage/test_oo.py
+++ b/translate/storage/test_oo.py
@@ -44,7 +44,7 @@ class TestOO:
 
     def ooregen(self, oosource):
         """helper that converts oo source to oofile object and back"""
-        return str(self.ooparse(oosource))
+        return self.ooparse(oosource).serialize()
 
     def test_simpleentry(self):
         """checks that a simple oo entry is parsed correctly"""

--- a/translate/storage/test_php.py
+++ b/translate/storage/test_php.py
@@ -100,7 +100,7 @@ class TestPhpFile(test_monolingual.TestMonolingualStore):
 
     def phpregen(self, phpsource):
         """helper that converts php source to phpfile object and back"""
-        return str(self.phpparse(phpsource))
+        return self.phpparse(phpsource).serialize()
 
     def test_simpledefinition(self):
         """checks that a simple php definition is parsed correctly"""

--- a/translate/storage/test_po.py
+++ b/translate/storage/test_po.py
@@ -178,7 +178,7 @@ class TestPOFile(test_base.TestTranslationStore):
 
     def poregen(self, posource):
         """helper that converts po source to pofile object and back"""
-        return str(self.poparse(posource))
+        return self.poparse(posource).serialize()
 
     def pomerge(self, oldmessage, newmessage, authoritative):
         """helper that merges two messages"""
@@ -200,7 +200,7 @@ class TestPOFile(test_base.TestTranslationStore):
             # force rewrapping:
             u.source = u.source
             u.target = u.target
-        return str(pofile)
+        return pofile.serialize()
 
     def test_context_only(self):
         """Checks that an empty msgid with msgctxt is handled correctly."""
@@ -212,7 +212,7 @@ msgstr ""
         assert pofile.units[0].istranslatable()
         assert not pofile.units[0].isheader()
         # we were not generating output for thse at some stage
-        assert str(pofile)
+        assert pofile.serialize()
 
     def test_simpleentry(self):
         """checks that a simple po entry is parsed correctly"""
@@ -340,7 +340,7 @@ msgid ""
 msgstr "POT-Creation-Date: 2006-03-08 17:30+0200\n"
 '''
         pofile = self.poparse(posource)
-        assert str(pofile) == posource
+        assert pofile.serialize() == posource
 
     def test_fuzzy(self):
         """checks that fuzzy functionality works as expected"""
@@ -351,7 +351,7 @@ msgstr "POT-Creation-Date: 2006-03-08 17:30+0200\n"
         assert pofile.units[0].isfuzzy()
         pofile.units[0].markfuzzy(False)
         assert not pofile.units[0].isfuzzy()
-        assert str(pofile) == expectednonfuzzy
+        assert pofile.serialize() == expectednonfuzzy
 
         posource = '#, fuzzy, python-format\nmsgid "ball"\nmsgstr "bal"\n'
         expectednonfuzzy = '#, python-format\nmsgid "ball"\nmsgstr "bal"\n'
@@ -361,10 +361,10 @@ msgstr "POT-Creation-Date: 2006-03-08 17:30+0200\n"
         assert pofile.units[0].isfuzzy()
         pofile.units[0].markfuzzy(False)
         assert not pofile.units[0].isfuzzy()
-        assert str(pofile) == expectednonfuzzy
+        assert pofile.serialize() == expectednonfuzzy
         pofile.units[0].markfuzzy()
-        print(str(pofile))
-        assert str(pofile) == expectedfuzzyagain
+        print(pofile.serialize())
+        assert pofile.serialize() == expectedfuzzyagain
 
         # test the same, but with flags in a different order
         posource = '#, python-format, fuzzy\nmsgid "ball"\nmsgstr "bal"\n'
@@ -375,11 +375,11 @@ msgstr "POT-Creation-Date: 2006-03-08 17:30+0200\n"
         assert pofile.units[0].isfuzzy()
         pofile.units[0].markfuzzy(False)
         assert not pofile.units[0].isfuzzy()
-        print(str(pofile))
-        assert str(pofile) == expectednonfuzzy
+        print(pofile.serialize())
+        assert pofile.serialize() == expectednonfuzzy
         pofile.units[0].markfuzzy()
-        print(str(pofile))
-        assert str(pofile) == expectedfuzzyagain
+        print(pofile.serialize())
+        assert pofile.serialize() == expectedfuzzyagain
 
     @mark.xfail(reason="Check differing behaviours between pypo and cpo")
     def test_makeobsolete_untranslated(self):
@@ -387,7 +387,7 @@ msgstr "POT-Creation-Date: 2006-03-08 17:30+0200\n"
         posource = '#. The automatic one\n#: test.c\nmsgid "test"\nmsgstr ""\n'
         pofile = self.poparse(posource)
         unit = pofile.units[0]
-        print(str(pofile))
+        print(pofile.serialize())
         assert not unit.isobsolete()
         unit.makeobsolete()
         assert str(unit) == ""
@@ -445,7 +445,7 @@ msgstr "tweede"
         assert len(pofile.units) == 1
         unit = pofile.units[0]
         assert unit.isobsolete()
-        assert str(pofile) == posource
+        assert pofile.serialize() == posource
 
         posource = '''msgid "one"
 msgstr "een"
@@ -461,9 +461,9 @@ msgstr "een"
         unit = pofile.units[1]
         assert unit.isobsolete()
 
-        print(str(pofile))
+        print(pofile.serialize())
         # Doesn't work with CPO if obsolete units are mixed with non-obsolete units
-        assert str(pofile) == posource
+        assert pofile.serialize() == posource
         unit.resurrect()
         assert unit.hasplural()
 
@@ -497,13 +497,13 @@ msgstr "een"
         assert not unit.istranslatable()
 
         print(posource)
-        print(str(pofile))
-        assert str(pofile) == posource
+        print(pofile.serialize())
+        assert pofile.serialize() == posource
 
     def test_header_escapes(self):
         pofile = self.StoreClass()
         pofile.updateheader(add=True, **{"Report-Msgid-Bugs-To": r"http://qa.openoffice.org/issues/enter_bug.cgi?subcomponent=ui&comment=&short_desc=Localization%20issue%20in%20file%3A%20dbaccess\source\core\resource.oo&component=l10n&form_name=enter_issue"})
-        filecontents = str(pofile)
+        filecontents = pofile.serialize()
         print(filecontents)
         # We need to make sure that the \r didn't get misrepresented as a
         # carriage return, but as a slash (escaped) followed by a normal 'r'
@@ -581,9 +581,9 @@ msgstr[1] "Koeie"
         assert len(pofile.units) == 1
         unit = pofile.units[0]
         assert unit.isobsolete()
-        print(str(pofile))
+        print(pofile.serialize())
         print(posource)
-        assert str(pofile) == posource
+        assert pofile.serialize() == posource
 
     def test_merge_duplicates(self):
         """checks that merging duplicates works"""
@@ -607,9 +607,9 @@ msgid "test"
 msgstr ""
 '''
         pofile = self.poparse(posource, duplicatestyle="allow")
-        print(str(pofile))
+        print(pofile.serialize())
         pofile.removeduplicates("merge")
-        print(str(pofile))
+        print(pofile.serialize())
         assert len(pofile.units) == 1
         assert pofile.units[0].getlocations() == ["source1", "source2"]
 
@@ -822,9 +822,9 @@ msgstr "プロジェクトが見つかりませんでした"
         pofile1 = self.poparse(posource)
         print(pofile1.units[1].source)
         assert pofile1.units[1].source == u"I cannot locate the project\\"
-        pofile2 = self.poparse(str(pofile1))
-        print(str(pofile2))
-        assert str(pofile1) == str(pofile2)
+        pofile2 = self.poparse(pofile1.serialize())
+        print(pofile2.serialize())
+        assert pofile1.serialize() == pofile2.serialize()
 
     def test_unfinished_lines(self):
         """Test that we reasonably handle lines with a single quote."""
@@ -841,10 +841,10 @@ msgstr "start thing dingis fish"
         pofile1 = self.poparse(posource)
         print(repr(pofile1.units[1].target))
         assert pofile1.units[1].target == u"start thing dingis fish"
-        pofile2 = self.poparse(str(pofile1))
+        pofile2 = self.poparse(pofile1.serialize())
         assert pofile2.units[1].target == u"start thing dingis fish"
-        print(str(pofile2))
-        assert str(pofile1) == str(pofile2)
+        print(pofile2.serialize())
+        assert pofile1.serialize() == pofile2.serialize()
 
     def test_encoding_change(self):
         posource = r'''
@@ -863,7 +863,7 @@ msgstr "d"
         pofile = self.poparse(posource)
         unit = pofile.units[1]
         unit.target = u"ḓ"
-        contents = str(pofile)
+        contents = pofile.serialize()
         assert 'msgstr "\341\270\223"' in contents
         assert 'charset=UTF-8' in contents
 

--- a/translate/storage/test_poheader.py
+++ b/translate/storage/test_poheader.py
@@ -264,15 +264,15 @@ msgstr ""
 '''
     pofile = poparse(posource)
     pofile.updatecontributor("Grasvreter")
-    assert "# Grasvreter, 20" in str(pofile)
+    assert "# Grasvreter, 20" in pofile.serialize()
 
     pofile.updatecontributor("Koeivreter", "monster@grasveld.moe")
-    assert "# Koeivreter <monster@grasveld.moe>, 20" in str(pofile)
+    assert "# Koeivreter <monster@grasveld.moe>, 20" in pofile.serialize()
 
     pofile.header().addnote("Khaled Hosny <khaledhosny@domain.org>, 2006, 2007, 2008.")
     pofile.updatecontributor("Khaled Hosny", "khaledhosny@domain.org")
-    print(str(pofile))
-    assert "# Khaled Hosny <khaledhosny@domain.org>, 2006, 2007, 2008, %s." % time.strftime("%Y") in str(pofile)
+    print(pofile.serialize())
+    assert "# Khaled Hosny <khaledhosny@domain.org>, 2006, 2007, 2008, %s." % time.strftime("%Y") in pofile.serialize()
 
 
 def test_language():

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -111,7 +111,7 @@ class TestProp(test_monolingual.TestMonolingualStore):
 
     def propregen(self, propsource):
         """helper that converts properties source to propfile object and back"""
-        return str(self.propparse(propsource))
+        return self.propparse(propsource).serialize()
 
     def test_simpledefinition(self):
         """checks that a simple properties definition is parsed correctly"""
@@ -137,7 +137,7 @@ class TestProp(test_monolingual.TestMonolingualStore):
         propunit = propfile.units[0]
         assert propunit.name == "unicode"
         assert propunit.source.encode("UTF-8") == "БЖЙШ"
-        regensource = str(propfile)
+        regensource = propfile.serialize()
         assert messagevalue in regensource
         assert "\\u" not in regensource
 
@@ -337,7 +337,7 @@ key=value
         # - quotes inside are escaped
         # - for the sake of beauty a pair of spaces encloses the equal mark
         # - every line ends with ";"
-        assert str(propfile).strip('\n\x00') == propsource.strip('\n\x00')
+        assert propfile.serialize().strip('\n\x00') == propsource.strip('\n\x00')
 
     def test_override_encoding(self):
         """test that we can override the encoding of a properties file"""
@@ -362,7 +362,7 @@ key=value
         """test that BOM appears in the resulting text once only"""
         propsource = u"key1 = value1\nkey2 = value2\n".encode('utf-16')
         propfile = self.propparse(propsource, encoding='utf-16')
-        result = str(propfile)
+        result = propfile.serialize()
         bom = propsource[:2]
         assert result.startswith(bom)
         assert bom not in result[2:]

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -206,7 +206,7 @@ class TestPYPOFile(test_po.TestPOFile):
         thepo = pofile.units[0]
         thepo.msgidcomments.append('"_: first comment\\n"')
         thepo.msgidcomments.append('"_: second comment\\n"')
-        regenposource = str(pofile)
+        regenposource = pofile.serialize()
         assert regenposource.count("_:") == 1
 
     def test_duplicates_default(self):
@@ -259,7 +259,7 @@ class TestPYPOFile(test_po.TestPOFile):
         posource = u'''#: nb\nmsgid "Norwegian Bokm\xe5l"\nmsgstr ""\n'''
         pofile = self.StoreClass(wStringIO.StringIO(posource.encode("UTF-8")), encoding="UTF-8")
         assert len(pofile.units) == 1
-        print(str(pofile))
+        print(pofile.serialize())
         thepo = pofile.units[0]
         assert str(thepo) == posource.encode("UTF-8")
         # extra test: what if we set the msgid to a unicode? this happens in prop2po etc
@@ -279,7 +279,7 @@ class TestPYPOFile(test_po.TestPOFile):
         pofile = self.poparse(posource)
         print(pofile)
         assert len(pofile.units) == 1
-        assert str(pofile) == posource
+        assert pofile.serialize() == posource
         assert pofile.units[0].othercomments == ["# other comment\n"]
         assert pofile.units[0].automaticcomments == ["#. automatic comment\n"]
         assert pofile.units[0].sourcecomments == ["#: source comment\n"]
@@ -289,7 +289,7 @@ class TestPYPOFile(test_po.TestPOFile):
         """tests behaviour of unassociated comments."""
         oldsource = '# old lonesome comment\n\nmsgid "one"\nmsgstr "een"\n'
         oldfile = self.poparse(oldsource)
-        print(str(oldfile))
+        print(oldfile.serialize())
         assert len(oldfile.units) == 1
 
     def test_prevmsgid_parse(self):
@@ -343,4 +343,4 @@ msgstr[1] "toetse"
         assert pofile.units[4].prev_msgctxt == [u'"context 2"']
         assert pofile.units[4].prev_source == multistring([u"tast", u"tasts"])
 
-        assert str(pofile) == posource
+        assert pofile.serialize() == posource

--- a/translate/storage/test_qm.py
+++ b/translate/storage/test_qm.py
@@ -15,7 +15,7 @@ class TestQtFile(test_base.TestTranslationStore):
 
     def test_parse(self):
         # self.reparse relies on __str__ to be output and then parsed
-        # qm.py does not implement __str__ but returns u''
+        # qm.py does not implement serialization
         pass
 
     def test_save(self):
@@ -30,10 +30,10 @@ class TestQtFile(test_base.TestTranslationStore):
 
     def test_nonascii(self):
         # QM does not implement serialising
-        assert pytest.raises(Exception, self.StoreClass.__str__,
+        assert pytest.raises(Exception, self.StoreClass.serialize,
                            self.StoreClass())
 
     def test_add(self):
         # QM does not implement serialising
-        assert pytest.raises(Exception, self.StoreClass.__str__,
+        assert pytest.raises(Exception, self.StoreClass.serialize,
                            self.StoreClass())

--- a/translate/storage/test_qph.py
+++ b/translate/storage/test_qph.py
@@ -50,8 +50,8 @@ class TestQphFile(test_base.TestTranslationStore):
         assert qphfile.units == []
         qphfile.addsourceunit("Bla")
         assert len(qphfile.units) == 1
-        newfile = qph.QphFile.parsestring(str(qphfile))
-        print(str(qphfile))
+        newfile = qph.QphFile.parsestring(qphfile.serialize())
+        print(qphfile.serialize())
         assert len(newfile.units) == 1
         assert newfile.units[0].source == "Bla"
         assert newfile.findunit("Bla").source == "Bla"
@@ -61,8 +61,8 @@ class TestQphFile(test_base.TestTranslationStore):
         qphfile = qph.QphFile()
         qphunit = qphfile.addsourceunit("Concept")
         qphunit.source = "Term"
-        newfile = qph.QphFile.parsestring(str(qphfile))
-        print(str(qphfile))
+        newfile = qph.QphFile.parsestring(qphfile.serialize())
+        print(qphfile.serialize())
         assert newfile.findunit("Concept") is None
         assert newfile.findunit("Term") is not None
 
@@ -70,8 +70,8 @@ class TestQphFile(test_base.TestTranslationStore):
         qphfile = qph.QphFile()
         qphunit = qphfile.addsourceunit("Concept")
         qphunit.target = "Konsep"
-        newfile = qph.QphFile.parsestring(str(qphfile))
-        print(str(qphfile))
+        newfile = qph.QphFile.parsestring(qphfile.serialize())
+        print(qphfile.serialize())
         assert newfile.findunit("Concept").target == "Konsep"
 
     def test_language(self):
@@ -85,7 +85,7 @@ class TestQphFile(test_base.TestTranslationStore):
         assert qphfile.gettargetlanguage() == 'fr'
         assert qphfile.getsourcelanguage() == 'de'
         qphfile.settargetlanguage('pt_BR')
-        assert 'pt_BR' in str(qphfile)
+        assert 'pt_BR' in qphfile.serialize()
         assert qphfile.gettargetlanguage() == 'pt-br'
         # We convert en_US to en
         qphstr = '''<!DOCTYPE QPH>

--- a/translate/storage/test_rc.py
+++ b/translate/storage/test_rc.py
@@ -24,7 +24,7 @@ class TestRcFile(object):
 
     def source_regenerate(self, source):
         """Helper that converts source to store object and back."""
-        return str(self.source_parse(source))
+        return self.source_parse(source).serialize()
 
     def test_parse_only_comments(self):
         """Test parsing a RC string with only comments."""

--- a/translate/storage/test_tbx.py
+++ b/translate/storage/test_tbx.py
@@ -15,8 +15,8 @@ class TestTBXfile(test_base.TestTranslationStore):
         assert tbxfile.units == []
         tbxfile.addsourceunit("Bla")
         assert len(tbxfile.units) == 1
-        newfile = tbx.tbxfile.parsestring(str(tbxfile))
-        print(str(tbxfile))
+        newfile = tbx.tbxfile.parsestring(tbxfile.serialize())
+        print(tbxfile.serialize())
         assert len(newfile.units) == 1
         assert newfile.units[0].source == "Bla"
         assert newfile.findunit("Bla").source == "Bla"
@@ -26,8 +26,8 @@ class TestTBXfile(test_base.TestTranslationStore):
         tbxfile = tbx.tbxfile()
         tbxunit = tbxfile.addsourceunit("Concept")
         tbxunit.source = "Term"
-        newfile = tbx.tbxfile.parsestring(str(tbxfile))
-        print(str(tbxfile))
+        newfile = tbx.tbxfile.parsestring(tbxfile.serialize())
+        print(tbxfile.serialize())
         assert newfile.findunit("Concept") is None
         assert newfile.findunit("Term") is not None
 
@@ -35,6 +35,6 @@ class TestTBXfile(test_base.TestTranslationStore):
         tbxfile = tbx.tbxfile()
         tbxunit = tbxfile.addsourceunit("Concept")
         tbxunit.target = "Konsep"
-        newfile = tbx.tbxfile.parsestring(str(tbxfile))
-        print(str(tbxfile))
+        newfile = tbx.tbxfile.parsestring(tbxfile.serialize())
+        print(tbxfile.serialize())
         assert newfile.findunit("Concept").target == "Konsep"

--- a/translate/storage/test_tmx.py
+++ b/translate/storage/test_tmx.py
@@ -48,8 +48,8 @@ class TestTMXfile(test_base.TestTranslationStore):
         """tests that addtranslation() stores strings correctly"""
         tmxfile = tmx.tmxfile()
         tmxfile.addtranslation("A string of characters", "en", "'n String karakters", "af")
-        newfile = self.tmxparse(str(tmxfile))
-        print(str(tmxfile))
+        newfile = self.tmxparse(tmxfile.serialize())
+        print(tmxfile.serialize())
         assert newfile.translate("A string of characters") == "'n String karakters"
 
     def test_withcomment(self):
@@ -57,16 +57,16 @@ class TestTMXfile(test_base.TestTranslationStore):
         tmxfile = tmx.tmxfile()
         tmxfile.addtranslation("A string of chars",
                                "en", "'n String karakters", "af", "comment")
-        newfile = self.tmxparse(str(tmxfile))
-        print(str(tmxfile))
+        newfile = self.tmxparse(tmxfile.serialize())
+        print(tmxfile.serialize())
         assert newfile.findunit("A string of chars").getnotes() == "comment"
 
     def test_withnewlines(self):
         """test addtranslation() with newlines"""
         tmxfile = tmx.tmxfile()
         tmxfile.addtranslation("First line\nSecond line", "en", "Eerste lyn\nTweede lyn", "af")
-        newfile = self.tmxparse(str(tmxfile))
-        print(str(tmxfile))
+        newfile = self.tmxparse(tmxfile.serialize())
+        print(tmxfile.serialize())
         assert newfile.translate("First line\nSecond line") == "Eerste lyn\nTweede lyn"
 
     def test_xmlentities(self):
@@ -74,7 +74,7 @@ class TestTMXfile(test_base.TestTranslationStore):
         tmxfile = tmx.tmxfile()
         tmxfile.addtranslation("Mail & News", "en", "Nuus & pos", "af")
         tmxfile.addtranslation("Five < ten", "en", "Vyf < tien", "af")
-        xmltext = str(tmxfile)
+        xmltext = tmxfile.serialize()
         print("The generated xml:")
         print(xmltext)
         assert tmxfile.translate('Mail & News') == 'Nuus & pos'

--- a/translate/storage/test_ts2.py
+++ b/translate/storage/test_ts2.py
@@ -87,8 +87,8 @@ class TestTSfile(test_base.TestTranslationStore):
         assert tsfile.units == []
         tsfile.addsourceunit("Bla")
         assert len(tsfile.units) == 1
-        newfile = ts.tsfile.parsestring(str(tsfile))
-        print(str(tsfile))
+        newfile = ts.tsfile.parsestring(tsfile.serialize())
+        print(tsfile.serialize())
         assert len(newfile.units) == 1
         assert newfile.units[0].source == "Bla"
         assert newfile.findunit("Bla").source == "Bla"
@@ -98,8 +98,8 @@ class TestTSfile(test_base.TestTranslationStore):
         tsfile = ts.tsfile()
         tsunit = tsfile.addsourceunit("Concept")
         tsunit.source = "Term"
-        newfile = ts.tsfile.parsestring(str(tsfile))
-        print(str(tsfile))
+        newfile = ts.tsfile.parsestring(tsfile.serialize())
+        print(tsfile.serialize())
         assert newfile.findunit("Concept") is None
         assert newfile.findunit("Term") is not None
 
@@ -107,8 +107,8 @@ class TestTSfile(test_base.TestTranslationStore):
         tsfile = ts.tsfile()
         tsunit = tsfile.addsourceunit("Concept")
         tsunit.target = "Konsep"
-        newfile = ts.tsfile.parsestring(str(tsfile))
-        print(str(tsfile))
+        newfile = ts.tsfile.parsestring(tsfile.serialize())
+        print(tsfile.serialize())
         assert newfile.findunit("Concept").target == "Konsep"
 
     def test_plurals(self):
@@ -116,8 +116,8 @@ class TestTSfile(test_base.TestTranslationStore):
         tsfile = ts.tsfile()
         tsunit = tsfile.addsourceunit("File(s)")
         tsunit.target = [u"Leêr", u"Leêrs"]
-        newfile = ts.tsfile.parsestring(str(tsfile))
-        print(str(tsfile))
+        newfile = ts.tsfile.parsestring(tsfile.serialize())
+        print(tsfile.serialize())
         checkunit = newfile.findunit("File(s)")
         assert checkunit.target == [u"Leêr", u"Leêrs"]
         assert checkunit.hasplural()
@@ -133,7 +133,7 @@ class TestTSfile(test_base.TestTranslationStore):
         assert tsfile.gettargetlanguage() == 'fr'
         assert tsfile.getsourcelanguage() == 'de'
         tsfile.settargetlanguage('pt_BR')
-        assert 'pt_BR' in str(tsfile)
+        assert 'pt_BR' in tsfile.serialize()
         assert tsfile.gettargetlanguage() == 'pt-br'
         # We convert en_US to en
         tsstr = '''<!DOCTYPE TS>
@@ -167,7 +167,7 @@ class TestTSfile(test_base.TestTranslationStore):
         newtsstr = tsstr.decode('utf-8').replace(
             '>TargetString', ' type="unfinished">TestTarget'
         ).encode('utf-8')
-        assert newtsstr == str(tsfile)
+        assert newtsstr == tsfile.serialize()
 
     def test_locations(self):
         """test that locations work well"""
@@ -253,4 +253,4 @@ class TestTSfile(test_base.TestTranslationStore):
     def test_backnforth(self):
         """test that ts files are read and output properly"""
         tsfile = ts.tsfile.parsestring(TS_NUMERUS)
-        assert str(tsfile) == TS_NUMERUS
+        assert tsfile.serialize() == TS_NUMERUS

--- a/translate/storage/test_txt.py
+++ b/translate/storage/test_txt.py
@@ -19,7 +19,7 @@ class TestTxtFile(test_monolingual.TestMonolingualStore):
 
     def txtregen(self, txtsource):
         """helper that converts txt source to txtfile object and back"""
-        return str(self.txtparse(txtsource))
+        return self.txtparse(txtsource).serialize()
 
     def test_simpleblock(self):
         """checks that a simple txt block is parsed correctly"""
@@ -35,7 +35,7 @@ class TestTxtFile(test_monolingual.TestMonolingualStore):
         txtfile = self.txtparse(txtsource)
         assert len(txtfile.units) == 3
         print(txtsource)
-        print(str(txtfile))
+        print(txtfile.serialize())
         print("*%s*" % txtfile.units[0])
-        assert str(txtfile) == txtsource
+        assert txtfile.serialize() == txtsource
         assert self.txtregen(txtsource) == txtsource

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -65,8 +65,8 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert xlifffile.units == []
         xlifffile.addsourceunit("Bla")
         assert len(xlifffile.units) == 1
-        newfile = xliff.xlifffile.parsestring(str(xlifffile))
-        print(str(xlifffile))
+        newfile = xliff.xlifffile.parsestring(xlifffile.serialize())
+        print(xlifffile.serialize())
         assert len(newfile.units) == 1
         assert newfile.units[0].source == "Bla"
         assert newfile.findunit("Bla").source == "Bla"
@@ -85,7 +85,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </xliff:file>
 </xliff:xliff>'''
         xlifffile = xliff.xlifffile.parsestring(xlfsource)
-        print(str(xlifffile))
+        print(xlifffile.serialize())
         assert xlifffile.units[0].source == "File 1"
 
     def test_rich_source(self):
@@ -169,8 +169,8 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         xlifffile = xliff.xlifffile()
         xliffunit = xlifffile.addsourceunit("Concept")
         xliffunit.source = "Term"
-        newfile = xliff.xlifffile.parsestring(str(xlifffile))
-        print(str(xlifffile))
+        newfile = xliff.xlifffile.parsestring(xlifffile.serialize())
+        print(xlifffile.serialize())
         assert newfile.findunit("Concept") is None
         assert newfile.findunit("Term") is not None
 
@@ -178,20 +178,20 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         xlifffile = xliff.xlifffile()
         xliffunit = xlifffile.addsourceunit("Concept")
         xliffunit.target = "Konsep"
-        newfile = xliff.xlifffile.parsestring(str(xlifffile))
-        print(str(xlifffile))
+        newfile = xliff.xlifffile.parsestring(xlifffile.serialize())
+        print(xlifffile.serialize())
         assert newfile.findunit("Concept").target == "Konsep"
 
     def test_sourcelanguage(self):
         xlifffile = xliff.xlifffile(sourcelanguage="xh")
-        xmltext = str(xlifffile)
+        xmltext = xlifffile.serialize()
         print(xmltext)
         assert xmltext.find('source-language="xh"') > 0
         #TODO: test that it also works for new files.
 
     def test_targetlanguage(self):
         xlifffile = xliff.xlifffile(sourcelanguage="zu", targetlanguage="af")
-        xmltext = str(xlifffile)
+        xmltext = xlifffile.serialize()
         print(xmltext)
         assert xmltext.find('source-language="zu"') > 0
         assert xmltext.find('target-language="af"') > 0
@@ -200,11 +200,11 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         xlifffile = xliff.xlifffile()
         unit = xlifffile.addsourceunit("Concept")
         # We don't want to add unnecessary notes
-        assert not "note" in str(xlifffile)
+        assert not "note" in xlifffile.serialize()
         unit.addnote(None)
-        assert not "note" in str(xlifffile)
+        assert not "note" in xlifffile.serialize()
         unit.addnote("")
-        assert not "note" in str(xlifffile)
+        assert not "note" in xlifffile.serialize()
 
         unit.addnote("Please buy bread")
         assert unit.getnotes() == "Please buy bread"

--- a/translate/storage/tiki.py
+++ b/translate/storage/tiki.py
@@ -103,7 +103,7 @@ class TikiStore(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def __str__(self):
+    def serialize(self):
         """Will return a formatted tiki-style language.php file."""
         _unused = []
         _untranslated = []

--- a/translate/storage/trados.py
+++ b/translate/storage/trados.py
@@ -199,6 +199,6 @@ class TradosTxtTmFile(base.TranslationStore):
             unit._soup = TradosSoup(str(tu))
             self.addunit(unit)
 
-    def __str__(self):
+    def serialize(self):
         # FIXME turn the lowercased tags back into mixed case
         return self._soup.prettify()

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -477,7 +477,7 @@ class tsfile(lisa.LISAfile):
         else:
             return 1
 
-    def __str__(self):
+    def serialize(self):
         """Converts to a string containing the file's XML."""
         root = self.document.getroot()
         doctype = self.document.docinfo.doctype

--- a/translate/storage/txt.py
+++ b/translate/storage/txt.py
@@ -147,7 +147,7 @@ class TxtFile(base.TranslationStore):
             unit = self.addsourceunit("\n".join(block))
             unit.addlocation("%s:%d" % (self.filename, startline + 1))
 
-    def __str__(self):
+    def serialize(self):
         source = self.getoutput()
         if isinstance(source, six.text_type):
             return source.encode(getattr(self, "encoding", "UTF-8"))

--- a/translate/storage/utx.py
+++ b/translate/storage/utx.py
@@ -270,7 +270,7 @@ class UtxFile(base.TranslationStore):
             newunit.dict = line
             self.addunit(newunit)
 
-    def __str__(self):
+    def serialize(self):
         output = csv.StringIO()
         writer = csv.DictWriter(output, fieldnames=self._fieldnames,
                                 dialect="utx")
@@ -282,4 +282,4 @@ class UtxFile(base.TranslationStore):
         if unit_count == 0:
             return ""
         output.reset()
-        return self._write_header() + "".join(output.readlines())
+        return self._write_header() + b"".join(output.readlines())

--- a/translate/storage/wordfast.py
+++ b/translate/storage/wordfast.py
@@ -400,7 +400,7 @@ class WordfastTMFile(base.TranslationStore):
             newunit.dict = line
             self.addunit(newunit)
 
-    def __str__(self):
+    def serialize(self):
         output = csv.StringIO()
         header_output = csv.StringIO()
         writer = csv.DictWriter(output, fieldnames=WF_FIELDNAMES,

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -774,9 +774,9 @@ class xlifffile(lisa.LISAfile):
             group.set("restype", restype)
         return group
 
-    def __str__(self):
+    def serialize(self):
         self.removedefaultfile()
-        return super(xlifffile, self).__str__()
+        return super(xlifffile, self).serialize()
 
     @classmethod
     def parsestring(cls, storestring):

--- a/translate/tools/phppo2pypo.py
+++ b/translate/tools/phppo2pypo.py
@@ -82,7 +82,7 @@ def convertphp2py(inputfile, outputfile, template=None):
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
         return False
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return True
 
 

--- a/translate/tools/poclean.py
+++ b/translate/tools/poclean.py
@@ -63,7 +63,7 @@ def runclean(inputfile, outputfile, templatefile):
     cleanfile(fromfile)
 #    if fromfile.isempty():
 #        return False
-    outputfile.write(str(fromfile))
+    outputfile.write(fromfile.serialize())
     return True
 
 

--- a/translate/tools/pocompile.py
+++ b/translate/tools/pocompile.py
@@ -53,7 +53,7 @@ class POCompile:
                         mounit.msgctxt = [context]
                 mounit.target = unit.target
                 outputfile.addunit(mounit)
-        return str(outputfile)
+        return outputfile.serialize()
 
 
 def convertmo(inputfile, outputfile, templatefile, includefuzzy=False):

--- a/translate/tools/poconflicts.py
+++ b/translate/tools/poconflicts.py
@@ -181,7 +181,7 @@ class ConflictOptionParser(optrecurse.RecursiveOptionParser):
                 unit.othercomments.append("# (poconflicts) %s\n" % filename)
                 conflictfile.units.append(unit)
             with open(fulloutputpath, "wb") as fh:
-                fh.write(str(conflictfile))
+                fh.write(conflictfile.serialize())
 
 
 def main():

--- a/translate/tools/podebug.py
+++ b/translate/tools/podebug.py
@@ -315,7 +315,7 @@ def convertpo(inputfile, outputfile, templatefile, format=None, rewritestyle=Non
         return 0
     convertor = podebug(format=format, rewritestyle=rewritestyle, ignoreoption=ignoreoption)
     outputstore = convertor.convertstore(inputstore)
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/tools/pogrep.py
+++ b/translate/tools/pogrep.py
@@ -338,7 +338,7 @@ def rungrep(inputfile, outputfile, templatefile, checkfilter):
     tofile = checkfilter.filterfile(fromfile)
     if tofile.isempty():
         return False
-    outputfile.write(str(tofile))
+    outputfile.write(tofile.serialize())
     return True
 
 

--- a/translate/tools/pomerge.py
+++ b/translate/tools/pomerge.py
@@ -99,7 +99,7 @@ def mergestore(inputfile, outputfile, templatefile, mergeblanks="no", mergefuzzy
                     mergefuzzy, mergecomments)
     if outputstore.isempty():
         return 0
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/tools/porestructure.py
+++ b/translate/tools/porestructure.py
@@ -107,7 +107,7 @@ class SplitOptionParser(optrecurse.RecursiveOptionParser):
                         outputpofile = po.pofile()
                     outputpofile.units.append(pounit)   # TODO:perhaps check to see if it's already there...
                     with open(fulloutputpath, 'wb') as fh:
-                        fh.write(str(outputpofile))
+                        fh.write(outputpofile.serialize())
 
 
 def main():

--- a/translate/tools/posegment.py
+++ b/translate/tools/posegment.py
@@ -80,7 +80,7 @@ def segmentfile(inputfile, outputfile, templatefile, sourcelanguage="en", target
     targetlang = lang_factory.getlanguage(targetlanguage)
     convertor = segment(sourcelang, targetlang, stripspaces=stripspaces, onlyaligned=onlyaligned)
     outputstore = convertor.convertstore(inputstore)
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return 1
 
 

--- a/translate/tools/poswap.py
+++ b/translate/tools/poswap.py
@@ -86,7 +86,7 @@ def convertpo(inputpofile, outputpotfile, template, reverse=False):
             unit.target = templateunit.target
         if unit.isobsolete():
             del inputpo.units[i]
-    outputpotfile.write(str(inputpo))
+    outputpotfile.write(inputpo.serialize())
     return 1
 
 

--- a/translate/tools/poterminology.py
+++ b/translate/tools/poterminology.py
@@ -450,7 +450,7 @@ class TerminologyOptionParser(optrecurse.RecursiveOptionParser):
         for count, unit in termitems:
             termfile.units.append(unit)
         with open(options.output, "wb") as fh:
-            fh.write(str(termfile))
+            fh.write(termfile.serialize())
 
 
 def fold_case_option(option, opt_str, value, parser):

--- a/translate/tools/pretranslate.py
+++ b/translate/tools/pretranslate.py
@@ -59,7 +59,7 @@ def pretranslate_file(input_file, output_file, template_file, tm=None,
 
     output = pretranslate_store(input_store, template_store, tm,
                                 min_similarity, fuzzymatching)
-    output_file.write(str(output))
+    output_file.write(output.serialize())
     return 1
 
 

--- a/translate/tools/pypo2phppo.py
+++ b/translate/tools/pypo2phppo.py
@@ -93,7 +93,7 @@ def convertpy2php(inputfile, outputfile, template=None):
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
         return False
-    outputfile.write(str(outputstore))
+    outputfile.write(outputstore.serialize())
     return True
 
 

--- a/translate/tools/test_podebug.py
+++ b/translate/tools/test_podebug.py
@@ -98,7 +98,7 @@ class TestPODebug:
 
         assert in_unit.source == out_unit.source
         print(out_unit.target)
-        print(str(po_out))
+        print(po_out.serialize())
         rewrite_func = self.debug.rewrite_unicode
         assert out_unit.target == u"%s%%s%s" % (rewrite_func(u'This is a '), rewrite_func(u' test, hooray.'))
 
@@ -111,7 +111,7 @@ class TestPODebug:
 
         assert in_unit.source == out_unit.source
         print(out_unit.target)
-        print(str(xliff_out))
+        print(xliff_out.serialize())
         assert out_unit.target == u'xxx%sxxx' % (in_unit.source)
 
     def test_hash(self):

--- a/translate/tools/test_pogrep.py
+++ b/translate/tools/test_pogrep.py
@@ -22,8 +22,8 @@ class TestPOGrep:
         options, args = pogrep.cmdlineparser().parse_args(["xxx.po"] + cmdlineoptions)
         grepfilter = pogrep.GrepFilter(searchstring, options.searchparts, options.ignorecase, options.useregexp, options.invertmatch, options.keeptranslations, options.accelchar)
         tofile = grepfilter.filterfile(self.poparse(posource))
-        print(str(tofile))
-        return str(tofile)
+        print(tofile.serialize())
+        return tofile.serialize()
 
     def test_simplegrep_msgid(self):
         """grep for a string in the source"""
@@ -151,7 +151,7 @@ class TestXLiffGrep:
         options, args = pogrep.cmdlineparser().parse_args(["xxx.xliff"] + cmdlineoptions)
         grepfilter = pogrep.GrepFilter(searchstring, options.searchparts, options.ignorecase, options.useregexp, options.invertmatch, options.accelchar)
         tofile = grepfilter.filterfile(self.xliff_parse(xliff_text))
-        return str(tofile)
+        return tofile.serialize()
 
     def test_simplegrep(self):
         """grep for a simple string."""

--- a/translate/tools/test_pomerge.py
+++ b/translate/tools/test_pomerge.py
@@ -152,7 +152,7 @@ msgstr "Dimpled Ring"'''
         expectedpo = '''#: location.c:1%slocation.c:2\nmsgid "Simple String"\nmsgstr "Dimpled Ring"\n''' % po.lsep
         pofile = self.mergestore(templatepo, inputpo)
         print(pofile)
-        assert str(pofile) == expectedpo
+        assert pofile.serialize() == expectedpo
 
     def test_unit_missing_in_template_with_locations(self):
         """If the unit is missing in the template we should raise an error"""
@@ -172,7 +172,7 @@ msgstr "Dimpled Ring"
 '''
         pofile = self.mergestore(templatepo, inputpo)
         print(pofile)
-        assert str(pofile) == expectedpo
+        assert pofile.serialize() == expectedpo
 
     def test_unit_missing_in_template_no_locations(self):
         """If the unit is missing in the template we should raise an error"""
@@ -188,7 +188,7 @@ msgstr "Dimpled Ring"
 '''
         pofile = self.mergestore(templatepo, inputpo)
         print(pofile)
-        assert str(pofile) == expectedpo
+        assert pofile.serialize() == expectedpo
 
     def test_reflowed_source_comments(self):
         """ensure that we don't duplicate source comments (locations) if they
@@ -199,7 +199,7 @@ msgstr "Dimpled Ring"
         pofile = self.mergestore(templatepo, newpo)
         pounit = self.singleunit(pofile)
         print(pofile)
-        assert str(pofile) == expectedpo
+        assert pofile.serialize() == expectedpo
 
     def test_comments_with_blank_lines(self):
         """ensure that we don't loose empty newlines in comments"""
@@ -215,7 +215,7 @@ msgstr "blabla"
         pofile = self.mergestore(templatepo, newpo)
         pounit = self.singleunit(pofile)
         print(pofile)
-        assert str(pofile) == expectedpo
+        assert pofile.serialize() == expectedpo
 
     def test_merge_dont_delete_unassociated_comments(self):
         """ensure that we do not delete comments in the PO file that are not
@@ -226,7 +226,7 @@ msgstr "blabla"
         pofile = self.mergestore(templatepo, mergepo)
 #        pounit = self.singleunit(pofile)
         print(pofile)
-        assert str(pofile) == expectedpo
+        assert pofile.serialize() == expectedpo
 
     def test_preserve_format_trailing_newlines(self):
         """Test that we can merge messages correctly that end with a newline"""
@@ -234,16 +234,16 @@ msgstr "blabla"
         mergepo = '''msgid "Simple string\\n"\nmsgstr "Dimpled ring\\n"\n'''
         expectedpo = '''msgid "Simple string\\n"\nmsgstr "Dimpled ring\\n"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
         templatepo = '''msgid ""\n"Simple string\\n"\nmsgstr ""\n'''
         mergepo = '''msgid ""\n"Simple string\\n"\nmsgstr ""\n"Dimpled ring\\n"\n'''
         expectedpo = '''msgid ""\n"Simple string\\n"\nmsgstr "Dimpled ring\\n"\n'''
         expectedpo2 = '''msgid "Simple string\\n"\nmsgstr "Dimpled ring\\n"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo or str(pofile) == expectedpo2
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo or pofile.serialize() == expectedpo2
 
     def test_preserve_format_minor_start_and_end_of_sentence_changes(self):
         """Test that we are not too fussy about large diffs for simple
@@ -252,22 +252,22 @@ msgstr "blabla"
         mergepo = '''msgid "Target type:"\nmsgstr "Doelsoort:"\n'''
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
         templatepo = '''msgid "&Select"\nmsgstr "Kies"\n\n'''
         mergepo = '''msgid "&Select"\nmsgstr "&Kies"\n'''
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
         templatepo = '''msgid "en-us, en"\nmsgstr "en-us, en"\n'''
         mergepo = '''msgid "en-us, en"\nmsgstr "af-za, af, en-za, en-gb, en-us, en"\n'''
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
     def test_preserve_format_last_entry_in_a_file(self):
         """The last entry in a PO file is usualy not followed by an empty
@@ -276,15 +276,15 @@ msgstr "blabla"
         mergepo = '''msgid "First"\nmsgstr "Eerste"\n\nmsgid "Second"\nmsgstr "Tweede"\n'''
         expectedpo = '''msgid "First"\nmsgstr "Eerste"\n\nmsgid "Second"\nmsgstr "Tweede"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
         templatepo = '''msgid "First"\nmsgstr ""\n\nmsgid "Second"\nmsgstr ""\n\n'''
         mergepo = '''msgid "First"\nmsgstr "Eerste"\n\nmsgid "Second"\nmsgstr "Tweede"\n'''
         expectedpo = '''msgid "First"\nmsgstr "Eerste"\n\nmsgid "Second"\nmsgstr "Tweede"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
     @mark.xfail(reason="Not Implemented")
     def test_escape_tabs(self):
@@ -298,8 +298,8 @@ msgstr "blabla"
 msgstr "Eerste\tTweede"
 '''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
     def test_preserve_comments_layout(self):
         """Ensure that when we merge with new '# (poconflict)' or other
@@ -308,8 +308,8 @@ msgstr "Eerste\tTweede"
         mergepo = '''# (pofilter) unchanged: please translate\n#: filename\nmsgid "Desktop Background.bmp"\nmsgstr "Desktop Background.bmp"\n'''
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
     def test_merge_dos2unix(self):
         """Test that merging a comment line with dos newlines doesn't add a
@@ -318,21 +318,21 @@ msgstr "Eerste\tTweede"
         mergepo = '''# User comment\r\n# (pofilter) Translate Toolkit comment\r\n#. Automatic comment\r\n#: location_comment.c:110\r\nmsgid "File"\r\nmsgstr "Ifayile"\r\n\r\n'''
         expectedpo = '''# User comment\n# (pofilter) Translate Toolkit comment\n#. Automatic comment\n#: location_comment.c:110\nmsgid "File"\nmsgstr "Ifayile"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        assert str(pofile) == expectedpo
+        assert pofile.serialize() == expectedpo
 
         # Unassociated comment
         templatepo = '''# Lonely comment\n\n#: location_comment.c:110\nmsgid "Bob"\nmsgstr "Toolmaker"\n'''
         mergepo = '''# Lonely comment\r\n\r\n#: location_comment.c:110\r\nmsgid "Bob"\r\nmsgstr "Builder"\r\n\r\n'''
         expectedpo = '''# Lonely comment\n#: location_comment.c:110\nmsgid "Bob"\nmsgstr "Builder"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        assert str(pofile) == expectedpo
+        assert pofile.serialize() == expectedpo
 
         # New comment
         templatepo = '''#: location_comment.c:110\nmsgid "File"\nmsgstr "File"\n\n'''
         mergepo = '''# User comment\r\n# (pofilter) Translate Toolkit comment\r\n#: location_comment.c:110\r\nmsgid "File"\r\nmsgstr "Ifayile"\r\n\r\n'''
         expectedpo = '''# User comment\n# (pofilter) Translate Toolkit comment\n#: location_comment.c:110\nmsgid "File"\nmsgstr "Ifayile"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        assert str(pofile) == expectedpo
+        assert pofile.serialize() == expectedpo
 
     def test_xliff_into_xliff(self):
         templatexliff = self.xliffskeleton % '''<trans-unit>
@@ -369,7 +369,7 @@ msgstr "Eerste\tTweede"
 </trans-unit>'''
         expectedpo = '# my comment\nmsgid "red"\nmsgstr "rooi"\n'
         pofile = self.mergestore(templatepo, mergexliff)
-        assert str(pofile) == expectedpo
+        assert pofile.serialize() == expectedpo
 
     def test_merging_dont_merge_kde_comments_found_in_translation(self):
         """If we find a KDE comment in the translation (target) then do not
@@ -379,21 +379,21 @@ msgstr "Eerste\tTweede"
         mergepo = '''msgid "_: KDE comment\\n"\n"File"\nmsgstr "_: KDE comment\\n"\n"Ifayile"\n\n'''
         expectedpo = '''msgid ""\n"_: KDE comment\\n"\n"File"\nmsgstr "Ifayile"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
         # Translated kde comment.
         mergepo = '''msgid "_: KDE comment\\n"\n"File"\nmsgstr "_: KDE kommentaar\\n"\n"Ifayile"\n\n'''
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
         # multiline KDE comment
         templatepo = '''msgid "_: KDE "\n"comment\\n"\n"File"\nmsgstr "File"\n\n'''
         mergepo = '''msgid "_: KDE "\n"comment\\n"\n"File"\nmsgstr "_: KDE "\n"comment\\n"\n"Ifayile"\n\n'''
         expectedpo = '''msgid ""\n"_: KDE comment\\n"\n"File"\nmsgstr "Ifayile"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
     def test_merging_untranslated_with_kde_disambiguation(self):
         """test merging untranslated messages that are the same except for
@@ -424,8 +424,8 @@ msgstr "Stuur"
 ''' % (po.lsep, po.lsep)
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
     def test_merging_header_entries(self):
         """Check that we do the right thing if we have header entries in the
@@ -487,8 +487,8 @@ msgid "Simple String"
 msgstr "Dimpled Ring"
 '''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo
+        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo
 
     def test_merging_different_locations(self):
         """Test when merging units that are unchanged except for changed
@@ -544,5 +544,5 @@ msgstr "ZERSTÖRE WACHPOSTEN"
 
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, str(pofile)))
-        assert str(pofile) == expectedpo or str(pofile) == expectedpo2
+        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, pofile.serialize()))
+        assert pofile.serialize() == expectedpo or pofile.serialize() == expectedpo2

--- a/translate/tools/test_pretranslate.py
+++ b/translate/tools/test_pretranslate.py
@@ -121,8 +121,8 @@ msgstr[1] "%d handleidings."
         template_source = '''#: simple.label\n#: simple.accesskey\nmsgid "A &hard coded newline.\\n"\nmsgstr "&Hart gekoeerde nuwe lyne\\n"\n'''
         poexpected = '''#: simple.label\n#: simple.accesskey\n#, fuzzy\nmsgid "Its &hard coding a newline.\\n"\nmsgstr "&Hart gekoeerde nuwe lyne\\n"\n'''
         newpo = self.pretranslatepo(input_source, template_source)
-        print(newpo)
-        assert str(newpo) == poexpected
+        print(newpo.serialize())
+        assert newpo.serialize() == poexpected
 
     def test_merging_location_change(self):
         """tests that if the location changes but the msgid stays the same that
@@ -131,8 +131,8 @@ msgstr[1] "%d handleidings."
         template_source = '''#: simple.label%ssimple.accesskey\nmsgid "A &hard coded newline.\\n"\nmsgstr "&Hart gekoeerde nuwe lyne\\n"\n''' % po.lsep
         poexpected = '''#: new_simple.label%snew_simple.accesskey\nmsgid "A &hard coded newline.\\n"\nmsgstr "&Hart gekoeerde nuwe lyne\\n"\n''' % po.lsep
         newpo = self.pretranslatepo(input_source, template_source)
-        print(newpo)
-        assert str(newpo) == poexpected
+        print(newpo.serialize())
+        assert newpo.serialize() == poexpected
 
     def test_merging_location_and_whitespace_change(self):
         """test that even if the location changes that if the msgid only has
@@ -141,8 +141,8 @@ msgstr[1] "%d handleidings."
         template_source = '''#: doublespace.label%sdoublespace.accesskey\nmsgid "&We  have  spaces"\nmsgstr "&One  het  spasies"\n''' % po.lsep
         poexpected = '''#: singlespace.label%ssinglespace.accesskey\n#, fuzzy\nmsgid "&We have spaces"\nmsgstr "&One  het  spasies"\n''' % po.lsep
         newpo = self.pretranslatepo(input_source, template_source)
-        print(newpo)
-        assert str(newpo) == poexpected
+        print(newpo.serialize())
+        assert newpo.serialize() == poexpected
 
     @mark.xfail(reason="Not Implemented")
     def test_merging_accelerator_changes(self):
@@ -152,8 +152,8 @@ msgstr[1] "%d handleidings."
         template_source = '''#: someline.c\nmsgid "&About"\nmsgstr "&Info"\n'''
         poexpected = '''#: someline.c\nmsgid "A&bout"\nmsgstr "&Info"\n'''
         newpo = self.pretranslatepo(input_source, template_source)
-        print(newpo)
-        assert str(newpo) == poexpected
+        print(newpo.serialize())
+        assert newpo.serialize() == poexpected
 
     @mark.xfail(reason="Not Implemented")
     def test_lines_cut_differently(self):
@@ -248,8 +248,8 @@ msgstr "36em"
         template_source = '''#~ msgid "&About"\n#~ msgstr "&Omtrent"\n'''
         expected = '''#: resurect.c\nmsgid "&About"\nmsgstr "&Omtrent"\n'''
         newpo = self.pretranslatepo(input_source, template_source)
-        print(newpo)
-        assert str(newpo) == expected
+        print(newpo.serialize())
+        assert newpo.serialize() == expected
 
     def test_merging_comments(self):
         """Test that we can merge comments correctly"""
@@ -294,9 +294,9 @@ msgstr "36em"
         template = xliff.xlifffile.parsestring(xlf_template)
         old = xliff.xlifffile.parsestring(xlf_old)
         new = self.pretranslatexliff(template, old)
-        print(str(old))
+        print(old.serialize())
         print('---')
-        print(str(new))
+        print(new.serialize())
         assert new.units[0].isapproved()
         # Layout might have changed, so we won't compare the serialised
         # versions


### PR DESCRIPTION
Before going further in this patch, I'd like to get your opinion on it. On Python 3, str(obj) cannot return bytes, so we have to do something at least. The "minimal" way could have been to replace __str__ by __bytes__, and then calling bytes(store). However, I think it would be clearer if we added a specific API (like serialize(), but could be another term) to serialize a store to a file. This is also easier if we have to pass arguments at some point, because adding arguments to Python magic methods is not very clean. Note that I still kept the serialization behavior of str(store) for Python 2, to not break compatibility if external tools count on it. The test suite still passes after the first commit. Not sure if this is worthy or not.

I'm waiting on your input before going further.