### PR TITLE
Fixed compiling all code on Python 3

### DIFF
--- a/translate/misc/wsgiserver/ssl_pyopenssl.py
+++ b/translate/misc/wsgiserver/ssl_pyopenssl.py
@@ -67,7 +67,7 @@ class SSL_fileobject(wsgiserver.CP_fileobject):
                 time.sleep(self.ssl_retry)
             except SSL.WantWriteError:
                 time.sleep(self.ssl_retry)
-            except SSL.SysCallError, e:
+            except SSL.SysCallError as e:
                 if is_reader and e.args == (-1, 'Unexpected EOF'):
                     return ""
 
@@ -75,7 +75,7 @@ class SSL_fileobject(wsgiserver.CP_fileobject):
                 if is_reader and errnum in wsgiserver.socket_errors_to_ignore:
                     return ""
                 raise socket.error(errnum)
-            except SSL.Error, e:
+            except SSL.Error as e:
                 if is_reader and e.args == (-1, 'Unexpected EOF'):
                     return ""
 

--- a/translate/misc/wsgiserver/wsgiserver2.py
+++ b/translate/misc/wsgiserver/wsgiserver2.py
@@ -84,6 +84,7 @@ except:
     import Queue as queue
 import re
 import rfc822
+import six
 import socket
 import sys
 if 'win' in sys.platform and not hasattr(socket, 'IPPROTO_IPV6'):
@@ -969,7 +970,7 @@ class CP_fileobject(socket._fileobject):
             try:
                 bytes_sent = self.send(data)
                 data = data[bytes_sent:]
-            except socket.error, e:
+            except socket.error as e:
                 if e.args[0] not in socket_errors_nonblocking:
                     raise
 
@@ -990,7 +991,7 @@ class CP_fileobject(socket._fileobject):
                 data = self._sock.recv(size)
                 self.bytes_read += len(data)
                 return data
-            except socket.error, e:
+            except socket.error as e:
                 if (e.args[0] not in socket_errors_nonblocking
                     and e.args[0] not in socket_error_eintr):
                     raise
@@ -2163,7 +2164,7 @@ class WSGIGateway(Gateway):
         # exc_info tuple."
         if self.req.sent_headers:
             try:
-                raise exc_info[0], exc_info[1], exc_info[2]
+                six.reraise(exc_info[0], exc_info[1], exc_info[2])
             finally:
                 exc_info = None
 

--- a/translate/search/indexing/XapianIndexer.py
+++ b/translate/search/indexing/XapianIndexer.py
@@ -488,7 +488,7 @@ def _truncate_term_length(term, taken=0):
         return term
 
 
-def _extract_fieldvalues(match, (result, fieldnames)):
+def _extract_fieldvalues(match, result_and_fieldnames):
     """Add a dict of field values to a list.
 
     Usually this function should be used together with :func:`_walk_matches`
@@ -501,6 +501,7 @@ def _extract_fieldvalues(match, (result, fieldnames)):
     :param fieldnames: the names of the fields to be added to the dict
     :type fieldnames: list of str
     """
+    result, fieldnames = result_and_fieldnames
     # prepare empty dict
     item_fields = {}
     # fill the dict


### PR DESCRIPTION
Even if some files might not be used with Python 3, the
'python -m compileall' command may choke on syntax issues.