### PR TITLE
Fixes for CSV and UTF-8 on Python 2

### DIFF
--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -21,7 +21,6 @@
 or entire files (csvfile) for use with localisation
 """
 
-import codecs
 import csv
 import six
 from io import StringIO
@@ -371,8 +370,6 @@ class csvfile(base.TranslationStore):
     def parse(self, csvsrc):
         text, encoding = self.detect_encoding(csvsrc, default_encodings=['utf-8', 'utf-16'])
         #FIXME: raise parse error if encoding detection fails?
-        if encoding and encoding.lower() != 'utf-8' and csvsrc.startswith(codecs.BOM_UTF8):
-            csvsrc = csvsrc.lstrip(codecs.BOM_UTF8)
         self.encoding = encoding or 'utf-8'
 
         sniffer = csv.Sniffer()

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -23,7 +23,6 @@ or entire files (csvfile) for use with localisation
 
 import csv
 import six
-from io import StringIO
 
 from translate.misc import csv_utils
 from translate.misc import sparse
@@ -326,7 +325,7 @@ def valid_fieldnames(fieldnames):
 
 def detect_header(sample, dialect, fieldnames):
     """Test if file has a header or not, also returns number of columns in first row"""
-    inputfile = StringIO(sample)
+    inputfile = csv.StringIO(sample)
     try:
         reader = csv.reader(inputfile, dialect)
     except csv.Error:
@@ -373,11 +372,14 @@ class csvfile(base.TranslationStore):
         self.encoding = encoding or 'utf-8'
 
         sniffer = csv.Sniffer()
-        sample = text[:1024]
+        # sniff and detect_header want bytes on Python 2 but text on Python 3
+        if six.PY2:
+            sample = csvsrc[:1024]
+        else:
+            sample = text[:1024]
 
         try:
-            # sniff wants bytes on Python 2 but text on Python 3
-            self.dialect = sniffer.sniff(csvsrc[:1024] if six.PY2 else sample)
+            self.dialect = sniffer.sniff(sample)
             if not self.dialect.escapechar:
                 self.dialect.escapechar = '\\'
                 if self.dialect.quoting == csv.QUOTE_MINIMAL:

--- a/translate/storage/test_csvl10n.py
+++ b/translate/storage/test_csvl10n.py
@@ -36,6 +36,12 @@ class TestCSV(test_base.TestTranslationStore):
         assert store.units[0].source == 'test'
         assert store.units[0].target == 'zkouška sirén'
 
+    def test_utf_8_sig(self):
+        store = self.parse_store('foo.c:1;test;zkouška sirén'.encode('utf-8-sig'))
+        assert len(store.units) == 1
+        assert store.units[0].source == 'test'
+        assert store.units[0].target == 'zkouška sirén'
+
     @mark.xfail(reason="Bug #3356")
     def test_context_is_parsed(self):
         """Tests that units with the same source are different based on context."""

--- a/translate/storage/test_csvl10n.py
+++ b/translate/storage/test_csvl10n.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from pytest import mark
 
 from translate.misc import wStringIO
@@ -26,6 +29,12 @@ class TestCSV(test_base.TestTranslationStore):
         self.check_equality(store, newstore)
         assert store.units[2] == newstore.units[2]
         assert bytes(store) == bytes(newstore)
+
+    def test_utf_8(self):
+        store = self.parse_store('foo.c:1;test;zkouška sirén'.encode('utf-8'))
+        assert len(store.units) == 1
+        assert store.units[0].source == 'test'
+        assert store.units[0].target == 'zkouška sirén'
 
     @mark.xfail(reason="Bug #3356")
     def test_context_is_parsed(self):


### PR DESCRIPTION
After recent changes the CSV storage doesn't handle UTF-8 input anymore. The problem is in detect_header which now accepted unicode in Python 2, however the csv reader wasn't able to consume unicode input leading to unicode errors.

While working with that, I've also removed BOM logic from CSV as it's no longer necessary here (since #3331 has been merged).