### PR TITLE
py3: don't install deps that are only py2 compatible

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -4,8 +4,8 @@
 # Format support #
 ##################
 BeautifulSoup4>=4.3  # Trados TM
-iniparse>=0.3.1      # INI (ini2po)
-vobject>=0.6.6       # iCal (ical2po)
+iniparse>=0.3.1 ;python_version < '3.0'      # INI (ini2po)
+vobject>=0.6.6 ;python_version < '3.0'       # iCal (ical2po)
 
 #aeidon>=0.14        # Subtitles (sub2po)
 # aeidon not available through pip/PyPI,


### PR DESCRIPTION
iniparse and vobject are not Python 3 ready.  So only install them if
we're in a Python 2 environment.

I haven't done anything in terms of not installing ini2po or ical2po on py3 or bailing early if the deps don't exist.  But just wanted to get some thoughts on using the new pip syntax to install these deps only on py2