### PR TITLE
Trailing newline in JSON files

### DIFF
--- a/translate/convert/test_po2json.py
+++ b/translate/convert/test_po2json.py
@@ -24,6 +24,7 @@ msgstr "Du texte simple"
 '''
         expected_json = '''{
     "text": "Du texte simple"
-}'''
+}
+'''
         json_out = self.po2json(input_po, json_template)
         assert json_out == expected_json

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -159,6 +159,7 @@ class JsonFile(base.TranslationStore):
             units[path] = unit.target
         out.write(json.dumps(units, sort_keys=True, separators=(',', ': '),
                              indent=4, ensure_ascii=False).encode(self.encoding))
+        out.write(b'\n')
 
     def _extract_translatables(self, data, stop=None, prev="", name_node=None,
                                name_last_node=None, last_node=None):

--- a/translate/storage/test_base.py
+++ b/translate/storage/test_base.py
@@ -81,7 +81,7 @@ class TestTranslationUnit:
         assert unit1 == unit2
         assert unit1 != unit3
         assert unit4 != unit5
-        if unit1.__class__.__name__ in ('RESXUnit', 'dtdunit', 'TxtUnit'):
+        if unit1.__class__.__name__ in ('RESXUnit', 'dtdunit', 'TxtUnit', 'JsonUnit'):
             # unit1 will generally equal unit6 for monolingual formats (resx, dtd, txt)
             # with the default comparison method which compare units by their
             # target and source properties only.

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -17,4 +17,4 @@ class TestJSONResourceStore(test_monolingual.TestMonolingualUnit):
         out = BytesIO()
         src = store.serialize(out)
 
-        assert out.getvalue() == b'{\n    "key": "value"\n}'
+        assert out.getvalue() == b'{\n    "key": "value"\n}\n'

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from io import BytesIO
+from translate.storage import jsonl10n, test_monolingual
+
+
+class TestJSONResourceUnit(test_monolingual.TestMonolingualUnit):
+    UnitClass = jsonl10n.JsonUnit
+
+
+class TestJSONResourceStore(test_monolingual.TestMonolingualUnit):
+    StoreClass = jsonl10n.JsonFile
+
+    def test_serialize(self):
+        store = jsonl10n.JsonFile()
+        store.parse('{"key": "value"}')
+        out = BytesIO()
+        src = store.serialize(out)
+
+        assert out.getvalue() == b'{\n    "key": "value"\n}'


### PR DESCRIPTION
Most editors do add trailing newline when editing JSON file, so let's be consistent.

While touching the code, I've also added basic testcase for JSON.