### PR TITLE
JSON: Use OrderedDict to maintain unit order

### DIFF
--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -67,6 +67,7 @@ Formats and Converters
 - JSON
 
   - Output now includes a trailing newline.
+  - Unit ordering is maintaned (:issue:`3394`).
 
 
 Filters and Checks

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -70,6 +70,12 @@ TODO:
 
 import json
 import os
+try:
+    from collections import OrderedDict
+except ImportError:
+    # Python 2.6 does not have OrderedDict and also can't use it in
+    # json.loads()
+    OrderedDict = None
 import six
 
 from translate.storage import base
@@ -214,7 +220,11 @@ class JsonFile(base.TranslationStore):
         if isinstance(input, bytes):
             input = input.decode('utf-8')
         try:
-            self._file = json.loads(input)
+            if OrderedDict is not None:
+                self._file = json.loads(input, object_pairs_hook=OrderedDict)
+            else:
+                # object_pairs_hook is not present in Python 2.6
+                self._file = json.loads(input)
         except ValueError as e:
             raise base.ParseError(e.message)
 

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
+import sys
 from io import BytesIO
 from translate.storage import jsonl10n, test_monolingual
+
+import pytest
 
 
 class TestJSONResourceUnit(test_monolingual.TestMonolingualUnit):
@@ -18,3 +21,16 @@ class TestJSONResourceStore(test_monolingual.TestMonolingualUnit):
         src = store.serialize(out)
 
         assert out.getvalue() == b'{\n    "key": "value"\n}\n'
+
+    @pytest.mark.skipif(sys.version_info < (2, 7),
+                        reason="json.loads() can't order in Python 2.6")
+    def test_ordering(self):
+        store = jsonl10n.JsonFile()
+        store.parse('''{
+    "foo": "foo",
+    "bar": "bar",
+    "baz": "baz"
+}''')
+
+        assert store.units[0].source == 'foo'
+        assert store.units[2].source == 'baz'


### PR DESCRIPTION
By default JSON will use a normal dict for objects.  Overridding this
and using OrderedDict means we can maintain order and thus translator
context.

Thanks http://stackoverflow.com/a/6921760/2167584

Fixes #3394