### PR TITLE
Improved encoding detection

### DIFF
--- a/requirements/recommended.txt
+++ b/requirements/recommended.txt
@@ -8,3 +8,6 @@ lxml>=2.3.6
 # Faster matching in e.g. pot2po
 # 0.11.0 is broken using pip, later versions are fixed
 python-Levenshtein>=0.10.2,!=0.11.0
+
+# Encoding detection
+chardet

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -764,7 +764,6 @@ class TranslationStore(object):
                 if encoding not in encodings:
                     encodings.append(encoding)
         else:
-            encodings.append(self.encoding)
             if (detected_encoding and
                     detected_encoding['encoding'] != self.encoding and
                     detected_encoding['confidence'] != 1.0):

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -766,8 +766,7 @@ class TranslationStore(object):
                 if encoding not in encodings:
                     encodings.append(encoding)
         elif detected_encoding:
-            if (detected_encoding['encoding'] != self.encoding and
-                    detected_encoding['confidence'] != 1.0):
+            if detected_encoding['encoding'] != self.encoding:
                 logging.warn("trying to parse %s with encoding: %s but "
                              "detected encoding is %s (confidence: %s)",
                              self.filename, self.encoding,

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -765,15 +765,16 @@ class TranslationStore(object):
             for encoding in default_encodings:
                 if encoding not in encodings:
                     encodings.append(encoding)
-        else:
-            if (detected_encoding and
-                    detected_encoding['encoding'] != self.encoding and
+        elif detected_encoding:
+            if (detected_encoding['encoding'] != self.encoding and
                     detected_encoding['confidence'] != 1.0):
                 logging.warn("trying to parse %s with encoding: %s but "
                              "detected encoding is %s (confidence: %s)",
                              self.filename, self.encoding,
                              detected_encoding['encoding'],
                              detected_encoding['confidence'])
+            encodings.append(self.encoding)
+        else:
             encodings.append(self.encoding)
 
         for encoding in encodings:

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -766,7 +766,16 @@ class TranslationStore(object):
                 if encoding not in encodings:
                     encodings.append(encoding)
         elif detected_encoding:
-            if detected_encoding['encoding'] != self.encoding:
+            if '-' in detected_encoding['encoding']:
+                encoding, suffix = detected_encoding['encoding'].rsplit('-', 1)
+            else:
+                encoding = detected_encoding['encoding']
+                suffix = None
+
+            # Different charset, just with BOM
+            if encoding == self.encoding and suffix == 'sig':
+                encodings.append(detected_encoding['encoding'])
+            elif detected_encoding['encoding'] != self.encoding:
                 logging.warn("trying to parse %s with encoding: %s but "
                              "detected encoding is %s (confidence: %s)",
                              self.filename, self.encoding,

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -751,7 +751,7 @@ class TranslationStore(object):
             if detected_encoding['confidence'] < 0.48:
                 detected_encoding = None
             elif detected_encoding['encoding'] == 'ascii':
-                detected_encoding['encoding'] = 'utf-8'
+                detected_encoding['encoding'] = self.encoding
             else:
                 detected_encoding['encoding'] = detected_encoding['encoding'].lower()
         except ImportError:

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -752,6 +752,8 @@ class TranslationStore(object):
                 detected_encoding = None
             elif detected_encoding['encoding'] == 'ascii':
                 detected_encoding['encoding'] = 'utf-8'
+            else:
+                detected_encoding['encoding'] = detected_encoding['encoding'].lower()
         except ImportError:
             detected_encoding = None
 

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -372,3 +372,13 @@ key=value
         propsource = u"key = ąćęłńóśźż".encode("cp1250")
         with raises(IOError):
             self.propparse(propsource, personality="strings")
+
+    def test_utf8_byte_order_mark(self):
+        """test that BOM handling works fine with newlines"""
+        propsource = u"\n\n\nkey1 = value1\n\nkey2 = value2\n".encode('utf-8-sig')
+        propfile = self.propparse(propsource, personality='java-utf8')
+        bom = propsource[:3]
+        result = propfile.serialize()
+        assert result.startswith(bom)
+        assert bom not in result[3:]
+        assert 'None' not in result[3:]


### PR DESCRIPTION
This series of patches fixes handling of unicode files with BOM with defined encoding. Eg. UTF-8 Java properties specify utf-8 encoding, but if the file has BOM, the BOM bytes are currently wrongly parsed as content of first unit.

Changes made to encoding detection:

- converts detected encoding to lower case as that's what is used in rest of the sources (so that we can actually compare these strings)
- removes double adding of `self.encoding` to list of detected encodings
- adds the BOM variant of the encoding if it has been detected
- brings back wrong encoding warning for confidence = 1.0 (because I've misunderstood surrounding code in #67)
- avoids detecting ascii text as utf-8 if it is expected to be iso-8859-1
- added basic unicode detection even without chardet