### PR TITLE
Write to output directly inside file.serialize()

### DIFF
--- a/docs/formats/base_classes.rst
+++ b/docs/formats/base_classes.rst
@@ -158,12 +158,12 @@ what we discussed is related to the above.  A quick summary:
     of duplicate code in them). Ideally conversion should be as simple as::
 
       >>> po_store = POStore(filecontent)
-      >>> print(po_store.serialize())
+      >>> print(bytes(po_store))
       msgid "bleep"
       msgstr "blorp"
        
       >>> xliff_store = XliffStore(po_store)
-      >>> print(xliff_store.serialize())
+      >>> print(bytes(xliff_store))
       <xliff>
         <file>
           <trans-unit>

--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -42,12 +42,17 @@ Formats and Converters
    - keys can contain delimiters if they are properly wrapped (:issue:`3275`).
 
 
-Dropped deprecated API
-----------------------
+API deprecation
+---------------
 
 - The deprecated ``translate.storage.properties.find_delimiter()`` was removed
   and replace by the ``translate.storage.properties.Dialect.find_delimiter()``
   class method.
+
+- ``TxtFile.getoutput()`` and ``dtdfile.getoutput()`` have been deprecated.
+  Either call ``bytes(<file_instance>)`` or use the
+  ``file_instance.serialize()`` API if you need to get the serialized store
+  content of a ``TxtFile`` or ``dtdfile`` instance.
 
 
 General

--- a/tests/odf_xliff/test_odf_xliff.py
+++ b/tests/odf_xliff/test_odf_xliff.py
@@ -62,7 +62,7 @@ xliff.xlifffile.__eq__ = xliff___eq__
 
 
 def print_diff(store1, store2):
-    for line in difflib.unified_diff(store1.serialize().split(b'\n'), store2.serialize().split(b'\n')):
+    for line in difflib.unified_diff(bytes(store1).split(b'\n'), bytes(store2).split(b'\n')):
         print(line)
 
 SOURCE_ODF = u'test_2.odt'

--- a/translate/convert/csv2po.py
+++ b/translate/convert/csv2po.py
@@ -220,7 +220,7 @@ def convertcsv(inputfile, outputfile, templatefile, charset=None,
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
         return 0
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/csv2tbx.py
+++ b/translate/convert/csv2tbx.py
@@ -66,7 +66,7 @@ def convertcsv(inputfile, outputfile, templatefile, charset=None,
     outputstore = convertor.convertfile(inputstore)
     if len(outputstore.units) == 0:
         return 0
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/dtd2po.py
+++ b/translate/convert/dtd2po.py
@@ -299,7 +299,7 @@ def convertdtd(inputfile, outputfile, templatefile, pot=False,
         outputstore = convertor.mergestore(templatestore, inputstore)
     if outputstore.isempty():
         return 0
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/html2po.py
+++ b/translate/convert/html2po.py
@@ -55,7 +55,7 @@ def converthtml(inputfile, outputfile, templates, includeuntagged=False,
                                         includeuntagged,
                                         duplicatestyle=duplicatestyle,
                                         keepcomments=keepcomments)
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/ical2po.py
+++ b/translate/convert/ical2po.py
@@ -100,7 +100,7 @@ def convertical(input_file, output_file, template_file, pot=False, duplicatestyl
         output_store = convertor.merge_store(template_store, input_store, blankmsgstr=pot, duplicatestyle=duplicatestyle)
     if output_store.isempty():
         return 0
-    output_file.write(output_store.serialize())
+    output_store.serialize(output_file)
     return 1
 
 

--- a/translate/convert/ini2po.py
+++ b/translate/convert/ini2po.py
@@ -111,7 +111,7 @@ def convertini(input_file, output_file, template_file, pot=False,
                                              duplicatestyle=duplicatestyle)
     if output_store.isempty():
         return 0
-    output_file.write(output_store.serialize())
+    output_store.serialize(output_file)
     return 1
 
 

--- a/translate/convert/json2po.py
+++ b/translate/convert/json2po.py
@@ -112,7 +112,7 @@ def convertjson(input_file, output_file, template_file, pot=False,
                                              duplicatestyle=duplicatestyle)
     if output_store.isempty():
         return 0
-    output_file.write(output_store.serialize())
+    output_store.serialize(output_file)
     return 1
 
 

--- a/translate/convert/mozlang2po.py
+++ b/translate/convert/mozlang2po.py
@@ -62,7 +62,7 @@ def convertlang(inputfile, outputfile, templates, pot=False,
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
         return 0
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/oo2po.py
+++ b/translate/convert/oo2po.py
@@ -156,7 +156,7 @@ def convertoo(inputfile, outputfile, templates, pot=False, sourcelanguage=None, 
     outputstore = convertor.convertstore(inputstore, duplicatestyle)
     if outputstore.isempty():
         return 0
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/oo2xliff.py
+++ b/translate/convert/oo2xliff.py
@@ -154,7 +154,7 @@ def convertoo(inputfile, outputfile, templates, pot=False, sourcelanguage=None, 
     outputstore = convertor.convertstore(inputstore, duplicatestyle)
     if outputstore.isempty():
         return 0
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/php2po.py
+++ b/translate/convert/php2po.py
@@ -108,7 +108,7 @@ def convertphp(inputfile, outputfile, templatefile, pot=False,
                                            duplicatestyle=duplicatestyle)
     if outputstore.isempty():
         return 0
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/po2csv.py
+++ b/translate/convert/po2csv.py
@@ -85,7 +85,7 @@ def convertcsv(inputfile, outputfile, templatefile, columnorder=None):
         return 0
     convertor = po2csv()
     outputstore = convertor.convertstore(inputstore, columnorder)
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/po2dtd.py
+++ b/translate/convert/po2dtd.py
@@ -187,7 +187,7 @@ def convertdtd(inputfile, outputfile, templatefile, includefuzzy=False,
         convertor = redtd(templatestore, android=android_dtd,
                           remove_untranslated=remove_untranslated)
     outputstore = convertor.convertstore(inputstore, includefuzzy)
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/po2ical.py
+++ b/translate/convert/po2ical.py
@@ -48,7 +48,7 @@ class reical:
                         unit.target = inputunit.target
                 else:
                     unit.target = unit.source
-        return self.templatestore.serialize()
+        return bytes(self.templatestore)
 
 
 def convertical(inputfile, outputfile, templatefile, includefuzzy=False,

--- a/translate/convert/po2ini.py
+++ b/translate/convert/po2ini.py
@@ -49,7 +49,7 @@ class reini:
                         unit.target = inputunit.target
                 else:
                     unit.target = unit.source
-        return self.templatestore.serialize()
+        return bytes(self.templatestore)
 
 
 def convertini(inputfile, outputfile, templatefile, includefuzzy=False,

--- a/translate/convert/po2json.py
+++ b/translate/convert/po2json.py
@@ -47,7 +47,7 @@ class rejson:
                     unit.target = inputunit.target
             else:
                 unit.target = unit.source
-        return self.templatestore.serialize()
+        return bytes(self.templatestore)
 
 
 def convertjson(inputfile, outputfile, templatefile, includefuzzy=False,

--- a/translate/convert/po2mozlang.py
+++ b/translate/convert/po2mozlang.py
@@ -66,7 +66,7 @@ def convertlang(inputfile, outputfile, templates, includefuzzy=False, mark_activ
 
     convertor = po2lang(mark_active=mark_active)
     outputstore = convertor.convertstore(inputstore, includefuzzy)
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return True
 
 

--- a/translate/convert/po2oo.py
+++ b/translate/convert/po2oo.py
@@ -216,7 +216,7 @@ def convertoo(inputfile, outputfile, templatefile, sourcelanguage=None,
                          filteraction=filteraction)
     outputstore = convertor.convertstore(inputstore)
     # TODO: check if we need to manually delete missing items
-    outputfile.write(outputstore.serialize(skip_source, targetlanguage))
+    outputstore.serialize(outputfile, skip_source, targetlanguage)
     return True
 
 

--- a/translate/convert/po2resx.py
+++ b/translate/convert/po2resx.py
@@ -53,7 +53,7 @@ class po2resx:
             if inputunit is not None:
                 self.addcomments(inputunit, unit)
 
-        return self.templatestore.serialize()
+        return bytes(self.templatestore)
 
     def addcomments(self, inputunit, unit):
         comments = []

--- a/translate/convert/po2sub.py
+++ b/translate/convert/po2sub.py
@@ -49,7 +49,7 @@ class resub:
                         unit.target = inputunit.target
                 else:
                     unit.target = unit.source
-        return self.templatestore.serialize()
+        return bytes(self.templatestore)
 
 
 def convertsub(inputfile, outputfile, templatefile, includefuzzy=False,

--- a/translate/convert/po2tiki.py
+++ b/translate/convert/po2tiki.py
@@ -65,7 +65,7 @@ def convertpo(inputfile, outputfile, template=None):
         return False
     convertor = po2tiki()
     outputstore = convertor.convertstore(inputstore)
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return True
 
 

--- a/translate/convert/po2tmx.py
+++ b/translate/convert/po2tmx.py
@@ -109,7 +109,7 @@ class TmxOptionParser(convert.ArchiveConvertOptionParser):
         super(TmxOptionParser, self).recursiveprocess(options)
         with open(options.output, 'wb') as self.output:
             options.outputarchive.tmxfile.setsourcelanguage(options.sourcelanguage)
-            self.output.write(options.outputarchive.tmxfile.serialize())
+            options.outputarchive.tmxfile.serialize(self.output)
 
 
 def main(argv=None):

--- a/translate/convert/po2wordfast.py
+++ b/translate/convert/po2wordfast.py
@@ -87,7 +87,7 @@ class WfOptionParser(convert.ArchiveConvertOptionParser):
         super(WfOptionParser, self).recursiveprocess(options)
         with open(options.output, 'wb') as self.output:
             #options.outputarchive.wffile.setsourcelanguage(options.sourcelanguage)
-            self.output.write(options.outputarchive.wffile.serialize())
+            options.outputarchive.wffile.serialize(self.output)
 
 
 def main(argv=None):

--- a/translate/convert/po2xliff.py
+++ b/translate/convert/po2xliff.py
@@ -87,7 +87,7 @@ class po2xliff:
             if inputunit.isblank():
                 continue
             transunitnode = self.convertunit(outputstore, inputunit, filename)
-        return outputstore.serialize()
+        return bytes(outputstore)
 
 
 def convertpo(inputfile, outputfile, templatefile):

--- a/translate/convert/poreplace.py
+++ b/translate/convert/poreplace.py
@@ -47,7 +47,7 @@ class poreplace:
         outputstore = self.convertfile(inputstore)
         if outputstore.isempty():
             return 0
-        outputfile.write(outputstore.serialize())
+        outputstore.serialize(outputfile)
         return 1
 
 

--- a/translate/convert/pot2po.py
+++ b/translate/convert/pot2po.py
@@ -52,7 +52,7 @@ def convertpot(input_file, output_file, template_file, tm=None,
 
     output_store = convert_stores(input_store, template_store, temp_store, tm,
                                   min_similarity, fuzzymatching, **kwargs)
-    output_file.write(output_store.serialize())
+    output_store.serialize(output_file)
 
     return 1
 

--- a/translate/convert/prop2po.py
+++ b/translate/convert/prop2po.py
@@ -319,7 +319,7 @@ def convertprop(inputfile, outputfile, templatefile, personality="java",
         outputstore = convertor.mergestore(templatestore, inputstore)
     if outputstore.isempty():
         return 0
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/rc2po.py
+++ b/translate/convert/rc2po.py
@@ -103,7 +103,7 @@ def convertrc(input_file, output_file, template_file, pot=False, duplicatestyle=
         output_store = convertor.merge_store(template_store, input_store, blankmsgstr=pot, duplicatestyle=duplicatestyle)
     if output_store.isempty():
         return 0
-    output_file.write(output_store.serialize())
+    output_store.serialize(output_file)
     return 1
 
 

--- a/translate/convert/resx2po.py
+++ b/translate/convert/resx2po.py
@@ -131,7 +131,7 @@ def convert_resx(input_file, output_file, template_file, pot=False, duplicatesty
                                              duplicatestyle=duplicatestyle)
     if output_store.isempty():
         return 0
-    output_file.write(output_store.serialize())
+    output_store.serialize(output_file)
     return 1
 
 

--- a/translate/convert/sub2po.py
+++ b/translate/convert/sub2po.py
@@ -108,7 +108,7 @@ def convertsub(input_file, output_file, template_file=None, pot=False,
                                    duplicatestyle=duplicatestyle)
     if output_store.isempty():
         return 0
-    output_file.write(output_store.serialize())
+    output_store.serialize(output_file)
     return 1
 
 

--- a/translate/convert/symb2po.py
+++ b/translate/convert/symb2po.py
@@ -104,7 +104,7 @@ def convert_symbian(input_file, output_file, template_file, pot=False, duplicate
     if output_store.isempty():
         return 0
     else:
-        output_file.write(output_store.serialize())
+        output_store.serialize(output_file)
         return 1
 
 

--- a/translate/convert/test_csv2po.py
+++ b/translate/convert/test_csv2po.py
@@ -28,7 +28,7 @@ class TestCSV2PO:
 
     def singleelement(self, storage):
         """checks that the pofile contains a single non-header element, and returns it"""
-        print(storage.serialize())
+        print(bytes(storage))
         assert headerless_len(storage.units) == 1
         return first_translatable(storage)
 
@@ -88,12 +88,12 @@ wat lank aanhou"
 ,"Use \"".","Gebruik \""."'''
         print(minicsv)
         csvfile = csvl10n.csvfile(wStringIO.StringIO(minicsv))
-        print(csvfile.serialize())
+        print(bytes(csvfile))
         pofile = self.csv2po(minicsv)
         unit = first_translatable(pofile)
         assert unit.source == 'Hello "Everyone"'
         assert pofile.findunit('Hello "Everyone"').target == 'Good day "All"'
-        print(pofile.serialize())
+        print(bytes(pofile))
         for unit in pofile.units:
             print(unit.source)
             print(unit.target)

--- a/translate/convert/test_dtd2po.py
+++ b/translate/convert/test_dtd2po.py
@@ -120,7 +120,7 @@ class TestDTD2PO:
 <!ENTITY alwaysCheckDefault.height  "3em">
 '''
         pofile = self.dtd2po(dtdsource)
-        posource = pofile.serialize().decode('utf-8')
+        posource = bytes(pofile).decode('utf-8')
         print(posource)
         assert posource.count('#.') == 5  # 1 Header extracted from, 3 comment lines, 1 autoinserted comment
 
@@ -155,7 +155,7 @@ class TestDTD2PO:
         dtdsource = '<!--LOCALIZATION NOTE (editorCheck.label): DONT_TRANSLATE -->\n' + \
             '<!ENTITY editorCheck.label "Composer">\n<!ENTITY editorCheck.accesskey "c">\n'
         pofile = self.dtd2po(dtdsource)
-        posource = pofile.serialize().decode('utf-8')
+        posource = bytes(pofile).decode('utf-8')
         # we need to decided what we're going to do here - see the comments in bug 30
         # this tests the current implementation which is that the DONT_TRANSLATE string is removed, but the other remains
         assert 'editorCheck.label' not in posource

--- a/translate/convert/test_html2po.py
+++ b/translate/convert/test_html2po.py
@@ -365,7 +365,7 @@ years has helped to bridge the digital divide to a limited extent.</p> \r
         # Translate and convert back:
         pofile.units[2].target = 'Projekte'
         pofile.units[3].target = 'Tuisblad'
-        htmlresult = self.po2html(pofile.serialize(), htmlsource).replace('\n', ' ').replace('= "', '="').replace('> <', '><')
+        htmlresult = self.po2html(bytes(pofile), htmlsource).replace('\n', ' ').replace('= "', '="').replace('> <', '><')
         snippet = '<td width="96%"><strong><font class="headingwhite">Projekte</font></strong></td>'
         assert snippet in htmlresult
         snippet = '<td width="96%"><a href="index.html">Tuisblad</a></td>'

--- a/translate/convert/test_json2po.py
+++ b/translate/convert/test_json2po.py
@@ -15,7 +15,7 @@ class TestJson2PO:
 
     def singleelement(self, storage):
         """checks that the pofile contains a single non-header element, and returns it"""
-        print(storage.serialize())
+        print(bytes(storage))
         assert len(storage.units) == 1
         return storage.units[0]
 

--- a/translate/convert/test_php2po.py
+++ b/translate/convert/test_php2po.py
@@ -93,7 +93,7 @@ $lang['prefPanel-smime'] = 'Security';'''
         pounit = self.singleelement(pofile)
         assert pounit.getlocations() == ["$lang['credit']"]
         assert pounit.getcontext() == "$lang['credit']"
-        assert b"#. /* comment" in pofile.serialize()
+        assert b"#. /* comment" in bytes(pofile)
         assert pounit.source == ""
 
     def test_hash_comment_with_equals(self):
@@ -102,7 +102,7 @@ $lang['prefPanel-smime'] = 'Security';'''
         pofile = self.php2po(phpsource)
         pounit = self.singleelement(pofile)
         assert pounit.getlocations() == ["$variable"]
-        assert b"#. # inside alt= stuffies" in pofile.serialize()
+        assert b"#. # inside alt= stuffies" in bytes(pofile)
         assert pounit.source == "stringy"
 
     def test_emptyentry_translated(self):

--- a/translate/convert/test_po2csv.py
+++ b/translate/convert/test_po2csv.py
@@ -63,7 +63,7 @@ msgstr "Eerste lyn\nTweede lyn"
         unit = self.singleelement(csvfile)
         assert unit.source == "First line\nSecond line"
         assert unit.target == "Eerste lyn\nTweede lyn"
-        pofile = self.csv2po(csvfile.serialize())
+        pofile = self.csv2po(bytes(csvfile))
         unit = self.singleelement(pofile)
         assert unit.source == "First line\nSecond line"
         assert unit.target == "Eerste lyn\nTweede lyn"
@@ -105,12 +105,12 @@ msgstr "Vind\\Opsies"
         """Tests that single quotes are preserved correctly"""
         minipo = '''msgid "source 'source'"\nmsgstr "target 'target'"\n'''
         csvfile = self.po2csv(minipo)
-        print(csvfile.serialize())
+        print(bytes(csvfile))
         assert csvfile.findunit("source 'source'").target == "target 'target'"
         # Make sure we don't mess with start quotes until writing
         minipo = '''msgid "'source'"\nmsgstr "'target'"\n'''
         csvfile = self.po2csv(minipo)
-        print(csvfile.serialize())
+        print(bytes(csvfile))
         assert csvfile.findunit(r"'source'").target == r"'target'"
         # TODO check that we escape on writing not in the internal representation
 

--- a/translate/convert/test_po2dtd.py
+++ b/translate/convert/test_po2dtd.py
@@ -90,14 +90,14 @@ class TestPO2DTD:
         """tests that po lines are joined seamlessly (bug 16)"""
         multilinepo = '''#: pref.menuPath\nmsgid ""\n"<span>Tools &gt; Options</"\n"span>"\nmsgstr ""\n'''
         dtdfile = self.po2dtd(multilinepo)
-        dtdsource = dtdfile.serialize()
+        dtdsource = bytes(dtdfile)
         assert b"</span>" in dtdsource
 
     def test_escapedstr(self):
         """tests that \n in msgstr is escaped correctly in dtd"""
         multilinepo = '''#: pref.menuPath\nmsgid "Hello\\nEveryone"\nmsgstr "Good day\\nAll"\n'''
         dtdfile = self.po2dtd(multilinepo)
-        dtdsource = dtdfile.serialize()
+        dtdsource = bytes(dtdfile)
         assert b"Good day\nAll" in dtdsource
 
     def test_missingaccesskey(self):
@@ -152,7 +152,7 @@ msgstr "Dimpled Ring"
         """tests that invalid ampersands are fixed in the dtd"""
         simplestring = '''#: simple.string\nmsgid "Simple String"\nmsgstr "Dimpled &Ring"\n'''
         dtdfile = self.po2dtd(simplestring)
-        dtdsource = dtdfile.serialize().decode('utf-8')
+        dtdsource = bytes(dtdfile).decode('utf-8')
         assert "Dimpled Ring" in dtdsource
 
         po_snippet = u'''#: searchIntegration.label
@@ -163,7 +163,7 @@ msgstr "&searchIntegration.engineName; &ileti aramasına izin ver"
         dtd_snippet = r'''<!ENTITY searchIntegration.accesskey      "s">
 <!ENTITY searchIntegration.label       "Allow &searchIntegration.engineName; to search messages">'''
         dtdfile = self.merge2dtd(dtd_snippet, po_snippet)
-        dtdsource = dtdfile.serialize().decode('utf-8')
+        dtdsource = bytes(dtdfile).decode('utf-8')
         print(dtdsource)
         assert u'"&searchIntegration.engineName; ileti aramasına izin ver"' in dtdsource
 
@@ -177,7 +177,7 @@ msgstr "Ileti"
         dtd_snippet = r'''<!ENTITY key.accesskey      "S">
 <!ENTITY key.label       "Ileti">'''
         dtdfile = self.merge2dtd(dtd_snippet, po_snippet)
-        dtdsource = dtdfile.serialize().decode('utf-8')
+        dtdsource = bytes(dtdfile).decode('utf-8')
         print(dtdsource)
         assert '"Ileti"' in dtdsource
         assert '""' not in dtdsource
@@ -195,7 +195,7 @@ msgstr "Lig en Kleur"
         dtd_snippet = r'''<!ENTITY key.accesskey      "L">
 <!ENTITY key.label       "Colour &amp; Light">'''
         dtdfile = self.merge2dtd(dtd_snippet, po_snippet)
-        dtdsource = dtdfile.serialize().decode('utf-8')
+        dtdsource = bytes(dtdfile).decode('utf-8')
         print(dtdsource)
         assert '"Lig en Kleur"' in dtdsource
         assert '"L"' in dtdsource
@@ -212,7 +212,7 @@ msgstr "Lig en &Kleur"
         dtd_snippet = r'''<!ENTITY key.accesskey      "L">
 <!ENTITY key.label       "Colour &amp; Light">'''
         dtdfile = self.merge2dtd(dtd_snippet, po_snippet)
-        dtdsource = dtdfile.serialize().decode('utf-8')
+        dtdsource = bytes(dtdfile).decode('utf-8')
         print(dtdsource)
         assert '"Lig en Kleur"' in dtdsource
         assert '"K"' in dtdsource
@@ -230,7 +230,7 @@ msgstr "Lig & &Kleur"
         dtd_snippet = r'''<!ENTITY key.accesskey      "L">
 <!ENTITY key.label       "Colour &amp; Light">'''
         dtdfile = self.merge2dtd(dtd_snippet, po_snippet)
-        dtdsource = dtdfile.serialize().decode('utf-8')
+        dtdsource = bytes(dtdfile).decode('utf-8')
         print(dtdsource)
         assert '"Lig &amp; Kleur"' in dtdsource
         assert '"K"' in dtdsource
@@ -239,21 +239,21 @@ msgstr "Lig & &Kleur"
         """test the error ouput when we find two entities"""
         simplestring = '''#: simple.string second.string\nmsgid "Simple String"\nmsgstr "Dimpled Ring"\n'''
         dtdfile = self.po2dtd(simplestring)
-        dtdsource = dtdfile.serialize()
+        dtdsource = bytes(dtdfile)
         assert b"CONVERSION NOTE - multiple entities" in dtdsource
 
     def test_entities(self):
         """tests that entities are correctly idnetified in the dtd"""
         simplestring = '''#: simple.string\nmsgid "Simple String"\nmsgstr "Dimpled Ring"\n'''
         dtdfile = self.po2dtd(simplestring)
-        dtdsource = dtdfile.serialize()
+        dtdsource = bytes(dtdfile)
         assert dtdsource.startswith(b"<!ENTITY simple.string")
 
     def test_comments_translator(self):
         """tests for translator comments"""
         simplestring = '''# Comment1\n# Comment2\n#: simple.string\nmsgid "Simple String"\nmsgstr "Dimpled Ring"\n'''
         dtdfile = self.po2dtd(simplestring)
-        dtdsource = dtdfile.serialize()
+        dtdsource = bytes(dtdfile)
         assert dtdsource.startswith(b"<!-- Comment1 -->")
 
     def test_retains_hashprefix(self):
@@ -261,7 +261,7 @@ msgstr "Lig & &Kleur"
         hashpo = '''#: lang.version\nmsgid "__MOZILLA_LOCALE_VERSION__"\nmsgstr "__MOZILLA_LOCALE_VERSION__"\n'''
         hashdtd = '#expand <!ENTITY lang.version "__MOZILLA_LOCALE_VERSION__">\n'
         dtdfile = self.merge2dtd(hashdtd, hashpo)
-        regendtd = dtdfile.serialize().decode('utf-8')
+        regendtd = bytes(dtdfile).decode('utf-8')
         assert regendtd == hashdtd
 
     def test_convertdtd(self):
@@ -329,8 +329,8 @@ msgstr "simple string four"
 <!ENTITY simple.label3 "Simple string 3">
 '''
         newdtd = self.po2dtd(posource, remove_untranslated=True)
-        print(newdtd.serialize())
-        assert newdtd.serialize().decode('utf-8') == dtdexpected
+        print(bytes(newdtd))
+        assert bytes(newdtd).decode('utf-8') == dtdexpected
 
     def test_blank_source(self):
         """test removing of untranslated entries where source is blank"""
@@ -362,8 +362,8 @@ msgstr "Simple string 3"
         print(newdtd_with_template)
         assert newdtd_with_template == dtdexpected_with_template
         newdtd_no_template = self.po2dtd(posource, remove_untranslated=True)
-        print(newdtd_no_template.serialize())
-        assert newdtd_no_template.serialize().decode('utf-8') == dtdexpected_no_template
+        print(bytes(newdtd_no_template))
+        assert bytes(newdtd_no_template).decode('utf-8') == dtdexpected_no_template
 
     def test_newlines_escapes(self):
         """check that we can handle a \n in the PO file"""
@@ -371,8 +371,8 @@ msgstr "Simple string 3"
         dtdtemplate = '<!ENTITY  simple.label "A hard coded newline.\n">\n'
         dtdexpected = '''<!ENTITY  simple.label "Hart gekoeerde nuwe lyne\n">\n'''
         dtdfile = self.merge2dtd(dtdtemplate, posource)
-        print(dtdfile.serialize())
-        assert dtdfile.serialize().decode('utf-8') == dtdexpected
+        print(bytes(dtdfile))
+        assert bytes(dtdfile).decode('utf-8') == dtdexpected
 
     def test_roundtrip_simple(self):
         """checks that simple strings make it through a dtd->po->dtd roundtrip"""
@@ -439,8 +439,8 @@ msgstr "Simple string 3"
           '                                          next lines.">\n'
         dtdexpected = '<!ENTITY simple.label "Eerste lyne en dan volgende lyne.">\n'
         dtdfile = self.merge2dtd(dtdtemplate, posource)
-        print(dtdfile.serialize())
-        assert dtdfile.serialize().decode('utf-8') == dtdexpected
+        print(bytes(dtdfile))
+        assert bytes(dtdfile).decode('utf-8') == dtdexpected
 
     def test_preserving_spaces(self):
         """ensure that we preseve spaces between entity and value. Bug 1662"""
@@ -448,8 +448,8 @@ msgstr "Simple string 3"
         dtdtemplate = '<!ENTITY     simple.label         "One">\n'
         dtdexpected = '<!ENTITY     simple.label         "Een">\n'
         dtdfile = self.merge2dtd(dtdtemplate, posource)
-        print(dtdfile.serialize())
-        assert dtdfile.serialize().decode('utf-8') == dtdexpected
+        print(bytes(dtdfile))
+        assert bytes(dtdfile).decode('utf-8') == dtdexpected
 
     def test_preserving_spaces_after_value(self):
         """Preseve spaces after value. Bug 1662"""
@@ -458,22 +458,22 @@ msgstr "Simple string 3"
         dtdtemplate = '<!ENTITY simple.label "One" >\n'
         dtdexpected = '<!ENTITY simple.label "Een" >\n'
         dtdfile = self.merge2dtd(dtdtemplate, posource)
-        print(dtdfile.serialize())
-        assert dtdfile.serialize().decode('utf-8') == dtdexpected
+        print(bytes(dtdfile))
+        assert bytes(dtdfile).decode('utf-8') == dtdexpected
         # Space after >
         dtdtemplate = '<!ENTITY simple.label "One"> \n'
         dtdexpected = '<!ENTITY simple.label "Een"> \n'
         dtdfile = self.merge2dtd(dtdtemplate, posource)
         print(dtdfile)
-        assert dtdfile.serialize().decode('utf-8') == dtdexpected
+        assert bytes(dtdfile).decode('utf-8') == dtdexpected
 
     def test_comments(self):
         """test that we preserve comments, bug 351"""
         posource = '''#: name\nmsgid "Text"\nmsgstr "Teks"'''
         dtdtemplate = '''<!ENTITY name "%s">\n<!-- \n\nexample -->\n'''
         dtdfile = self.merge2dtd(dtdtemplate % "Text", posource)
-        print(dtdfile.serialize())
-        assert dtdfile.serialize().decode('utf-8') == dtdtemplate % "Teks"
+        print(bytes(dtdfile))
+        assert bytes(dtdfile).decode('utf-8') == dtdtemplate % "Teks"
 
     def test_duplicates(self):
         """test that we convert duplicates back correctly to their respective entries."""
@@ -503,8 +503,8 @@ msgstr "Dipukutshwayo3"
 <!ENTITY bookmarksButton.label "Dipukutshwayo3">
 '''
         dtdfile = self.merge2dtd(dtdtemplate, posource)
-        print(dtdfile.serialize())
-        assert dtdfile.serialize().decode('utf-8') == dtdexpected
+        print(bytes(dtdfile))
+        assert bytes(dtdfile).decode('utf-8') == dtdexpected
 
 
 class TestPO2DTDCommand(test_convert.TestConvertCommand, TestPO2DTD):

--- a/translate/convert/test_po2mozlang.py
+++ b/translate/convert/test_po2mozlang.py
@@ -13,7 +13,7 @@ class TestPO2Lang:
         inputpo = po.pofile(inputfile)
         convertor = po2mozlang.po2lang(mark_active=False)
         outputlang = convertor.convertstore(inputpo)
-        return outputlang.serialize().decode('utf-8')
+        return bytes(outputlang).decode('utf-8')
 
     def test_simple(self):
         """check the simplest case of merging a translation"""

--- a/translate/convert/test_po2resx.py
+++ b/translate/convert/test_po2resx.py
@@ -26,7 +26,7 @@ from translate.misc import wStringIO
 
 
 class TestPO2RESX:
-    XMLskeleton = '''<?xml version='1.0' encoding='utf-8'?>
+    XMLskeleton = '''<?xml version='1.0' encoding='UTF-8'?>
 <root>
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>

--- a/translate/convert/test_po2tmx.py
+++ b/translate/convert/test_po2tmx.py
@@ -42,10 +42,10 @@ msgstr "Toepassings"
 """
         tmx = self.po2tmx(minipo)
         print("The generated xml:")
-        print(tmx.serialize())
+        print(bytes(tmx))
         assert tmx.translate("Applications") == "Toepassings"
         assert tmx.translate("bla") is None
-        xmltext = tmx.serialize().decode('utf-8')
+        xmltext = bytes(tmx).decode('utf-8')
         assert xmltext.index('creationtool="Translate Toolkit - po2tmx"')
         assert xmltext.index('adminlang')
         assert xmltext.index('creationtoolversion')
@@ -58,7 +58,7 @@ msgstr "Toepassings"
         minipo = 'msgid "String"\nmsgstr "String"\n'
         tmx = self.po2tmx(minipo, sourcelanguage="xh")
         print("The generated xml:")
-        print(tmx.serialize())
+        print(bytes(tmx))
         header = tmx.document.find("header")
         assert header.get("srclang") == "xh"
 
@@ -66,7 +66,7 @@ msgstr "Toepassings"
         minipo = 'msgid "String"\nmsgstr "String"\n'
         tmx = self.po2tmx(minipo, targetlanguage="xh")
         print("The generated xml:")
-        print(tmx.serialize())
+        print(bytes(tmx))
         tuv = tmx.document.findall(".//%s" % tmx.namespaced("tuv"))[1]
         #tag[0] will be the source, we want the target tuv
         assert tuv.get("{%s}lang" % XML_NS) == "xh"
@@ -79,7 +79,7 @@ msgstr "Eerste deel "
 "en ekstra"'''
         tmx = self.po2tmx(minipo)
         print("The generated xml:")
-        print(tmx.serialize())
+        print(bytes(tmx))
         assert tmx.translate('First part and extra') == 'Eerste deel en ekstra'
 
     def test_escapednewlines(self):
@@ -89,7 +89,7 @@ msgstr "Eerste lyn\nTweede lyn"
 '''
         tmx = self.po2tmx(minipo)
         print("The generated xml:")
-        print(tmx.serialize())
+        print(bytes(tmx))
         assert tmx.translate("First line\nSecond line") == "Eerste lyn\nTweede lyn"
 
     def test_escapedtabs(self):
@@ -99,7 +99,7 @@ msgstr "Eerste kolom\tTweede kolom"
 '''
         tmx = self.po2tmx(minipo)
         print("The generated xml:")
-        print(tmx.serialize())
+        print(bytes(tmx))
         assert tmx.translate("First column\tSecond column") == "Eerste kolom\tTweede kolom"
 
     def test_escapedquotes(self):
@@ -112,7 +112,7 @@ msgstr "Gebruik \\\"."
 '''
         tmx = self.po2tmx(minipo)
         print("The generated xml:")
-        print(tmx.serialize())
+        print(bytes(tmx))
         assert tmx.translate('Hello "Everyone"') == 'Good day "All"'
         assert tmx.translate(r'Use \".') == r'Gebruik \".'
 
@@ -130,8 +130,8 @@ msgstr "Drie"
 '''
         tmx = self.po2tmx(minipo)
         print("The generated xml:")
-        print(tmx.serialize())
-        assert b"<tu" not in tmx.serialize()
+        print(bytes(tmx))
+        assert b"<tu" not in bytes(tmx)
         assert len(tmx.units) == 0
 
     def test_nonascii(self):
@@ -140,7 +140,7 @@ msgstr "Drie"
 msgstr "Bézier-kurwe"
 '''
         tmx = self.po2tmx(minipo)
-        print(tmx.serialize())
+        print(bytes(tmx))
         assert tmx.translate(u"Bézier curve") == u"Bézier-kurwe"
 
     def test_nonecomments(self):
@@ -150,7 +150,7 @@ msgid "Bézier curve"
 msgstr "Bézier-kurwe"
 '''
         tmx = self.po2tmx(minipo)
-        print(tmx.serialize())
+        print(bytes(tmx))
         unit = tmx.findunits(u"Bézier curve")
         assert len(unit[0].getnotes()) == 0
 
@@ -161,7 +161,7 @@ msgid "Bézier curve"
 msgstr "Bézier-kurwe"
 '''
         tmx = self.po2tmx(minipo, comment='others')
-        print(tmx.serialize())
+        print(bytes(tmx))
         unit = tmx.findunits(u"Bézier curve")
         assert unit[0].getnotes() == u"My comment rules"
 
@@ -172,7 +172,7 @@ msgid "Bézier curve"
 msgstr "Bézier-kurwe"
 '''
         tmx = self.po2tmx(minipo, comment='source')
-        print(tmx.serialize())
+        print(bytes(tmx))
         unit = tmx.findunits(u"Bézier curve")
         assert unit[0].getnotes() == u"../PuzzleFourSided.h:45"
 
@@ -183,7 +183,7 @@ msgid "Bézier curve"
 msgstr "Bézier-kurwe"
 '''
         tmx = self.po2tmx(minipo, comment='type')
-        print(tmx.serialize())
+        print(bytes(tmx))
         unit = tmx.findunits(u"Bézier curve")
         assert unit[0].getnotes() == u"csharp-format"
 

--- a/translate/convert/test_po2xliff.py
+++ b/translate/convert/test_po2xliff.py
@@ -22,7 +22,7 @@ class TestPO2XLIFF:
         minipo = '''msgid "red"\nmsgstr "rooi"\n'''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        print(xliff.serialize())
+        print(bytes(xliff))
         assert len(xliff.units) == 1
         assert xliff.translate("red") == "rooi"
         assert xliff.translate("bla") is None
@@ -49,10 +49,10 @@ msgstr "Toepassings"
 """
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        print(xliff.serialize())
+        print(bytes(xliff))
         assert xliff.translate("Applications") == "Toepassings"
         assert xliff.translate("bla") is None
-        xmltext = xliff.serialize().decode('utf-8')
+        xmltext = bytes(xliff).decode('utf-8')
         assert xmltext.index('<xliff ') >= 0
         assert xmltext.index(' version="1.1"') >= 0
         assert xmltext.index('<file')
@@ -67,7 +67,7 @@ msgstr "Eerste deel "
 "en ekstra"'''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        print(xliff.serialize())
+        print(bytes(xliff))
         assert xliff.translate('First part and extra') == 'Eerste deel en ekstra'
 
     def test_escapednewlines(self):
@@ -77,7 +77,7 @@ msgstr "Eerste lyn\nTweede lyn"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = xliff.serialize().decode('utf-8')
+        xmltext = bytes(xliff).decode('utf-8')
         print(xmltext)
         assert xliff.translate("First line\nSecond line") == "Eerste lyn\nTweede lyn"
         assert xliff.translate("First line\\nSecond line") is None
@@ -93,7 +93,7 @@ msgstr "Eerste kolom\tTweede kolom"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = xliff.serialize().decode('utf-8')
+        xmltext = bytes(xliff).decode('utf-8')
         print(xmltext)
         assert xliff.translate("First column\tSecond column") == "Eerste kolom\tTweede kolom"
         assert xliff.translate("First column\\tSecond column") is None
@@ -112,7 +112,7 @@ msgstr "Gebruik \\\"."
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = xliff.serialize().decode('utf-8')
+        xmltext = bytes(xliff).decode('utf-8')
         print(xmltext)
         assert xliff.translate('Hello "Everyone"') == 'Good day "All"'
         assert xliff.translate(r'Use \".') == r'Gebruik \".'
@@ -132,7 +132,7 @@ msgstr "kunye"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = xliff.serialize().decode('utf-8')
+        xmltext = bytes(xliff).decode('utf-8')
         print(xmltext)
         assert xliff.translate("one") == "kunye"
         assert len(xliff.units) == 1
@@ -153,7 +153,7 @@ msgstr "kunye"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = xliff.serialize()
+        xmltext = bytes(xliff)
         print(xmltext)
         assert xliff.translate("one") == "kunye"
         assert len(xliff.units) == 1
@@ -176,7 +176,7 @@ msgstr "kunye"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = xliff.serialize()
+        xmltext = bytes(xliff)
         print(xmltext)
         assert xliff.translate("one") == "kunye"
         assert len(xliff.units) == 1
@@ -199,7 +199,7 @@ msgstr ""
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = xliff.serialize()
+        xmltext = bytes(xliff)
         print(xmltext)
         assert len(xliff.units) == 1
         unit = xliff.units[0]
@@ -219,7 +219,7 @@ msgstr "raro"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = xliff.serialize()
+        xmltext = bytes(xliff)
         print(xmltext)
         assert len(xliff.units) == 2
         assert xliff.units[0].isfuzzy()
@@ -233,7 +233,7 @@ msgstr[1] "iinkomo"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = xliff.serialize()
+        xmltext = bytes(xliff)
         print(xmltext)
         assert len(xliff.units) == 1
         assert xliff.translate("cow") == "inkomo"
@@ -247,7 +247,7 @@ msgstr[2] "iiinkomo"
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = xliff.serialize()
+        xmltext = bytes(xliff)
         print(xmltext)
         assert len(xliff.units) == 1
         assert xliff.translate("cow") == "inkomo"
@@ -280,7 +280,7 @@ msgstr ""
 '''
         xliff = self.po2xliff(minipo)
         print("The generated xml:")
-        xmltext = xliff.serialize()
+        xmltext = bytes(xliff)
         print(xmltext)
         assert len(xliff.units) == 3
         assert xliff.units[0].xmlelement.get("approved") != "yes"

--- a/translate/convert/test_pot2po.py
+++ b/translate/convert/test_pot2po.py
@@ -285,7 +285,7 @@ msgstr "Sertifikate"
         posource = '# Some comment\n#. Extracted comment\n#: obsoleteme:10\nmsgid "One"\nmsgstr "Een"\n'
         expected = '# Some comment\n#~ msgid "One"\n#~ msgstr "Een"\n'
         newpo = self.convertpot(potsource, posource)
-        print(newpo.serialize())
+        print(bytes(newpo))
         newpounit = self.singleunit(newpo)
         assert str(newpounit) == expected
 
@@ -295,7 +295,7 @@ msgstr "Sertifikate"
         potsource = 'msgid ""\nmsgstr ""\n'
         posource = '#: obsoleteme:10\nmsgid "One"\nmsgstr ""\n'
         newpo = self.convertpot(potsource, posource)
-        print(newpo.serialize())
+        print(bytes(newpo))
         # We should only have the header
         assert len(newpo.units) == 1
 
@@ -393,7 +393,7 @@ msgstr ""
         newpo = self.convertpot(potsource, posource)
         print('Output Header:\n%s' % newpo)
         print('Expected Header:\n%s' % expected)
-        assert newpo.serialize().decode('utf-8') == expected
+        assert bytes(newpo).decode('utf-8') == expected
 
     def test_merging_comments(self):
         """Test that we can merge comments correctly"""
@@ -461,7 +461,7 @@ msgstr "teks"
 """
         newpo = self.convertpot(potsource, posource)
         print(newpo)
-        assert poexpected in newpo.serialize().decode('utf-8')
+        assert poexpected in bytes(newpo).decode('utf-8')
 
     def test_msgctxt_multiline(self):
         """Test multiline msgctxt fields."""
@@ -774,7 +774,7 @@ msgstr ""
         newpo = self.convertpot(potsource, posource)
         print('Output:\n%s' % newpo)
         print('Expected:\n%s' % expected)
-        assert newpo.serialize().decode('utf-8') == expected
+        assert bytes(newpo).decode('utf-8') == expected
 
 
 class TestPOT2POCommand(test_convert.TestConvertCommand, TestPOT2PO):

--- a/translate/convert/test_prop2po.py
+++ b/translate/convert/test_prop2po.py
@@ -132,9 +132,9 @@ prefPanel-smime=Security'''
 prefPanel-smime=
 '''
         pofile = self.prop2po(propsource)
-        print(pofile.serialize())
+        print(bytes(pofile))
         #header comments:
-        assert b"#. # Comment\n#. # commenty 2" in pofile.serialize()
+        assert b"#. # Comment\n#. # commenty 2" in bytes(pofile)
         pounit = self.singleelement(pofile)
         assert pounit.getnotes("developer") == "## @name GENERIC_ERROR\n## @loc none"
 
@@ -164,7 +164,7 @@ do=translate me
             assert pounit.getlocations() == ["credit"]
             assert pounit.getcontext() == "credit"
             assert 'msgctxt "credit"' in str(pounit)
-            assert b"#. # comment" in pofile.serialize()
+            assert b"#. # comment" in bytes(pofile)
             assert pounit.source == ""
 
     def test_emptyproperty_translated(self):
@@ -210,14 +210,14 @@ do=translate me
         propsource = '''prop=value\n'''
 
         outputpo = self.prop2po(propsource, personality="mozilla")
-        assert b"X-Accelerator-Marker" in outputpo.serialize()
-        assert b"X-Merge-On" in outputpo.serialize()
+        assert b"X-Accelerator-Marker" in bytes(outputpo)
+        assert b"X-Merge-On" in bytes(outputpo)
 
         # Even though the gaia flavour inherrits from mozilla, it should not
         # get the header
         outputpo = self.prop2po(propsource, personality="gaia")
-        assert b"X-Accelerator-Marker" not in outputpo.serialize()
-        assert b"X-Merge-On" not in outputpo.serialize()
+        assert b"X-Accelerator-Marker" not in bytes(outputpo)
+        assert b"X-Merge-On" not in bytes(outputpo)
 
     def test_gaia_plurals(self):
         """Test conversion of gaia plural units."""

--- a/translate/convert/test_ts2po.py
+++ b/translate/convert/test_ts2po.py
@@ -11,7 +11,7 @@ class TestTS2PO:
         tsfile = wStringIO.StringIO(tssource)
         outputpo = converter.convertfile(tsfile)
         print("The generated po:")
-        print(outputpo.serialize())
+        print(bytes(outputpo))
         return outputpo
 
     def test_blank(self):

--- a/translate/convert/test_txt2po.py
+++ b/translate/convert/test_txt2po.py
@@ -15,7 +15,7 @@ class TestTxt2PO:
 
     def singleelement(self, storage):
         """checks that the pofile contains a single non-header element, and returns it"""
-        print(storage.serialize())
+        print(bytes(storage))
         assert len(storage.units) == 1
         return storage.units[0]
 
@@ -70,7 +70,7 @@ class TestDoku2po:
 
     def singleelement(self, storage):
         """checks that the pofile contains a single non-header element, and returns it"""
-        print(storage.serialize())
+        print(bytes(storage))
         assert len(storage.units) == 1
         return storage.units[0]
 

--- a/translate/convert/test_xliff2po.py
+++ b/translate/convert/test_xliff2po.py
@@ -23,7 +23,7 @@ class TestXLIFF2PO:
         outputpo = convertor.convertstore(inputfile)
         print("The generated po:")
         print(type(outputpo))
-        print(outputpo.serialize())
+        print(bytes(outputpo))
         return outputpo
 
     def test_minimal(self):
@@ -61,7 +61,7 @@ Content-Transfer-Encoding: 8bit'''
         pofile = self.xliff2po(minixlf)
         assert pofile.translate("gras") == "utshani"
         assert pofile.translate("bla") is None
-        potext = pofile.serialize().decode('utf-8')
+        potext = bytes(pofile).decode('utf-8')
         assert potext.index('# Zulu translation of program ABC') == 0
         assert potext.index('msgid "gras"\n')
         assert potext.index('msgstr "utshani"\n')
@@ -84,7 +84,7 @@ it</note>
         assert pofile.translate("bla") is None
         unit = first_translatable(pofile)
         assert unit.getnotes("translator") == "Couldn't do it"
-        potext = pofile.serialize().decode('utf-8')
+        potext = bytes(pofile).decode('utf-8')
         assert potext.index("# Couldn't do it\n") >= 0
 
         minixlf = self.xliffskeleton % '''<trans-unit xml:space="preserve">
@@ -102,7 +102,7 @@ it</note>
         assert pofile.translate("bla") is None
         unit = first_translatable(pofile)
         assert unit.getnotes("translator") == "Couldn't do\nit"
-        potext = pofile.serialize().decode('utf-8')
+        potext = bytes(pofile).decode('utf-8')
         assert potext.index("# Couldn't do\n# it\n") >= 0
 
     def test_autocomment(self):
@@ -122,7 +122,7 @@ garbage</note>
         assert pofile.translate("bla") is None
         unit = first_translatable(pofile)
         assert unit.getnotes("developer") == "Note that this is garbage"
-        potext = pofile.serialize().decode('utf-8')
+        potext = bytes(pofile).decode('utf-8')
         assert potext.index("#. Note that this is garbage\n") >= 0
 
         minixlf = self.xliffskeleton % '''<trans-unit xml:space="preserve">
@@ -140,7 +140,7 @@ garbage</note>
         assert pofile.translate("bla") is None
         unit = first_translatable(pofile)
         assert unit.getnotes("developer") == "Note that this is\ngarbage"
-        potext = pofile.serialize().decode('utf-8')
+        potext = bytes(pofile).decode('utf-8')
         assert potext.index("#. Note that this is\n#. garbage\n") >= 0
 
     def test_locations(self):
@@ -202,8 +202,8 @@ garbage</note>
         </trans-unit>
 </group>'''
         pofile = self.xliff2po(minixlf)
-        print(pofile.serialize())
-        potext = pofile.serialize().decode('utf-8')
+        print(bytes(pofile))
+        potext = bytes(pofile).decode('utf-8')
         assert headerless_len(pofile.units) == 1
         assert potext.index('msgid_plural "cows"')
         assert potext.index('msgstr[0] "inkomo"')

--- a/translate/convert/tiki2po.py
+++ b/translate/convert/tiki2po.py
@@ -71,7 +71,7 @@ def converttiki(inputfile, outputfile, template=None, includeunused=False):
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
         return False
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return True
 
 

--- a/translate/convert/ts2po.py
+++ b/translate/convert/ts2po.py
@@ -77,7 +77,7 @@ def convertts(inputfile, outputfile, templates, pot=False, duplicatestyle="msgct
     outputstore = convertor.convertfile(inputfile)
     if outputstore.isempty():
         return 0
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/txt2po.py
+++ b/translate/convert/txt2po.py
@@ -55,7 +55,7 @@ def converttxt(inputfile, outputfile, templates, duplicatestyle="msgctxt",
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
         return 0
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/web2py2po.py
+++ b/translate/convert/web2py2po.py
@@ -73,7 +73,7 @@ def convertpy(inputfile, outputfile, encoding="UTF-8"):
     if outputstore.isempty():
         return 0
 
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/convert/xliff2po.py
+++ b/translate/convert/xliff2po.py
@@ -96,7 +96,7 @@ def convertxliff(inputfile, outputfile, templates, duplicatestyle="msgctxt"):
     outputstore = convertor.convertstore(inputfile, duplicatestyle)
     if outputstore.isempty():
         return 0
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/filters/pofilter.py
+++ b/translate/filters/pofilter.py
@@ -220,7 +220,7 @@ def runfilter(inputfile, outputfile, templatefile, checkfilter=None):
     if tofile.isempty():
         return 0
 
-    outputfile.write(tofile.serialize())
+    tofile.serialize(outputfile)
 
     return 1
 

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -711,7 +711,7 @@ class TranslationStore(object):
         # This allows the old str(store) method for serialization to be kept
         # for compatibility purpose.
         if six.PY2:
-            return self.serialize()
+            return self.__bytes__()
         return super(TranslationStore, self).__str__()
 
     def __bytes__(self):
@@ -835,12 +835,11 @@ class TranslationStore(object):
 
     def savefile(self, storefile):
         """Write the string representation to the given file (or filename)."""
-        storestring = self.serialize()
         if isinstance(storefile, six.string_types):
             storefile = open(storefile, 'wb')
         self.fileobj = storefile
         self._assignname()
-        storefile.write(storestring)
+        self.serialize(storefile)
         storefile.close()
 
     def save(self):

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -26,6 +26,7 @@ try:
     import cPickle as pickle
 except ImportError:
     import pickle
+from io import BytesIO
 
 from translate.misc.multistring import multistring
 from translate.storage.placeables import (StringElem, general,
@@ -714,12 +715,16 @@ class TranslationStore(object):
         return super(TranslationStore, self).__str__()
 
     def __bytes__(self):
-        return self.serialize()
+        out = BytesIO()
+        self.serialize(out)
+        return out.getvalue()
 
-    def serialize(self):
+    def serialize(self, out):
         """Converts to a bytes representation that can be parsed back using
-        :meth:`~.TranslationStore.parsestring`."""
-        return pickle.dumps(self)
+        :meth:`~.TranslationStore.parsestring`.
+        `out` should be an open file-like objects to write to.
+        """
+        out.write(pickle.dumps(self))
 
     def isempty(self):
         """Return True if the object doesn't contain any translation units."""

--- a/translate/storage/catkeys.py
+++ b/translate/storage/catkeys.py
@@ -261,11 +261,11 @@ class CatkeysFile(base.TranslationStore):
             newunit.dict = line
             self.addunit(newunit)
 
-    def serialize(self):
+    def serialize(self, out):
         output = csv.StringIO()
         writer = csv_utils.UnicodeDictWriter(output, FIELDNAMES, encoding=self.encoding, dialect="catkeys")
         # No real headers, the first line contains metadata
         writer.writerow(dict(zip(FIELDNAMES, [self.header._header_dict[key] for key in FIELDNAMES_HEADER])))
         for unit in self.units:
             writer.writerow(unit.dict)
-        return output.getvalue() if six.PY2 else output.getvalue().encode(self.encoding)
+        out.write(output.getvalue() if six.PY2 else output.getvalue().encode(self.encoding))

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -530,7 +530,7 @@ class pounit(pocommon.pounit):
     def __str__(self):
         pf = pofile(noheader=True)
         pf.addunit(self)
-        return pf.serialize().decode(self.CPO_ENC)
+        return bytes(pf).decode(self.CPO_ENC)
 
     def getlocations(self):
         locations = []

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -705,7 +705,7 @@ class pofile(pocommon.pofile):
         self._gpo_memory_file = new_gpo_memory_file
         self.units = uniqueunits
 
-    def serialize(self):
+    def serialize(self, out):
 
         def obsolete_workaround():
             # Remove all items that are not output by msgmerge when a unit is obsolete.  This is a work
@@ -740,7 +740,7 @@ class pofile(pocommon.pofile):
                                       content_transfer_encoding="8bit")
                     outputstring = writefile(fname)
             os.remove(fname)
-        return outputstring
+        out.write(outputstring)
 
     def isempty(self):
         """Returns True if the object doesn't contain any translation units."""

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -408,12 +408,12 @@ class csvfile(base.TranslationStore):
                 self.addunit(newce)
             first_row = False
 
-    def serialize(self):
-        """convert to bytes. double check that unicode is handled somehow here"""
+    def serialize(self, out):
+        """Write to file"""
         source = self.getoutput()
         if not isinstance(source, six.text_type):
             source = source.decode('utf-8')
-        return source.encode(self.encoding)
+        out.write(source.encode(self.encoding))
 
     def getoutput(self):
         output = csv.StringIO()

--- a/translate/storage/fpo.py
+++ b/translate/storage/fpo.py
@@ -521,8 +521,8 @@ class pofile(pocommon.pofile):
                 uniqueunits.append(thepo)
         self.units = uniqueunits
 
-    def serialize(self):
-        """Convert to bytes. double check that unicode is handled somehow here"""
+    def serialize(self, out):
+        """Write content to file"""
         self._cpo_store = cpo.pofile(encoding=self.encoding, noheader=True)
         try:
             self._build_cpo_from_self()
@@ -530,6 +530,5 @@ class pofile(pocommon.pofile):
             self.encoding = "utf-8"
             self.updateheader(add=True, Content_Type="text/plain; charset=UTF-8")
             self._build_cpo_from_self()
-        output = self._cpo_store.serialize()
+        self._cpo_store.serialize(out)
         del self._cpo_store
-        return output

--- a/translate/storage/ical.py
+++ b/translate/storage/ical.py
@@ -87,7 +87,7 @@ class icalfile(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def serialize(self):
+    def serialize(self, out):
         _outicalfile = self._icalfile
         for unit in self.units:
             for location in unit.getlocations():
@@ -102,9 +102,7 @@ class icalfile(base.TranslationStore):
                             property.value = unit.target
 
         if _outicalfile:
-            return str(_outicalfile.serialize())
-        else:
-            return ""
+            _outicalfile.serialize(out)
 
     def parse(self, input):
         """parse the given file or file source string"""

--- a/translate/storage/ini.py
+++ b/translate/storage/ini.py
@@ -102,16 +102,14 @@ class inifile(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def serialize(self):
+    def serialize(self, out):
         _outinifile = self._inifile
         for unit in self.units:
             for location in unit.getlocations():
                 match = re.match('\\[(?P<section>.+)\\](?P<entry>.+)', location)
                 _outinifile[match.groupdict()['section']][match.groupdict()['entry']] = self._dialect.escape(unit.target)
         if _outinifile:
-            return str(_outinifile)
-        else:
-            return b""
+            out.write(str(_outinifile))
 
     def parse(self, input):
         """Parse the given file or file source string."""

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -153,13 +153,13 @@ class JsonFile(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def serialize(self):
+    def serialize(self, out):
         units = {}
         for unit in self.unit_iter():
             path = unit.getid().lstrip('.')
             units[path] = unit.target
-        return json.dumps(units, sort_keys=True, separators=(',', ': '),
-                          indent=4, ensure_ascii=False).encode(self.encoding)
+        out.write(json.dumps(units, sort_keys=True, separators=(',', ': '),
+                             indent=4, ensure_ascii=False).encode(self.encoding))
 
     def _extract_translatables(self, data, stop=None, prev="", name_node=None,
                                name_last_node=None, last_node=None):

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -326,10 +326,10 @@ class LISAfile(base.TranslationStore):
         if new:
             self.body.append(unit.xmlelement)
 
-    def serialize(self):
+    def serialize(self, out=None):
         """Converts to a string containing the file's XML"""
-        return etree.tostring(self.document, pretty_print=True,
-                              xml_declaration=True, encoding='utf-8')
+        self.document.write(out, pretty_print=True, xml_declaration=True,
+                            encoding='utf-8')
 
     def parse(self, xml):
         """Populates this object from the given xml string"""

--- a/translate/storage/mo.py
+++ b/translate/storage/mo.py
@@ -141,7 +141,7 @@ class mofile(poheader.poheader, base.TranslationStore):
         if inputfile is not None:
             self.parsestring(inputfile)
 
-    def serialize(self):
+    def serialize(self, out):
         """Output a string representation of the MO data file"""
         # check the header of this file for the copyright note of this function
 
@@ -230,7 +230,7 @@ class mofile(poheader.poheader, base.TranslationStore):
             output = output + hash_table.tostring()
             output = output + ids
             output = output + strs
-        return output
+        return out.write(output)
 
     def parse(self, input):
         """parses the given file or file source string"""

--- a/translate/storage/mozilla_lang.py
+++ b/translate/storage/mozilla_lang.py
@@ -105,10 +105,11 @@ class LangStore(txt.TxtFile):
                     u.addnote(comment[:-1], 'developer')
                     comment = ""
 
-    def serialize(self):
-        ret_string = b""
+    def serialize(self, out):
         if self.is_active or self.mark_active:
-            ret_string += b"## active ##\n"
-        ret_string += u"\n\n\n".join([six.text_type(unit) for unit in self.units]).encode('utf-8')
-        ret_string += b"\n"
-        return ret_string
+            out.write(b"## active ##\n")
+        for idx, unit in enumerate(self.units):
+            if idx > 0:
+                out.write(b"\n\n\n")
+            out.write(six.text_type(unit).encode('utf-8'))
+        out.write(b"\n")

--- a/translate/storage/omegat.py
+++ b/translate/storage/omegat.py
@@ -174,18 +174,18 @@ class OmegaTFile(base.TranslationStore):
             newunit.dict = line
             self.addunit(newunit)
 
-    def serialize(self):
+    def serialize(self, out):
         # Check first if there is at least one translated unit
         translated_units = [u for u in self.units if u.istranslated()]
         if not translated_units:
-            return b""
+            return
 
         output = csv.StringIO()
         writer = csv_utils.UnicodeDictWriter(
             output, fieldnames=OMEGAT_FIELDNAMES, encoding=self.encoding, dialect="omegat")
         for unit in translated_units:
             writer.writerow(unit.dict)
-        return output.getvalue() if six.PY2 else output.getvalue().encode(self.encoding)
+        out.write(output.getvalue() if six.PY2 else output.getvalue().encode(self.encoding))
 
 
 class OmegaTFileTab(OmegaTFile):

--- a/translate/storage/oo.py
+++ b/translate/storage/oo.py
@@ -35,6 +35,7 @@ import os
 import re
 import six
 import warnings
+from io import BytesIO
 
 from translate.misc import quote, wStringIO
 
@@ -305,12 +306,19 @@ class oofile:
 
     def __str__(self, *args, **kwargs):
         if six.PY2:
-            return self.serialize(*args, **kwargs)
+            out = BytesIO()
+            self.serialize(out, **kwargs)
+            return out.getvalue()
         return super(oofile, self).__str__()
 
-    def serialize(self, skip_source=False, fallback_lang=None):
+    def __bytes__(self):
+        out = BytesIO()
+        self.serialize(out)
+        return out.getvalue()
+
+    def serialize(self, out, skip_source=False, fallback_lang=None):
         """convert to a string. double check that unicode is handled"""
-        return self.getoutput(skip_source, fallback_lang).encode(self.encoding)
+        out.write(self.getoutput(skip_source, fallback_lang).encode(self.encoding))
 
     def getoutput(self, skip_source=False, fallback_lang=None):
         """converts all the lines back to tab-delimited form"""

--- a/translate/storage/php.py
+++ b/translate/storage/php.py
@@ -207,12 +207,10 @@ class phpfile(base.TranslationStore):
             inputfile.close()
             self.parse(phpsrc)
 
-    def serialize(self):
+    def serialize(self, out):
         """Convert the units back to lines."""
-        lines = []
         for unit in self.units:
-            lines.append(str(unit))
-        return ("".join(lines)).encode(self.encoding)
+            out.write(six.text_type(unit).encode(self.encoding))
 
     def parse(self, phpsrc):
         """Read the source of a PHP file in and include them as units."""

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -115,6 +115,7 @@ Name and Value pairs:
 
 import re
 import six
+from codecs import iterencode
 
 from translate.lang import data
 from translate.misc import quote
@@ -625,13 +626,11 @@ class propfile(base.TranslationStore):
         if inmultilinevalue or len(newunit.comments) > 0:
             self.addunit(newunit)
 
-    def serialize(self):
-        """Convert the units back to lines."""
-        lines = []
-        for unit in self.units:
-            lines.append(unit.getoutput())
-        uret = u"".join(lines)
-        return uret.encode(self.encoding)
+    def serialize(self, out):
+        """Write the units back to file."""
+        # Thanks to iterencode, a possible BOM is written only once
+        for chunk in iterencode((unit.getoutput() for unit in self.units), self.encoding):
+            out.write(chunk)
 
 
 class javafile(propfile):

--- a/translate/storage/qm.py
+++ b/translate/storage/qm.py
@@ -98,7 +98,7 @@ class qmfile(base.TranslationStore):
         if inputfile is not None:
             self.parsestring(inputfile)
 
-    def serialize(self):
+    def serialize(self, out):
         """Output a string representation of the .qm data file"""
         raise Exception("Writing of .qm files is not supported yet")
 

--- a/translate/storage/qph.py
+++ b/translate/storage/qph.py
@@ -137,11 +137,11 @@ class QphFile(lisa.LISAfile):
         if targetlanguage:
             self.header.set('language', targetlanguage)
 
-    def serialize(self):
-        """Converts to a string containing the file's XML.
+    def serialize(self, out):
+        """Write the XML document to the file `out`.
 
         We have to override this to ensure mimic the Qt convention:
-            - no XML decleration
+            - no XML declaration
         """
-        return etree.tostring(self.document, pretty_print=True,
-                              xml_declaration=False, encoding='utf-8')
+        self.document.write(out, pretty_print=True, xml_declaration=False,
+                            encoding='utf-8')

--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -232,6 +232,6 @@ class rcfile(base.TranslationStore):
                     newunit.match = match
                     self.addunit(newunit)
 
-    def serialize(self):
-        """Convert the units back to lines."""
-        return ("".join(self.blocks)).encode(self.encoding)
+    def serialize(self, out):
+        """Write the units back to file."""
+        out.write(("".join(self.blocks)).encode(self.encoding))

--- a/translate/storage/subtitles.py
+++ b/translate/storage/subtitles.py
@@ -86,7 +86,7 @@ class SubtitleFile(base.TranslationStore):
         if inputfile is not None:
             self._parsefile(inputfile)
 
-    def serialize(self):
+    def serialize(self, out):
         subtitles = []
         for unit in self.units:
             subtitle = Subtitle()
@@ -94,9 +94,11 @@ class SubtitleFile(base.TranslationStore):
             subtitle.start = unit._start
             subtitle.end = unit._end
             subtitles.append(subtitle)
+        # Using transient output might be dropped if/when we have more control
+        # over the open mode of out files.
         output = StringIO()
         self._subtitlefile.write_to_file(subtitles, documents.MAIN, output)
-        return output.getvalue().encode(self._subtitlefile.encoding)
+        out.write(output.getvalue().encode(self._subtitlefile.encoding))
 
     def _parse(self):
         try:

--- a/translate/storage/test_base.py
+++ b/translate/storage/test_base.py
@@ -22,6 +22,7 @@
 import os
 import six
 import warnings
+from io import BytesIO
 
 import pytest
 
@@ -222,7 +223,7 @@ class TestTranslationStore(object):
         store = self.StoreClass()
         unit = store.addsourceunit("Test String")
         print(str(unit))
-        print(store.serialize())
+        print(bytes(store))
         assert headerless_len(store.units) == 1
         assert unit.source == "Test String"
 
@@ -247,7 +248,7 @@ class TestTranslationStore(object):
 
     def reparse(self, store):
         """converts the store to a string and back to a store again"""
-        storestring = store.serialize()
+        storestring = bytes(store)
         newstore = self.StoreClass.parsestring(storestring)
         return newstore
 
@@ -260,9 +261,9 @@ class TestTranslationStore(object):
             if not match:
                 print("match failed between elements %d of %d" % ((n + 1), headerless_len(store1.units)))
                 print("store1:")
-                print(store1.serialize())
+                print(bytes(store1))
                 print("store2:")
-                print(store2.serialize())
+                print(bytes(store2))
                 print("store1.units[%d].__dict__:" % n, store1unit.__dict__)
                 print("store2.units[%d].__dict__:" % n, store2unit.__dict__)
                 assert store1unit == store2unit
@@ -317,7 +318,7 @@ class TestTranslationStore(object):
             answer = answer.decode("utf-8")
         assert answer == u"Beziér-kurwe"
         #Just test that __str__ doesn't raise exception:
-        src = store.serialize()
+        src = store.serialize(BytesIO())
 
     def test_extensions(self):
         """Test that the factory knows the extensions for this class."""

--- a/translate/storage/test_cpo.py
+++ b/translate/storage/test_cpo.py
@@ -97,7 +97,7 @@ class TestCPOFile(test_po.TestPOFile):
         print("Blah", thepo.source)
         assert thepo.source == "test me"
         thepo.msgidcomment = "second comment"
-        assert pofile.serialize().count(b"_:") == 1
+        assert bytes(pofile).count(b"_:") == 1
 
     @mark.xfail(reason="Were disabled during port of Pypo to cPO - they might work")
     def test_merge_duplicates_msgctxt(self):
@@ -156,9 +156,9 @@ class TestCPOFile(test_po.TestPOFile):
         posource = u'''#: nb\nmsgid "Norwegian Bokm\xe5l"\nmsgstr ""\n'''
         pofile = self.StoreClass(wStringIO.StringIO(posource.encode("UTF-8")), encoding="UTF-8")
         assert len(pofile.units) == 1
-        print(pofile.serialize())
+        print(bytes(pofile))
         thepo = pofile.units[0]
-#        assert pofile.serialize() == posource.encode("UTF-8")
+#        assert bytes(pofile) == posource.encode("UTF-8")
         # extra test: what if we set the msgid to a unicode? this happens in prop2po etc
         thepo.source = u"Norwegian Bokm\xe5l"
 #        assert str(thepo) == posource.encode("UTF-8")
@@ -166,9 +166,9 @@ class TestCPOFile(test_po.TestPOFile):
         # this is an escaped half character (1/2)
         halfstr = b"\xbd ...".decode("latin-1")
         thepo.target = halfstr
-#        assert halfstr in pofile.serialize().decode("UTF-8")
+#        assert halfstr in bytes(pofile).decode("UTF-8")
         thepo.target = halfstr.encode("UTF-8")
-#        assert halfstr.encode("UTF-8") in pofile.serialize()
+#        assert halfstr.encode("UTF-8") in bytes(pofile)
 
     def test_posections(self):
         """checks the content of all the expected sections of a PO message"""
@@ -176,23 +176,23 @@ class TestCPOFile(test_po.TestPOFile):
         pofile = self.poparse(posource)
         print(pofile)
         assert len(pofile.units) == 1
-        assert pofile.serialize().decode('utf-8') == posource
+        assert bytes(pofile).decode('utf-8') == posource
 
     def test_multiline_obsolete(self):
         """Tests for correct output of mulitline obsolete messages"""
         posource = '#~ msgid ""\n#~ "Old thing\\n"\n#~ "Second old thing"\n#~ msgstr ""\n#~ "Ou ding\\n"\n#~ "Tweede ou ding"\n'
         pofile = self.poparse(posource)
         print("Source:\n%s" % posource)
-        print("Output:\n%s" % pofile.serialize())
+        print("Output:\n%s" % bytes(pofile))
         assert len(pofile.units) == 1
         assert pofile.units[0].isobsolete()
         assert not pofile.units[0].istranslatable()
-        assert pofile.serialize().decode('utf-8') == posource
+        assert bytes(pofile).decode('utf-8') == posource
 
     def test_unassociated_comments(self):
         """tests behaviour of unassociated comments."""
         oldsource = '# old lonesome comment\n\nmsgid "one"\nmsgstr "een"\n'
         oldfile = self.poparse(oldsource)
-        print("serialize", oldfile.serialize())
+        print("serialize", bytes(oldfile))
         assert len(oldfile.units) == 1
-        assert "# old lonesome comment\nmsgid" in oldfile.serialize().decode('utf-8')
+        assert "# old lonesome comment\nmsgid" in bytes(oldfile).decode('utf-8')

--- a/translate/storage/test_csvl10n.py
+++ b/translate/storage/test_csvl10n.py
@@ -25,7 +25,7 @@ class TestCSV(test_base.TestTranslationStore):
         newstore = self.reparse(store)
         self.check_equality(store, newstore)
         assert store.units[2] == newstore.units[2]
-        assert store.serialize() == newstore.serialize()
+        assert bytes(store) == bytes(newstore)
 
     @mark.xfail(reason="Bug #3356")
     def test_context_is_parsed(self):

--- a/translate/storage/test_dtd.py
+++ b/translate/storage/test_dtd.py
@@ -199,7 +199,7 @@ class TestDTD(test_monolingual.TestMonolingualStore):
 
     def dtdregen(self, dtdsource):
         """helper that converts dtd source to dtdfile object and back"""
-        return self.dtdparse(dtdsource).serialize().decode('utf-8')
+        return bytes(self.dtdparse(dtdsource)).decode('utf-8')
 
     def test_getouput_deprecated(self):
         dtdfile = self.dtdparse('<!ENTITY test.me "bananas for sale">\n')
@@ -333,7 +333,7 @@ class TestDTD(test_monolingual.TestMonolingualStore):
         assert len(dtdfile.units) == 1
         dtdunit = dtdfile.units[0]
         assert dtdunit.definition == '"bananas for sale"'
-        assert dtdfile.serialize() == '<!ENTITY test.me "bananas for sale">\n'
+        assert bytes(dtdfile) == b'<!ENTITY test.me "bananas for sale">\n'
 
     def test_missing_quotes(self, recwarn):
         """test that we fail graacefully when a message without quotes is found (bug #161)"""
@@ -417,7 +417,7 @@ class TestAndroidDTD(test_monolingual.TestMonolingualStore):
         in-memory store and writing back to an Android DTD file without really
         having a real file.
         """
-        return self.dtdparse(dtdsource).serialize().decode('utf-8')
+        return bytes(self.dtdparse(dtdsource)).decode('utf-8')
 
     # Test for bug #2480
     def test_android_single_quote_escape(self):

--- a/translate/storage/test_dtd.py
+++ b/translate/storage/test_dtd.py
@@ -18,7 +18,8 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 from io import BytesIO
-from pytest import mark
+from pytest import deprecated_call, mark
+
 
 from translate.storage import dtd, test_monolingual
 
@@ -199,6 +200,11 @@ class TestDTD(test_monolingual.TestMonolingualStore):
     def dtdregen(self, dtdsource):
         """helper that converts dtd source to dtdfile object and back"""
         return self.dtdparse(dtdsource).serialize().decode('utf-8')
+
+    def test_getouput_deprecated(self):
+        dtdfile = self.dtdparse('<!ENTITY test.me "bananas for sale">\n')
+        assert dtdfile.getoutput() == bytes(dtdfile)
+        deprecated_call(dtdfile.getoutput)
 
     def test_simpleentity(self):
         """checks that a simple dtd entity definition is parsed correctly"""

--- a/translate/storage/test_monolingual.py
+++ b/translate/storage/test_monolingual.py
@@ -41,9 +41,9 @@ class TestMonolingualStore(test_base.TestTranslationStore):
             if str(store1unit) != str(store2unit):
                 print("match failed between elements %d of %d" % (n+1, len(store1.units)))
                 print("store1:")
-                print(store1.serialize())
+                print(bytes(store1))
                 print("store2:")
-                print(store2.serialize())
+                print(bytes(store2))
                 print("store1.units[%d].__dict__:" % n, store1unit.__dict__)
                 print("store2.units[%d].__dict__:" % n, store2unit.__dict__)
                 assert str(store1unit) == str(store2unit)

--- a/translate/storage/test_mozilla_lang.py
+++ b/translate/storage/test_mozilla_lang.py
@@ -57,7 +57,7 @@ class TestMozLangFile(test_base.TestTranslationStore):
         assert unit.source == "Source"
         assert unit.target == "Target"
         assert "Comment" in unit.getnotes()
-        assert store.serialize().decode('utf-8') == lang
+        assert bytes(store).decode('utf-8') == lang
 
     def test_active_flag(self):
         """Test the ## active ## flag"""
@@ -66,7 +66,7 @@ class TestMozLangFile(test_base.TestTranslationStore):
                 "Target\n")
         store = self.StoreClass.parsestring(lang)
         assert store.is_active
-        assert store.serialize().decode('utf-8') == lang
+        assert bytes(store).decode('utf-8') == lang
 
     def test_multiline_comments(self):
         """Ensure we can handle and preserve miltiline comments"""
@@ -77,7 +77,7 @@ class TestMozLangFile(test_base.TestTranslationStore):
                 ";Source\n"
                 "Target\n")
         store = self.StoreClass.parsestring(lang)
-        assert store.serialize().decode('utf-8') == lang
+        assert bytes(store).decode('utf-8') == lang
 
     def test_template(self):
         """A template should have source == target, though it could be blank"""
@@ -87,7 +87,7 @@ class TestMozLangFile(test_base.TestTranslationStore):
         unit = store.units[0]
         assert unit.source == "Source"
         assert unit.target == ""
-        assert store.serialize().decode('utf-8') == lang
+        assert bytes(store).decode('utf-8') == lang
         lang2 = (";Source\n"
                 "\n"
                 ";Source2\n")

--- a/translate/storage/test_oo.py
+++ b/translate/storage/test_oo.py
@@ -43,7 +43,8 @@ class TestOO:
 
     def ooregen(self, oosource):
         """helper that converts oo source to oofile object and back"""
-        return self.ooparse(oosource).serialize().decode('utf-8')
+        oofile = self.ooparse(oosource)
+        return bytes(oofile).decode('utf-8')
 
     def test_simpleentry(self):
         """checks that a simple oo entry is parsed correctly"""

--- a/translate/storage/test_php.py
+++ b/translate/storage/test_php.py
@@ -99,7 +99,7 @@ class TestPhpFile(test_monolingual.TestMonolingualStore):
 
     def phpregen(self, phpsource):
         """helper that converts php source to phpfile object and back"""
-        return self.phpparse(phpsource).serialize().decode('utf-8')
+        return bytes(self.phpparse(phpsource)).decode('utf-8')
 
     def test_simpledefinition(self):
         """checks that a simple php definition is parsed correctly"""

--- a/translate/storage/test_po.py
+++ b/translate/storage/test_po.py
@@ -193,7 +193,7 @@ class TestPOFile(test_base.TestTranslationStore):
 
     def poregen(self, posource):
         """helper that converts po source to pofile object and back"""
-        return self.poparse(posource).serialize()
+        return bytes(self.poparse(posource))
 
     def pomerge(self, oldmessage, newmessage, authoritative):
         """helper that merges two messages"""
@@ -215,7 +215,7 @@ class TestPOFile(test_base.TestTranslationStore):
             # force rewrapping:
             u.source = u.source
             u.target = u.target
-        return pofile.serialize().decode('utf-8')
+        return bytes(pofile).decode('utf-8')
 
     def test_context_only(self):
         """Checks that an empty msgid with msgctxt is handled correctly."""
@@ -227,7 +227,7 @@ msgstr ""
         assert pofile.units[0].istranslatable()
         assert not pofile.units[0].isheader()
         # we were not generating output for thse at some stage
-        assert pofile.serialize()
+        assert bytes(pofile)
 
     def test_simpleentry(self):
         """checks that a simple po entry is parsed correctly"""
@@ -355,7 +355,7 @@ msgid ""
 msgstr "POT-Creation-Date: 2006-03-08 17:30+0200\n"
 '''
         pofile = self.poparse(posource)
-        assert pofile.serialize().decode('utf-8') == posource
+        assert bytes(pofile).decode('utf-8') == posource
 
     def test_fuzzy(self):
         """checks that fuzzy functionality works as expected"""
@@ -366,7 +366,7 @@ msgstr "POT-Creation-Date: 2006-03-08 17:30+0200\n"
         assert pofile.units[0].isfuzzy()
         pofile.units[0].markfuzzy(False)
         assert not pofile.units[0].isfuzzy()
-        assert pofile.serialize().decode('utf-8') == expectednonfuzzy
+        assert bytes(pofile).decode('utf-8') == expectednonfuzzy
 
         posource = '#, fuzzy, python-format\nmsgid "ball"\nmsgstr "bal"\n'
         expectednonfuzzy = '#, python-format\nmsgid "ball"\nmsgstr "bal"\n'
@@ -376,10 +376,10 @@ msgstr "POT-Creation-Date: 2006-03-08 17:30+0200\n"
         assert pofile.units[0].isfuzzy()
         pofile.units[0].markfuzzy(False)
         assert not pofile.units[0].isfuzzy()
-        assert pofile.serialize().decode('utf-8') == expectednonfuzzy
+        assert bytes(pofile).decode('utf-8') == expectednonfuzzy
         pofile.units[0].markfuzzy()
-        print(pofile.serialize())
-        assert pofile.serialize().decode('utf-8') == expectedfuzzyagain
+        print(bytes(pofile))
+        assert bytes(pofile).decode('utf-8') == expectedfuzzyagain
 
         # test the same, but with flags in a different order
         posource = '#, python-format, fuzzy\nmsgid "ball"\nmsgstr "bal"\n'
@@ -390,11 +390,11 @@ msgstr "POT-Creation-Date: 2006-03-08 17:30+0200\n"
         assert pofile.units[0].isfuzzy()
         pofile.units[0].markfuzzy(False)
         assert not pofile.units[0].isfuzzy()
-        print(pofile.serialize())
-        assert pofile.serialize().decode('utf-8') == expectednonfuzzy
+        print(bytes(pofile))
+        assert bytes(pofile).decode('utf-8') == expectednonfuzzy
         pofile.units[0].markfuzzy()
-        print(pofile.serialize())
-        assert pofile.serialize().decode('utf-8') == expectedfuzzyagain
+        print(bytes(pofile))
+        assert bytes(pofile).decode('utf-8') == expectedfuzzyagain
 
     @mark.xfail(reason="Check differing behaviours between pypo and cpo")
     def test_makeobsolete_untranslated(self):
@@ -402,7 +402,7 @@ msgstr "POT-Creation-Date: 2006-03-08 17:30+0200\n"
         posource = '#. The automatic one\n#: test.c\nmsgid "test"\nmsgstr ""\n'
         pofile = self.poparse(posource)
         unit = pofile.units[0]
-        print(pofile.serialize())
+        print(bytes(pofile))
         assert not unit.isobsolete()
         unit.makeobsolete()
         assert str(unit) == ""
@@ -460,7 +460,7 @@ msgstr "tweede"
         assert len(pofile.units) == 1
         unit = pofile.units[0]
         assert unit.isobsolete()
-        assert pofile.serialize().decode('utf-8') == posource
+        assert bytes(pofile).decode('utf-8') == posource
 
         posource = '''msgid "one"
 msgstr "een"
@@ -476,9 +476,9 @@ msgstr "een"
         unit = pofile.units[1]
         assert unit.isobsolete()
 
-        print(pofile.serialize())
+        print(bytes(pofile))
         # Doesn't work with CPO if obsolete units are mixed with non-obsolete units
-        assert pofile.serialize().decode('utf-8') == posource
+        assert bytes(pofile).decode('utf-8') == posource
         unit.resurrect()
         assert unit.hasplural()
 
@@ -512,13 +512,13 @@ msgstr "een"
         assert not unit.istranslatable()
 
         print(posource)
-        print(pofile.serialize())
-        assert pofile.serialize().decode('utf-8') == posource
+        print(bytes(pofile))
+        assert bytes(pofile).decode('utf-8') == posource
 
     def test_header_escapes(self):
         pofile = self.StoreClass()
         pofile.updateheader(add=True, **{"Report-Msgid-Bugs-To": r"http://qa.openoffice.org/issues/enter_bug.cgi?subcomponent=ui&comment=&short_desc=Localization%20issue%20in%20file%3A%20dbaccess\source\core\resource.oo&component=l10n&form_name=enter_issue"})
-        filecontents = pofile.serialize().decode('utf-8')
+        filecontents = bytes(pofile).decode('utf-8')
         print(filecontents)
         # We need to make sure that the \r didn't get misrepresented as a
         # carriage return, but as a slash (escaped) followed by a normal 'r'
@@ -596,9 +596,9 @@ msgstr[1] "Koeie"
         assert len(pofile.units) == 1
         unit = pofile.units[0]
         assert unit.isobsolete()
-        print(pofile.serialize())
+        print(bytes(pofile))
         print(posource)
-        assert pofile.serialize().decode('utf-8') == posource
+        assert bytes(pofile).decode('utf-8') == posource
 
     def test_merge_duplicates(self):
         """checks that merging duplicates works"""
@@ -622,9 +622,9 @@ msgid "test"
 msgstr ""
 '''
         pofile = self.poparse(posource, duplicatestyle="allow")
-        print(pofile.serialize())
+        print(bytes(pofile))
         pofile.removeduplicates("merge")
-        print(pofile.serialize())
+        print(bytes(pofile))
         assert len(pofile.units) == 1
         assert pofile.units[0].getlocations() == ["source1", "source2"]
 
@@ -837,9 +837,9 @@ msgstr "プロジェクトが見つかりませんでした"
         pofile1 = self.poparse(posource)
         print(pofile1.units[1].source)
         assert pofile1.units[1].source == u"I cannot locate the project\\"
-        pofile2 = self.poparse(pofile1.serialize())
-        print(pofile2.serialize())
-        assert pofile1.serialize() == pofile2.serialize()
+        pofile2 = self.poparse(bytes(pofile1))
+        print(bytes(pofile2))
+        assert bytes(pofile1) == bytes(pofile2)
 
     def test_unfinished_lines(self):
         """Test that we reasonably handle lines with a single quote."""
@@ -856,10 +856,10 @@ msgstr "start thing dingis fish"
         pofile1 = self.poparse(posource)
         print(repr(pofile1.units[1].target))
         assert pofile1.units[1].target == u"start thing dingis fish"
-        pofile2 = self.poparse(pofile1.serialize())
+        pofile2 = self.poparse(bytes(pofile1))
         assert pofile2.units[1].target == u"start thing dingis fish"
-        print(pofile2.serialize())
-        assert pofile1.serialize() == pofile2.serialize()
+        print(bytes(pofile2))
+        assert bytes(pofile1) == bytes(pofile2)
 
     def test_encoding_change(self):
         posource = r'''
@@ -878,7 +878,7 @@ msgstr "d"
         pofile = self.poparse(posource)
         unit = pofile.units[1]
         unit.target = u"ḓ"
-        contents = pofile.serialize()
+        contents = bytes(pofile)
         assert b'msgstr "\xe1\xb8\x93"' in contents
         assert b'charset=UTF-8' in contents
 

--- a/translate/storage/test_poheader.py
+++ b/translate/storage/test_poheader.py
@@ -263,15 +263,15 @@ msgstr ""
 '''
     pofile = poparse(posource)
     pofile.updatecontributor("Grasvreter")
-    assert "# Grasvreter, 20" in pofile.serialize().decode('utf-8')
+    assert "# Grasvreter, 20" in bytes(pofile).decode('utf-8')
 
     pofile.updatecontributor("Koeivreter", "monster@grasveld.moe")
-    assert "# Koeivreter <monster@grasveld.moe>, 20" in pofile.serialize().decode('utf-8')
+    assert "# Koeivreter <monster@grasveld.moe>, 20" in bytes(pofile).decode('utf-8')
 
     pofile.header().addnote("Khaled Hosny <khaledhosny@domain.org>, 2006, 2007, 2008.")
     pofile.updatecontributor("Khaled Hosny", "khaledhosny@domain.org")
-    print(pofile.serialize())
-    assert "# Khaled Hosny <khaledhosny@domain.org>, 2006, 2007, 2008, %s." % time.strftime("%Y") in pofile.serialize().decode('utf-8')
+    print(bytes(pofile))
+    assert "# Khaled Hosny <khaledhosny@domain.org>, 2006, 2007, 2008, %s." % time.strftime("%Y") in bytes(pofile).decode('utf-8')
 
 
 def test_language():

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from pytest import deprecated_call, raises
+from pytest import raises
 
 from translate.misc import wStringIO
 from translate.storage import properties, test_monolingual

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -106,7 +106,7 @@ class TestProp(test_monolingual.TestMonolingualStore):
 
     def propregen(self, propsource):
         """helper that converts properties source to propfile object and back"""
-        return self.propparse(propsource).serialize().decode('utf-8')
+        return bytes(self.propparse(propsource)).decode('utf-8')
 
     def test_simpledefinition(self):
         """checks that a simple properties definition is parsed correctly"""
@@ -132,7 +132,7 @@ class TestProp(test_monolingual.TestMonolingualStore):
         propunit = propfile.units[0]
         assert propunit.name == "unicode"
         assert propunit.source == u"БЖЙШ"
-        regensource = propfile.serialize()
+        regensource = bytes(propfile)
         assert messagevalue in regensource
         assert b"\\u" not in regensource
 
@@ -340,7 +340,7 @@ key=value
         # - quotes inside are escaped
         # - for the sake of beauty a pair of spaces encloses the equal mark
         # - every line ends with ";"
-        assert propfile.serialize().strip(b'\n\x00') == propsource.strip(b'\n\x00')
+        assert bytes(propfile).strip(b'\n\x00') == propsource.strip(b'\n\x00')
 
     def test_override_encoding(self):
         """test that we can override the encoding of a properties file"""
@@ -365,7 +365,7 @@ key=value
         """test that BOM appears in the resulting text once only"""
         propsource = u"key1 = value1\nkey2 = value2\n".encode('utf-16')
         propfile = self.propparse(propsource, encoding='utf-16')
-        result = propfile.serialize()
+        result = bytes(propfile)
         bom = propsource[:2]
         assert result.startswith(bom)
         assert bom not in result[2:]
@@ -381,7 +381,7 @@ key=value
         propsource = u"\n\n\nkey1 = value1\n\nkey2 = value2\n".encode('utf-8-sig')
         propfile = self.propparse(propsource, personality='java-utf8')
         bom = propsource[:3]
-        result = propfile.serialize()
+        result = bytes(propfile)
         assert result.startswith(bom)
         assert bom not in result[3:]
         assert b'None' not in result[3:]

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -206,7 +206,7 @@ class TestPYPOFile(test_po.TestPOFile):
         thepo = pofile.units[0]
         thepo.msgidcomments.append('"_: first comment\\n"')
         thepo.msgidcomments.append('"_: second comment\\n"')
-        regenposource = pofile.serialize().decode('utf-8')
+        regenposource = bytes(pofile).decode('utf-8')
         assert regenposource.count("_:") == 1
 
     def test_duplicates_default(self):
@@ -259,7 +259,7 @@ class TestPYPOFile(test_po.TestPOFile):
         posource = u'''#: nb\nmsgid "Norwegian Bokm\xe5l"\nmsgstr ""\n'''
         pofile = self.StoreClass(wStringIO.StringIO(posource.encode("UTF-8")), encoding="UTF-8")
         assert len(pofile.units) == 1
-        print(pofile.serialize())
+        print(bytes(pofile))
         thepo = pofile.units[0]
         # On Python 2, str() returns bytestrings while on Python 3, str() returns unicode
         assert str(thepo) == posource if six.PY3 else posource.encode("UTF-8")
@@ -279,7 +279,7 @@ class TestPYPOFile(test_po.TestPOFile):
         pofile = self.poparse(posource)
         print(pofile)
         assert len(pofile.units) == 1
-        assert pofile.serialize().decode('utf-8') == posource
+        assert bytes(pofile).decode('utf-8') == posource
         assert pofile.units[0].othercomments == ["# other comment\n"]
         assert pofile.units[0].automaticcomments == ["#. automatic comment\n"]
         assert pofile.units[0].sourcecomments == ["#: source comment\n"]
@@ -289,7 +289,7 @@ class TestPYPOFile(test_po.TestPOFile):
         """tests behaviour of unassociated comments."""
         oldsource = '# old lonesome comment\n\nmsgid "one"\nmsgstr "een"\n'
         oldfile = self.poparse(oldsource)
-        print(oldfile.serialize())
+        print(bytes(oldfile))
         assert len(oldfile.units) == 1
 
     def test_prevmsgid_parse(self):
@@ -343,4 +343,4 @@ msgstr[1] "toetse"
         assert pofile.units[4].prev_msgctxt == [u'"context 2"']
         assert pofile.units[4].prev_source == multistring([u"tast", u"tasts"])
 
-        assert pofile.serialize().decode('utf-8') == posource
+        assert bytes(pofile).decode('utf-8') == posource

--- a/translate/storage/test_qph.py
+++ b/translate/storage/test_qph.py
@@ -49,8 +49,8 @@ class TestQphFile(test_base.TestTranslationStore):
         assert qphfile.units == []
         qphfile.addsourceunit("Bla")
         assert len(qphfile.units) == 1
-        newfile = qph.QphFile.parsestring(qphfile.serialize())
-        print(qphfile.serialize())
+        newfile = qph.QphFile.parsestring(bytes(qphfile))
+        print(bytes(qphfile))
         assert len(newfile.units) == 1
         assert newfile.units[0].source == "Bla"
         assert newfile.findunit("Bla").source == "Bla"
@@ -60,8 +60,8 @@ class TestQphFile(test_base.TestTranslationStore):
         qphfile = qph.QphFile()
         qphunit = qphfile.addsourceunit("Concept")
         qphunit.source = "Term"
-        newfile = qph.QphFile.parsestring(qphfile.serialize())
-        print(qphfile.serialize())
+        newfile = qph.QphFile.parsestring(bytes(qphfile))
+        print(bytes(qphfile))
         assert newfile.findunit("Concept") is None
         assert newfile.findunit("Term") is not None
 
@@ -69,8 +69,8 @@ class TestQphFile(test_base.TestTranslationStore):
         qphfile = qph.QphFile()
         qphunit = qphfile.addsourceunit("Concept")
         qphunit.target = "Konsep"
-        newfile = qph.QphFile.parsestring(qphfile.serialize())
-        print(qphfile.serialize())
+        newfile = qph.QphFile.parsestring(bytes(qphfile))
+        print(bytes(qphfile))
         assert newfile.findunit("Concept").target == "Konsep"
 
     def test_language(self):
@@ -84,7 +84,7 @@ class TestQphFile(test_base.TestTranslationStore):
         assert qphfile.gettargetlanguage() == 'fr'
         assert qphfile.getsourcelanguage() == 'de'
         qphfile.settargetlanguage('pt_BR')
-        assert 'pt_BR' in qphfile.serialize().decode('utf-8')
+        assert 'pt_BR' in bytes(qphfile).decode('utf-8')
         assert qphfile.gettargetlanguage() == 'pt-br'
         # We convert en_US to en
         qphstr = '''<!DOCTYPE QPH>

--- a/translate/storage/test_rc.py
+++ b/translate/storage/test_rc.py
@@ -24,7 +24,7 @@ class TestRcFile(object):
 
     def source_regenerate(self, source):
         """Helper that converts source to store object and back."""
-        return self.source_parse(source).serialize()
+        return bytes(self.source_parse(source))
 
     def test_parse_only_comments(self):
         """Test parsing a RC string with only comments."""

--- a/translate/storage/test_tbx.py
+++ b/translate/storage/test_tbx.py
@@ -13,8 +13,8 @@ class TestTBXfile(test_base.TestTranslationStore):
         assert tbxfile.units == []
         tbxfile.addsourceunit("Bla")
         assert len(tbxfile.units) == 1
-        newfile = tbx.tbxfile.parsestring(tbxfile.serialize())
-        print(tbxfile.serialize())
+        newfile = tbx.tbxfile.parsestring(bytes(tbxfile))
+        print(bytes(tbxfile))
         assert len(newfile.units) == 1
         assert newfile.units[0].source == "Bla"
         assert newfile.findunit("Bla").source == "Bla"
@@ -24,8 +24,8 @@ class TestTBXfile(test_base.TestTranslationStore):
         tbxfile = tbx.tbxfile()
         tbxunit = tbxfile.addsourceunit("Concept")
         tbxunit.source = "Term"
-        newfile = tbx.tbxfile.parsestring(tbxfile.serialize())
-        print(tbxfile.serialize())
+        newfile = tbx.tbxfile.parsestring(bytes(tbxfile))
+        print(bytes(tbxfile))
         assert newfile.findunit("Concept") is None
         assert newfile.findunit("Term") is not None
 
@@ -33,6 +33,6 @@ class TestTBXfile(test_base.TestTranslationStore):
         tbxfile = tbx.tbxfile()
         tbxunit = tbxfile.addsourceunit("Concept")
         tbxunit.target = "Konsep"
-        newfile = tbx.tbxfile.parsestring(tbxfile.serialize())
-        print(tbxfile.serialize())
+        newfile = tbx.tbxfile.parsestring(bytes(tbxfile))
+        print(bytes(tbxfile))
         assert newfile.findunit("Concept").target == "Konsep"

--- a/translate/storage/test_tmx.py
+++ b/translate/storage/test_tmx.py
@@ -46,8 +46,8 @@ class TestTMXfile(test_base.TestTranslationStore):
         """tests that addtranslation() stores strings correctly"""
         tmxfile = tmx.tmxfile()
         tmxfile.addtranslation("A string of characters", "en", "'n String karakters", "af")
-        newfile = self.tmxparse(tmxfile.serialize())
-        print(tmxfile.serialize())
+        newfile = self.tmxparse(bytes(tmxfile))
+        print(bytes(tmxfile))
         assert newfile.translate("A string of characters") == "'n String karakters"
 
     def test_withcomment(self):
@@ -55,16 +55,16 @@ class TestTMXfile(test_base.TestTranslationStore):
         tmxfile = tmx.tmxfile()
         tmxfile.addtranslation("A string of chars",
                                "en", "'n String karakters", "af", "comment")
-        newfile = self.tmxparse(tmxfile.serialize())
-        print(tmxfile.serialize())
+        newfile = self.tmxparse(bytes(tmxfile))
+        print(bytes(tmxfile))
         assert newfile.findunit("A string of chars").getnotes() == "comment"
 
     def test_withnewlines(self):
         """test addtranslation() with newlines"""
         tmxfile = tmx.tmxfile()
         tmxfile.addtranslation("First line\nSecond line", "en", "Eerste lyn\nTweede lyn", "af")
-        newfile = self.tmxparse(tmxfile.serialize())
-        print(tmxfile.serialize())
+        newfile = self.tmxparse(bytes(tmxfile))
+        print(bytes(tmxfile))
         assert newfile.translate("First line\nSecond line") == "Eerste lyn\nTweede lyn"
 
     def test_xmlentities(self):
@@ -72,7 +72,7 @@ class TestTMXfile(test_base.TestTranslationStore):
         tmxfile = tmx.tmxfile()
         tmxfile.addtranslation("Mail & News", "en", "Nuus & pos", "af")
         tmxfile.addtranslation("Five < ten", "en", "Vyf < tien", "af")
-        xmltext = tmxfile.serialize().decode('utf-8')
+        xmltext = bytes(tmxfile).decode('utf-8')
         print("The generated xml:")
         print(xmltext)
         assert tmxfile.translate('Mail & News') == 'Nuus & pos'

--- a/translate/storage/test_ts2.py
+++ b/translate/storage/test_ts2.py
@@ -86,8 +86,8 @@ class TestTSfile(test_base.TestTranslationStore):
         assert tsfile.units == []
         tsfile.addsourceunit("Bla")
         assert len(tsfile.units) == 1
-        newfile = ts.tsfile.parsestring(tsfile.serialize())
-        print(tsfile.serialize())
+        newfile = ts.tsfile.parsestring(bytes(tsfile))
+        print(bytes(tsfile))
         assert len(newfile.units) == 1
         assert newfile.units[0].source == "Bla"
         assert newfile.findunit("Bla").source == "Bla"
@@ -97,8 +97,8 @@ class TestTSfile(test_base.TestTranslationStore):
         tsfile = ts.tsfile()
         tsunit = tsfile.addsourceunit("Concept")
         tsunit.source = "Term"
-        newfile = ts.tsfile.parsestring(tsfile.serialize())
-        print(tsfile.serialize())
+        newfile = ts.tsfile.parsestring(bytes(tsfile))
+        print(bytes(tsfile))
         assert newfile.findunit("Concept") is None
         assert newfile.findunit("Term") is not None
 
@@ -106,8 +106,8 @@ class TestTSfile(test_base.TestTranslationStore):
         tsfile = ts.tsfile()
         tsunit = tsfile.addsourceunit("Concept")
         tsunit.target = "Konsep"
-        newfile = ts.tsfile.parsestring(tsfile.serialize())
-        print(tsfile.serialize())
+        newfile = ts.tsfile.parsestring(bytes(tsfile))
+        print(bytes(tsfile))
         assert newfile.findunit("Concept").target == "Konsep"
 
     def test_plurals(self):
@@ -115,8 +115,8 @@ class TestTSfile(test_base.TestTranslationStore):
         tsfile = ts.tsfile()
         tsunit = tsfile.addsourceunit("File(s)")
         tsunit.target = [u"Leêr", u"Leêrs"]
-        newfile = ts.tsfile.parsestring(tsfile.serialize())
-        print(tsfile.serialize())
+        newfile = ts.tsfile.parsestring(bytes(tsfile))
+        print(bytes(tsfile))
         checkunit = newfile.findunit("File(s)")
         assert checkunit.target == [u"Leêr", u"Leêrs"]
         assert checkunit.hasplural()
@@ -132,7 +132,7 @@ class TestTSfile(test_base.TestTranslationStore):
         assert tsfile.gettargetlanguage() == 'fr'
         assert tsfile.getsourcelanguage() == 'de'
         tsfile.settargetlanguage('pt_BR')
-        assert 'pt_BR' in tsfile.serialize().decode('utf-8')
+        assert 'pt_BR' in bytes(tsfile).decode('utf-8')
         assert tsfile.gettargetlanguage() == 'pt-br'
         # We convert en_US to en
         tsstr = '''<!DOCTYPE TS>
@@ -166,7 +166,7 @@ class TestTSfile(test_base.TestTranslationStore):
         newtsstr = tsstr.replace(
             '>TargetString', ' type="unfinished">TestTarget'
         )
-        assert newtsstr == tsfile.serialize().decode('utf-8')
+        assert newtsstr == bytes(tsfile).decode('utf-8')
 
     def test_locations(self):
         """test that locations work well"""
@@ -252,4 +252,4 @@ class TestTSfile(test_base.TestTranslationStore):
     def test_backnforth(self):
         """test that ts files are read and output properly"""
         tsfile = ts.tsfile.parsestring(TS_NUMERUS)
-        assert tsfile.serialize().decode('utf-8') == TS_NUMERUS
+        assert bytes(tsfile).decode('utf-8') == TS_NUMERUS

--- a/translate/storage/test_txt.py
+++ b/translate/storage/test_txt.py
@@ -1,3 +1,5 @@
+from py.test import deprecated_call
+
 from translate.misc import wStringIO
 from translate.storage import test_monolingual, txt
 
@@ -37,3 +39,10 @@ class TestTxtFile(test_monolingual.TestMonolingualStore):
         print("*%s*" % txtfile.units[0])
         assert txtfile.serialize().decode('utf-8') == txtsource
         assert self.txtregen(txtsource) == txtsource
+
+    def test_getoutput(self):
+        # Test deprecated method still works
+        txtsource = 'bananas for sale'
+        txtfile = self.txtparse(txtsource)
+        assert txtfile.getoutput() == bytes(txtfile)
+        deprecated_call(txtfile.getoutput)

--- a/translate/storage/test_txt.py
+++ b/translate/storage/test_txt.py
@@ -19,7 +19,7 @@ class TestTxtFile(test_monolingual.TestMonolingualStore):
 
     def txtregen(self, txtsource):
         """helper that converts txt source to txtfile object and back"""
-        return self.txtparse(txtsource).serialize().decode('utf-8')
+        return bytes(self.txtparse(txtsource)).decode('utf-8')
 
     def test_simpleblock(self):
         """checks that a simple txt block is parsed correctly"""
@@ -35,9 +35,9 @@ class TestTxtFile(test_monolingual.TestMonolingualStore):
         txtfile = self.txtparse(txtsource)
         assert len(txtfile.units) == 3
         print(txtsource)
-        print(txtfile.serialize())
+        print(bytes(txtfile))
         print("*%s*" % txtfile.units[0])
-        assert txtfile.serialize().decode('utf-8') == txtsource
+        assert bytes(txtfile).decode('utf-8') == txtsource
         assert self.txtregen(txtsource) == txtsource
 
     def test_getoutput(self):

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -63,8 +63,8 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert xlifffile.units == []
         xlifffile.addsourceunit("Bla")
         assert len(xlifffile.units) == 1
-        newfile = xliff.xlifffile.parsestring(xlifffile.serialize())
-        print(xlifffile.serialize())
+        newfile = xliff.xlifffile.parsestring(bytes(xlifffile))
+        print(bytes(xlifffile))
         assert len(newfile.units) == 1
         assert newfile.units[0].source == "Bla"
         assert newfile.findunit("Bla").source == "Bla"
@@ -83,7 +83,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </xliff:file>
 </xliff:xliff>'''
         xlifffile = xliff.xlifffile.parsestring(xlfsource)
-        print(xlifffile.serialize())
+        print(bytes(xlifffile))
         assert xlifffile.units[0].source == "File 1"
 
     def test_rich_source(self):
@@ -167,8 +167,8 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         xlifffile = xliff.xlifffile()
         xliffunit = xlifffile.addsourceunit("Concept")
         xliffunit.source = "Term"
-        newfile = xliff.xlifffile.parsestring(xlifffile.serialize())
-        print(xlifffile.serialize())
+        newfile = xliff.xlifffile.parsestring(bytes(xlifffile))
+        print(bytes(xlifffile))
         assert newfile.findunit("Concept") is None
         assert newfile.findunit("Term") is not None
 
@@ -176,20 +176,20 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         xlifffile = xliff.xlifffile()
         xliffunit = xlifffile.addsourceunit("Concept")
         xliffunit.target = "Konsep"
-        newfile = xliff.xlifffile.parsestring(xlifffile.serialize())
-        print(xlifffile.serialize())
+        newfile = xliff.xlifffile.parsestring(bytes(xlifffile))
+        print(bytes(xlifffile))
         assert newfile.findunit("Concept").target == "Konsep"
 
     def test_sourcelanguage(self):
         xlifffile = xliff.xlifffile(sourcelanguage="xh")
-        xmltext = xlifffile.serialize().decode('utf-8')
+        xmltext = bytes(xlifffile).decode('utf-8')
         print(xmltext)
         assert xmltext.find('source-language="xh"') > 0
         #TODO: test that it also works for new files.
 
     def test_targetlanguage(self):
         xlifffile = xliff.xlifffile(sourcelanguage="zu", targetlanguage="af")
-        xmltext = xlifffile.serialize().decode('utf-8')
+        xmltext = bytes(xlifffile).decode('utf-8')
         print(xmltext)
         assert xmltext.find('source-language="zu"') > 0
         assert xmltext.find('target-language="af"') > 0
@@ -198,11 +198,11 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         xlifffile = xliff.xlifffile()
         unit = xlifffile.addsourceunit("Concept")
         # We don't want to add unnecessary notes
-        assert not "note" in xlifffile.serialize().decode('utf-8')
+        assert not "note" in bytes(xlifffile).decode('utf-8')
         unit.addnote(None)
-        assert not "note" in xlifffile.serialize().decode('utf-8')
+        assert not "note" in bytes(xlifffile).decode('utf-8')
         unit.addnote("")
-        assert not "note" in xlifffile.serialize().decode('utf-8')
+        assert not "note" in bytes(xlifffile).decode('utf-8')
 
         unit.addnote("Please buy bread")
         assert unit.getnotes() == "Please buy bread"

--- a/translate/storage/tiki.py
+++ b/translate/storage/tiki.py
@@ -102,14 +102,14 @@ class TikiStore(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def serialize(self):
+    def serialize(self, out):
         """Will return a formatted tiki-style language.php file."""
         _unused = []
         _untranslated = []
         _possiblyuntranslated = []
         _translated = []
 
-        output = self._tiki_header()
+        out.write(self._tiki_header().encode(self.encoding))
 
         # Reorder all the units into their groups
         for unit in self.units:
@@ -122,23 +122,22 @@ class TikiStore(base.TranslationStore):
             else:
                 _translated.append(unit)
 
-        output += "// ### Start of unused words\n"
+        out.write(b"// ### Start of unused words\n")
         for unit in _unused:
-            output += six.text_type(unit)
-        output += "// ### end of unused words\n\n"
-        output += "// ### start of untranslated words\n"
+            out.write(six.text_type(unit).encode(self.encoding))
+        out.write(b"// ### end of unused words\n\n"
+                  b"// ### start of untranslated words\n")
         for unit in _untranslated:
-            output += six.text_type(unit)
-        output += "// ### end of untranslated words\n\n"
-        output += "// ### start of possibly untranslated words\n"
+            out.write(six.text_type(unit).encode(self.encoding))
+        out.write(b"// ### end of untranslated words\n\n"
+                  b"// ### start of possibly untranslated words\n")
         for unit in _possiblyuntranslated:
-            output += six.text_type(unit)
-        output += "// ### end of possibly untranslated words\n\n"
+            out.write(six.text_type(unit).encode(self.encoding))
+        out.write(b"// ### end of possibly untranslated words\n\n")
         for unit in _translated:
-            output += six.text_type(unit)
+            out.write(six.text_type(unit).encode(self.encoding))
 
-        output += self._tiki_footer()
-        return output.encode(self.encoding)
+        out.write(self._tiki_footer().encode(self.encoding))
 
     def _tiki_header(self):
         """Returns a tiki-file header string."""

--- a/translate/storage/trados.py
+++ b/translate/storage/trados.py
@@ -198,6 +198,6 @@ class TradosTxtTmFile(base.TranslationStore):
             unit._soup = TradosSoup(str(tu))
             self.addunit(unit)
 
-    def serialize(self):
+    def serialize(self, out):
         # FIXME turn the lowercased tags back into mixed case
-        return self._soup.prettify()
+        out.write(self._soup.prettify())

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -476,13 +476,13 @@ class tsfile(lisa.LISAfile):
         else:
             return 1
 
-    def serialize(self):
-        """Converts to a string containing the file's XML."""
+    def serialize(self, out):
+        """Write the XML document to a file."""
         root = self.document.getroot()
         doctype = self.document.docinfo.doctype
         # Iterate over empty tags without children and force empty text
         # This will prevent self-closing tags in pretty_print mode
         for e in root.xpath("//*[not(./node()) and not(text())]"):
             e.text = ""
-        return etree.tostring(root, doctype=doctype, pretty_print=True,
-                              xml_declaration=True, encoding='utf-8')
+        out.write(etree.tostring(root, doctype=doctype, pretty_print=True,
+                                 xml_declaration=True, encoding='utf-8'))

--- a/translate/storage/txt.py
+++ b/translate/storage/txt.py
@@ -29,6 +29,7 @@ Supported formats are
 import re
 import six
 
+from translate.misc.deprecation import deprecated
 from translate.storage import base
 
 
@@ -145,14 +146,13 @@ class TxtFile(base.TranslationStore):
             unit = self.addsourceunit("\n".join(block))
             unit.addlocation("%s:%d" % (self.filename, startline + 1))
 
-    def serialize(self):
-        source = self.getoutput()
-        if isinstance(source, six.text_type):
-            return source.encode(self.encoding)
-        return source
+    def serialize(self, out):
+        for idx, unit in enumerate(self.units):
+            if idx > 0:
+                out.write(b'\n\n')
+            out.write(six.text_type(unit).encode(self.encoding))
 
+    # Deprecated on 1.14
+    @deprecated("Use bytes(TxtFile) instead")
     def getoutput(self):
-        """Convert the units back to blocks"""
-        blocks = [str(unit) for unit in self.units]
-        string = "\n\n".join(blocks)
-        return string
+        return bytes(self)

--- a/translate/storage/utx.py
+++ b/translate/storage/utx.py
@@ -269,11 +269,11 @@ class UtxFile(base.TranslationStore):
             newunit.dict = line
             self.addunit(newunit)
 
-    def serialize(self):
+    def serialize(self, out):
         # Check first if there is at least one translated unit
         translated_units = [u for u in self.units if u.istranslated()]
         if not translated_units:
-            return b""
+            return
 
         output = csv.StringIO()
         writer = csv_utils.UnicodeDictWriter(
@@ -282,4 +282,5 @@ class UtxFile(base.TranslationStore):
             writer.writerow(unit.dict)
 
         result = output.getvalue() if six.PY2 else output.getvalue().encode(self.encoding)
-        return self._write_header().encode(self.encoding) + result
+        out.write(self._write_header().encode(self.encoding))
+        out.write(result)

--- a/translate/storage/wordfast.py
+++ b/translate/storage/wordfast.py
@@ -397,11 +397,11 @@ class WordfastTMFile(base.TranslationStore):
             newunit.dict = line
             self.addunit(newunit)
 
-    def serialize(self):
+    def serialize(self, out):
         # Check first if there is at least one translated unit
         translated_units = [u for u in self.units if u.istranslated()]
         if not translated_units:
-            return b""
+            return
 
         output = csv.StringIO()
         writer = csv_utils.UnicodeDictWriter(
@@ -412,4 +412,4 @@ class WordfastTMFile(base.TranslationStore):
 
         for unit in translated_units:
             writer.writerow(unit.dict)
-        return output.getvalue() if six.PY2 else output.getvalue().encode(self.encoding)
+        out.write(output.getvalue() if six.PY2 else output.getvalue().encode(self.encoding))

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -773,9 +773,9 @@ class xlifffile(lisa.LISAfile):
             group.set("restype", restype)
         return group
 
-    def serialize(self):
+    def serialize(self, out):
         self.removedefaultfile()
-        return super(xlifffile, self).serialize()
+        super(xlifffile, self).serialize(out)
 
     @classmethod
     def parsestring(cls, storestring):

--- a/translate/tools/phppo2pypo.py
+++ b/translate/tools/phppo2pypo.py
@@ -82,7 +82,7 @@ def convertphp2py(inputfile, outputfile, template=None):
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
         return False
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return True
 
 

--- a/translate/tools/poclean.py
+++ b/translate/tools/poclean.py
@@ -63,7 +63,7 @@ def runclean(inputfile, outputfile, templatefile):
     cleanfile(fromfile)
 #    if fromfile.isempty():
 #        return False
-    outputfile.write(fromfile.serialize())
+    fromfile.serialize(outputfile)
     return True
 
 

--- a/translate/tools/pocompile.py
+++ b/translate/tools/pocompile.py
@@ -53,7 +53,7 @@ class POCompile:
                         mounit.msgctxt = [context]
                 mounit.target = unit.target
                 outputfile.addunit(mounit)
-        return outputfile.serialize()
+        return bytes(outputfile)
 
 
 def convertmo(inputfile, outputfile, templatefile, includefuzzy=False):

--- a/translate/tools/poconflicts.py
+++ b/translate/tools/poconflicts.py
@@ -181,7 +181,7 @@ class ConflictOptionParser(optrecurse.RecursiveOptionParser):
                 unit.othercomments.append("# (poconflicts) %s\n" % filename)
                 conflictfile.units.append(unit)
             with open(fulloutputpath, "wb") as fh:
-                fh.write(conflictfile.serialize())
+                conflictfile.serialize(fh)
 
 
 def main():

--- a/translate/tools/podebug.py
+++ b/translate/tools/podebug.py
@@ -315,7 +315,7 @@ def convertpo(inputfile, outputfile, templatefile, format=None, rewritestyle=Non
         return 0
     convertor = podebug(format=format, rewritestyle=rewritestyle, ignoreoption=ignoreoption)
     outputstore = convertor.convertstore(inputstore)
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/tools/pogrep.py
+++ b/translate/tools/pogrep.py
@@ -338,7 +338,7 @@ def rungrep(inputfile, outputfile, templatefile, checkfilter):
     tofile = checkfilter.filterfile(fromfile)
     if tofile.isempty():
         return False
-    outputfile.write(tofile.serialize())
+    tofile.serialize(outputfile)
     return True
 
 

--- a/translate/tools/pomerge.py
+++ b/translate/tools/pomerge.py
@@ -99,7 +99,7 @@ def mergestore(inputfile, outputfile, templatefile, mergeblanks="no", mergefuzzy
                     mergefuzzy, mergecomments)
     if outputstore.isempty():
         return 0
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/tools/porestructure.py
+++ b/translate/tools/porestructure.py
@@ -107,7 +107,7 @@ class SplitOptionParser(optrecurse.RecursiveOptionParser):
                         outputpofile = po.pofile()
                     outputpofile.units.append(pounit)   # TODO:perhaps check to see if it's already there...
                     with open(fulloutputpath, 'wb') as fh:
-                        fh.write(outputpofile.serialize())
+                        outputpofile.serialize(fh)
 
 
 def main():

--- a/translate/tools/posegment.py
+++ b/translate/tools/posegment.py
@@ -80,7 +80,7 @@ def segmentfile(inputfile, outputfile, templatefile, sourcelanguage="en", target
     targetlang = lang_factory.getlanguage(targetlanguage)
     convertor = segment(sourcelang, targetlang, stripspaces=stripspaces, onlyaligned=onlyaligned)
     outputstore = convertor.convertstore(inputstore)
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return 1
 
 

--- a/translate/tools/poswap.py
+++ b/translate/tools/poswap.py
@@ -86,7 +86,7 @@ def convertpo(inputpofile, outputpotfile, template, reverse=False):
             unit.target = templateunit.target
         if unit.isobsolete():
             del inputpo.units[i]
-    outputpotfile.write(inputpo.serialize())
+    inputpo.serialize(outputpotfile)
     return 1
 
 

--- a/translate/tools/poterminology.py
+++ b/translate/tools/poterminology.py
@@ -450,7 +450,7 @@ class TerminologyOptionParser(optrecurse.RecursiveOptionParser):
         for count, unit in termitems:
             termfile.units.append(unit)
         with open(options.output, "wb") as fh:
-            fh.write(termfile.serialize())
+            termfile.serialize(fh)
 
 
 def fold_case_option(option, opt_str, value, parser):

--- a/translate/tools/pretranslate.py
+++ b/translate/tools/pretranslate.py
@@ -59,7 +59,7 @@ def pretranslate_file(input_file, output_file, template_file, tm=None,
 
     output = pretranslate_store(input_store, template_store, tm,
                                 min_similarity, fuzzymatching)
-    output_file.write(output.serialize())
+    output.serialize(output_file)
     return 1
 
 

--- a/translate/tools/pypo2phppo.py
+++ b/translate/tools/pypo2phppo.py
@@ -93,7 +93,7 @@ def convertpy2php(inputfile, outputfile, template=None):
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
         return False
-    outputfile.write(outputstore.serialize())
+    outputstore.serialize(outputfile)
     return True
 
 

--- a/translate/tools/test_podebug.py
+++ b/translate/tools/test_podebug.py
@@ -98,7 +98,7 @@ class TestPODebug:
 
         assert in_unit.source == out_unit.source
         print(out_unit.target)
-        print(po_out.serialize())
+        print(bytes(po_out))
         rewrite_func = self.debug.rewrite_unicode
         assert out_unit.target == u"%s%%s%s" % (rewrite_func(u'This is a '), rewrite_func(u' test, hooray.'))
 
@@ -111,7 +111,7 @@ class TestPODebug:
 
         assert in_unit.source == out_unit.source
         print(out_unit.target)
-        print(xliff_out.serialize())
+        print(bytes(xliff_out))
         assert out_unit.target == u'xxx%sxxx' % (in_unit.source)
 
     def test_hash(self):

--- a/translate/tools/test_pogrep.py
+++ b/translate/tools/test_pogrep.py
@@ -21,8 +21,8 @@ class TestPOGrep:
         options, args = pogrep.cmdlineparser().parse_args(["xxx.po"] + cmdlineoptions)
         grepfilter = pogrep.GrepFilter(searchstring, options.searchparts, options.ignorecase, options.useregexp, options.invertmatch, options.keeptranslations, options.accelchar)
         tofile = grepfilter.filterfile(self.poparse(posource))
-        print(tofile.serialize())
-        return tofile.serialize()
+        print(bytes(tofile))
+        return bytes(tofile)
 
     def test_simplegrep_msgid(self):
         """grep for a string in the source"""
@@ -150,7 +150,7 @@ class TestXLiffGrep:
         options, args = pogrep.cmdlineparser().parse_args(["xxx.xliff"] + cmdlineoptions)
         grepfilter = pogrep.GrepFilter(searchstring, options.searchparts, options.ignorecase, options.useregexp, options.invertmatch, options.accelchar)
         tofile = grepfilter.filterfile(self.xliff_parse(xliff_text))
-        return tofile.serialize()
+        return bytes(tofile)
 
     def test_simplegrep(self):
         """grep for a simple string."""

--- a/translate/tools/test_pomerge.py
+++ b/translate/tools/test_pomerge.py
@@ -154,7 +154,7 @@ msgstr "Dimpled Ring"'''
         expectedpo = '''#: location.c:1%slocation.c:2\nmsgid "Simple String"\nmsgstr "Dimpled Ring"\n''' % po.lsep
         pofile = self.mergestore(templatepo, inputpo)
         print(pofile)
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_unit_missing_in_template_with_locations(self):
         """If the unit is missing in the template we should raise an error"""
@@ -174,7 +174,7 @@ msgstr "Dimpled Ring"
 '''
         pofile = self.mergestore(templatepo, inputpo)
         print(pofile)
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_unit_missing_in_template_no_locations(self):
         """If the unit is missing in the template we should raise an error"""
@@ -190,7 +190,7 @@ msgstr "Dimpled Ring"
 '''
         pofile = self.mergestore(templatepo, inputpo)
         print(pofile)
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_reflowed_source_comments(self):
         """ensure that we don't duplicate source comments (locations) if they
@@ -201,7 +201,7 @@ msgstr "Dimpled Ring"
         pofile = self.mergestore(templatepo, newpo)
         pounit = self.singleunit(pofile)
         print(pofile)
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_comments_with_blank_lines(self):
         """ensure that we don't loose empty newlines in comments"""
@@ -217,7 +217,7 @@ msgstr "blabla"
         pofile = self.mergestore(templatepo, newpo)
         pounit = self.singleunit(pofile)
         print(pofile)
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_merge_dont_delete_unassociated_comments(self):
         """ensure that we do not delete comments in the PO file that are not
@@ -228,7 +228,7 @@ msgstr "blabla"
         pofile = self.mergestore(templatepo, mergepo)
 #        pounit = self.singleunit(pofile)
         print(pofile)
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_preserve_format_trailing_newlines(self):
         """Test that we can merge messages correctly that end with a newline"""
@@ -236,16 +236,16 @@ msgstr "blabla"
         mergepo = '''msgid "Simple string\\n"\nmsgstr "Dimpled ring\\n"\n'''
         expectedpo = '''msgid "Simple string\\n"\nmsgstr "Dimpled ring\\n"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
         templatepo = '''msgid ""\n"Simple string\\n"\nmsgstr ""\n'''
         mergepo = '''msgid ""\n"Simple string\\n"\nmsgstr ""\n"Dimpled ring\\n"\n'''
         expectedpo = '''msgid ""\n"Simple string\\n"\nmsgstr "Dimpled ring\\n"\n'''
         expectedpo2 = '''msgid "Simple string\\n"\nmsgstr "Dimpled ring\\n"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo or pofile.serialize() == expectedpo2
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo or bytes(pofile) == expectedpo2
 
     def test_preserve_format_minor_start_and_end_of_sentence_changes(self):
         """Test that we are not too fussy about large diffs for simple
@@ -254,22 +254,22 @@ msgstr "blabla"
         mergepo = '''msgid "Target type:"\nmsgstr "Doelsoort:"\n'''
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
         templatepo = '''msgid "&Select"\nmsgstr "Kies"\n\n'''
         mergepo = '''msgid "&Select"\nmsgstr "&Kies"\n'''
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
         templatepo = '''msgid "en-us, en"\nmsgstr "en-us, en"\n'''
         mergepo = '''msgid "en-us, en"\nmsgstr "af-za, af, en-za, en-gb, en-us, en"\n'''
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_preserve_format_last_entry_in_a_file(self):
         """The last entry in a PO file is usualy not followed by an empty
@@ -278,15 +278,15 @@ msgstr "blabla"
         mergepo = '''msgid "First"\nmsgstr "Eerste"\n\nmsgid "Second"\nmsgstr "Tweede"\n'''
         expectedpo = '''msgid "First"\nmsgstr "Eerste"\n\nmsgid "Second"\nmsgstr "Tweede"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
         templatepo = '''msgid "First"\nmsgstr ""\n\nmsgid "Second"\nmsgstr ""\n\n'''
         mergepo = '''msgid "First"\nmsgstr "Eerste"\n\nmsgid "Second"\nmsgstr "Tweede"\n'''
         expectedpo = '''msgid "First"\nmsgstr "Eerste"\n\nmsgid "Second"\nmsgstr "Tweede"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     @mark.xfail(reason="Not Implemented")
     def test_escape_tabs(self):
@@ -300,8 +300,8 @@ msgstr "blabla"
 msgstr "Eerste\tTweede"
 '''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_preserve_comments_layout(self):
         """Ensure that when we merge with new '# (poconflict)' or other
@@ -310,8 +310,8 @@ msgstr "Eerste\tTweede"
         mergepo = '''# (pofilter) unchanged: please translate\n#: filename\nmsgid "Desktop Background.bmp"\nmsgstr "Desktop Background.bmp"\n'''
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_merge_dos2unix(self):
         """Test that merging a comment line with dos newlines doesn't add a
@@ -320,21 +320,21 @@ msgstr "Eerste\tTweede"
         mergepo = '''# User comment\r\n# (pofilter) Translate Toolkit comment\r\n#. Automatic comment\r\n#: location_comment.c:110\r\nmsgid "File"\r\nmsgstr "Ifayile"\r\n\r\n'''
         expectedpo = '''# User comment\n# (pofilter) Translate Toolkit comment\n#. Automatic comment\n#: location_comment.c:110\nmsgid "File"\nmsgstr "Ifayile"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
         # Unassociated comment
         templatepo = '''# Lonely comment\n\n#: location_comment.c:110\nmsgid "Bob"\nmsgstr "Toolmaker"\n'''
         mergepo = '''# Lonely comment\r\n\r\n#: location_comment.c:110\r\nmsgid "Bob"\r\nmsgstr "Builder"\r\n\r\n'''
         expectedpo = '''# Lonely comment\n#: location_comment.c:110\nmsgid "Bob"\nmsgstr "Builder"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
         # New comment
         templatepo = '''#: location_comment.c:110\nmsgid "File"\nmsgstr "File"\n\n'''
         mergepo = '''# User comment\r\n# (pofilter) Translate Toolkit comment\r\n#: location_comment.c:110\r\nmsgid "File"\r\nmsgstr "Ifayile"\r\n\r\n'''
         expectedpo = '''# User comment\n# (pofilter) Translate Toolkit comment\n#: location_comment.c:110\nmsgid "File"\nmsgstr "Ifayile"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_xliff_into_xliff(self):
         templatexliff = self.xliffskeleton % '''<trans-unit>
@@ -371,7 +371,7 @@ msgstr "Eerste\tTweede"
 </trans-unit>'''
         expectedpo = '# my comment\nmsgid "red"\nmsgstr "rooi"\n'
         pofile = self.mergestore(templatepo, mergexliff)
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_merging_dont_merge_kde_comments_found_in_translation(self):
         """If we find a KDE comment in the translation (target) then do not
@@ -381,21 +381,21 @@ msgstr "Eerste\tTweede"
         mergepo = '''msgid "_: KDE comment\\n"\n"File"\nmsgstr "_: KDE comment\\n"\n"Ifayile"\n\n'''
         expectedpo = '''msgid ""\n"_: KDE comment\\n"\n"File"\nmsgstr "Ifayile"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
         # Translated kde comment.
         mergepo = '''msgid "_: KDE comment\\n"\n"File"\nmsgstr "_: KDE kommentaar\\n"\n"Ifayile"\n\n'''
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
         # multiline KDE comment
         templatepo = '''msgid "_: KDE "\n"comment\\n"\n"File"\nmsgstr "File"\n\n'''
         mergepo = '''msgid "_: KDE "\n"comment\\n"\n"File"\nmsgstr "_: KDE "\n"comment\\n"\n"Ifayile"\n\n'''
         expectedpo = '''msgid ""\n"_: KDE comment\\n"\n"File"\nmsgstr "Ifayile"\n'''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_merging_untranslated_with_kde_disambiguation(self):
         """test merging untranslated messages that are the same except for
@@ -426,8 +426,8 @@ msgstr "Stuur"
 ''' % (po.lsep, po.lsep)
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_merging_header_entries(self):
         """Check that we do the right thing if we have header entries in the
@@ -489,8 +489,8 @@ msgid "Simple String"
 msgstr "Dimpled Ring"
 '''
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, pofile.serialize()))
-        assert pofile.serialize().decode('utf-8') == expectedpo
+        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, bytes(pofile)))
+        assert bytes(pofile).decode('utf-8') == expectedpo
 
     def test_merging_different_locations(self):
         """Test when merging units that are unchanged except for changed
@@ -546,6 +546,6 @@ msgstr "ZERSTÖRE WACHPOSTEN"
 
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        output = pofile.serialize().decode('utf-8')
+        output = bytes(pofile).decode('utf-8')
         print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, output))
         assert output == expectedpo or output == expectedpo2

--- a/translate/tools/test_pretranslate.py
+++ b/translate/tools/test_pretranslate.py
@@ -120,8 +120,8 @@ msgstr[1] "%d handleidings."
         template_source = '''#: simple.label\n#: simple.accesskey\nmsgid "A &hard coded newline.\\n"\nmsgstr "&Hart gekoeerde nuwe lyne\\n"\n'''
         poexpected = '''#: simple.label\n#: simple.accesskey\n#, fuzzy\nmsgid "Its &hard coding a newline.\\n"\nmsgstr "&Hart gekoeerde nuwe lyne\\n"\n'''
         newpo = self.pretranslatepo(input_source, template_source)
-        print(newpo.serialize())
-        assert newpo.serialize().decode('utf-8') == poexpected
+        print(bytes(newpo))
+        assert bytes(newpo).decode('utf-8') == poexpected
 
     def test_merging_location_change(self):
         """tests that if the location changes but the msgid stays the same that
@@ -130,8 +130,8 @@ msgstr[1] "%d handleidings."
         template_source = '''#: simple.label%ssimple.accesskey\nmsgid "A &hard coded newline.\\n"\nmsgstr "&Hart gekoeerde nuwe lyne\\n"\n''' % po.lsep
         poexpected = '''#: new_simple.label%snew_simple.accesskey\nmsgid "A &hard coded newline.\\n"\nmsgstr "&Hart gekoeerde nuwe lyne\\n"\n''' % po.lsep
         newpo = self.pretranslatepo(input_source, template_source)
-        print(newpo.serialize())
-        assert newpo.serialize().decode('utf-8') == poexpected
+        print(bytes(newpo))
+        assert bytes(newpo).decode('utf-8') == poexpected
 
     def test_merging_location_and_whitespace_change(self):
         """test that even if the location changes that if the msgid only has
@@ -140,8 +140,8 @@ msgstr[1] "%d handleidings."
         template_source = '''#: doublespace.label%sdoublespace.accesskey\nmsgid "&We  have  spaces"\nmsgstr "&One  het  spasies"\n''' % po.lsep
         poexpected = '''#: singlespace.label%ssinglespace.accesskey\n#, fuzzy\nmsgid "&We have spaces"\nmsgstr "&One  het  spasies"\n''' % po.lsep
         newpo = self.pretranslatepo(input_source, template_source)
-        print(newpo.serialize())
-        assert newpo.serialize().decode('utf-8') == poexpected
+        print(bytes(newpo))
+        assert bytes(newpo).decode('utf-8') == poexpected
 
     @mark.xfail(reason="Not Implemented")
     def test_merging_accelerator_changes(self):
@@ -151,8 +151,8 @@ msgstr[1] "%d handleidings."
         template_source = '''#: someline.c\nmsgid "&About"\nmsgstr "&Info"\n'''
         poexpected = '''#: someline.c\nmsgid "A&bout"\nmsgstr "&Info"\n'''
         newpo = self.pretranslatepo(input_source, template_source)
-        print(newpo.serialize())
-        assert newpo.serialize().decode('utf-8') == poexpected
+        print(bytes(newpo))
+        assert bytes(newpo).decode('utf-8') == poexpected
 
     @mark.xfail(reason="Not Implemented")
     def test_lines_cut_differently(self):
@@ -247,8 +247,8 @@ msgstr "36em"
         template_source = '''#~ msgid "&About"\n#~ msgstr "&Omtrent"\n'''
         expected = '''#: resurect.c\nmsgid "&About"\nmsgstr "&Omtrent"\n'''
         newpo = self.pretranslatepo(input_source, template_source)
-        print(newpo.serialize())
-        assert newpo.serialize().decode('utf-8') == expected
+        print(bytes(newpo))
+        assert bytes(newpo).decode('utf-8') == expected
 
     def test_merging_comments(self):
         """Test that we can merge comments correctly"""
@@ -293,9 +293,9 @@ msgstr "36em"
         template = xliff.xlifffile.parsestring(xlf_template)
         old = xliff.xlifffile.parsestring(xlf_old)
         new = self.pretranslatexliff(template, old)
-        print(old.serialize())
+        print(bytes(old))
         print('---')
-        print(new.serialize())
+        print(bytes(new))
         assert new.units[0].isapproved()
         # Layout might have changed, so we won't compare the serialised
         # versions


### PR DESCRIPTION
I'd like to take advantage of the fact that the serialize() API is still not part of a released version to adapt it to accept a file-like objects as first mandatory parameter. This allows us to write to that file directly inside the method, incrementally for those storages that support it. This should be more memory-friendly.