### PR TITLE
Bug fix 3374

### DIFF
--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -34,7 +34,6 @@ import logging
 import re
 import six
 
-from itertools import izip_longest
 from translate.filters import decoration, helpers, prefilters, spelling
 from translate.filters.decorators import (cosmetic, critical, extraction,
                                           functional)

--- a/translate/filters/test_checks.py
+++ b/translate/filters/test_checks.py
@@ -592,6 +592,10 @@ def test_printf():
     assert fails(stdchecker.printf, "I am %#100s", "Ek is %10s")
     assert fails(stdchecker.printf, "... for user %.100s on %.100s:", "... lomuntu osebenzisa i-%. I-100s e-100s:")
     assert passes(stdchecker.printf, "%dMB", "%d MG")
+    assert fails(stdchecker.printf, "Discount 10% something", "Korting tien procent")
+    assert fails(stdchecker.printf, "Discount 10%%", "Koring 10%")
+    assert fails(stdchecker.printf, "%%$", "%$")
+    assert passes(stdchecker.printf, "%%$", "%%$")
     # Reordering
     assert passes(stdchecker.printf, "String %s and number %d", "String %1$s en nommer %2$d")
     assert passes(stdchecker.printf, "String %1$s and number %2$d", "String %1$s en nommer %2$d")


### PR DESCRIPTION
1. Add pipe brackets to printf regex to match boost format specification
2. Add space to list of flags in prinf regex to match classical printf specification so that check will catch '% s'
3. Check that all percent signs are either paired (%%) or part of printf placeholder, otherwise fail check.
4. Tests to cover added changes