### PR TITLE
Added Python 3.5 compatibility in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,6 @@ matrix:
       env: USECPO=0 MINVERSION=1 META=1
     - python: 3.5
       env: USECPO=0 MINVERSION= META=1
-  allow_failures:
-    - python: 3.5
 #before_install:
 #  # Ubuntu used by Travis only supports python3-aeidon.
 #  - sudo apt-get install python-aeidon

--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ classifiers = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.3",
     "Programming Language :: Python :: 3.4",
+    "Programming Language :: Python :: 3.5",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Localization",
 ]

--- a/tests/odf_xliff/test_odf_xliff.py
+++ b/tests/odf_xliff/test_odf_xliff.py
@@ -62,7 +62,9 @@ xliff.xlifffile.__eq__ = xliff___eq__
 
 
 def print_diff(store1, store2):
-    for line in difflib.unified_diff(bytes(store1).split(b'\n'), bytes(store2).split(b'\n')):
+    store1_lines = bytes(store1).decode(store1.encoding).split('\n')
+    store2_lines = bytes(store2).decode(store2.encoding).split('\n')
+    for line in difflib.unified_diff(store1_lines, store2_lines):
         print(line)
 
 SOURCE_ODF = u'test_2.odt'
@@ -94,6 +96,8 @@ def is_content_file(filename):
 
 
 class ODF(object):
+
+    encoding = 'utf-8'
 
     def __init__(self, filename):
         self.odf = zipfile.ZipFile(filename)


### PR DESCRIPTION
Looks like difflib.unified_diff doesn't accept bytes any longer.