### PR TITLE
Provided proper text param for dbapi2.connect

### DIFF
--- a/translate/storage/statsdb.py
+++ b/translate/storage/statsdb.py
@@ -297,7 +297,7 @@ class StatsCache(object):
 
             def connect(cache):
                 # sqlite needs to get the name in utf-8 on all platforms
-                cache.con = dbapi2.connect(statsfile.encode('utf-8'))
+                cache.con = dbapi2.connect(statsfile.encode('utf-8') if six.PY2 else statsfile)
                 cache.cur = cache.con.cursor()
 
             def clear_old_data(cache):

--- a/translate/storage/tmdb.py
+++ b/translate/storage/tmdb.py
@@ -75,7 +75,7 @@ class TMDB(object):
     def _get_connection(self, index):
         current_thread = threading.currentThread()
         if current_thread not in self._tm_db:
-            connection = dbapi2.connect(self.db_file.encode('utf-8'))
+            connection = dbapi2.connect(self.db_file.encode('utf-8') if six.PY2 else self.db_file)
             cursor = connection.cursor()
             self._tm_db[current_thread] = (connection, cursor)
         return self._tm_db[current_thread][index]


### PR DESCRIPTION
dbapi2.connect accepts bytestring param on Python 2, but text
param on Python 3.