### PR TITLE
Accept unicode input for parsestring

### DIFF
--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -753,6 +753,9 @@ class TranslationStore(object):
         """Convert the string representation back to an object."""
         newstore = cls()
         if storestring:
+            if isinstance(storestring, six.text_type):
+                # parse() is expecting bytes
+                storestring = storestring.encode(cls.default_encoding)
             newstore.parse(storestring)
         return newstore
 


### PR DESCRIPTION
As text (unicode) becomes ubuquitous on Python 3, it is easier
to just accept and transform any text content to bytes in parsetring
before feeding parse() with it.