### PR TITLE
Do not fail on unknown locale

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -31,7 +31,7 @@ from translate.lang import data
 from translate.storage import base, lisa
 from translate.misc.multistring import multistring
 
-from babel.core import Locale
+from babel.core import Locale, UnknownLocaleError
 
 EOF = None
 WHITESPACE = ' \n\t'  # Whitespace that we collapse.
@@ -298,7 +298,10 @@ class AndroidResourceUnit(base.TranslationUnit):
                 self.xmlelement.tail = '\n'
                 self.setid(old_id)
 
-            lang_tags = set(Locale(self.gettargetlanguage()).plural_form.tags)
+            try:
+                lang_tags = set(Locale(self.gettargetlanguage()).plural_form.tags)
+            except UnknownLocaleError:
+                lang_tags = set(Locale('en').plural_form.tags)
             # Ensure that the implicit default "other" rule is present (usually omitted by Babel)
             lang_tags.add('other')
 

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -127,6 +127,14 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
                '</plurals>\n\n')
         self.__check_escape(mString, xml, 'en')
 
+    def test_plural_invalid_lang(self):
+        mString = multistring(['one message', 'other message'])
+        xml = ('<plurals name="Test String">\n\t'
+                 '<item quantity="one">one message</item>\n\t'
+                 '<item quantity="other">other message</item>\n'
+               '</plurals>\n\n')
+        self.__check_escape(mString, xml, 'invalid')
+
     def test_escape_html_quote(self):
         string = 'start \'here\' <b>html code \'to escape\'</b> also \'here\''
         xml = ('<string name="Test String">start \\\'here\\\' <b>html code \\\'to escape\\\'</b> also \\\'here\\\''


### PR DESCRIPTION
There are locales which Babel doesn't know but are valid and crashing on
these is not nice. The code now falls back to using plurals as for
English.

Signed-off-by: Michal Čihař <michal@cihar.com>