### PR TITLE
Reopen file with open instead of a class constructor

### DIFF
--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -811,7 +811,7 @@ class TranslationStore(object):
                                getattr(fileobj, "filename", None))
             if not filename:
                 raise ValueError("No file or filename to save to")
-            fileobj = fileobj.__class__(filename, 'wb')
+            fileobj = open(filename, 'wb')
         self.savefile(fileobj)
 
     @classmethod


### PR DESCRIPTION
Python 3 doesn't seem to like opening files with the file
class. Let's stick to the classical open().