### PR TITLE
optrecurse: use .seek(0,0) instead of missing .reset

### DIFF
--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -537,7 +537,7 @@ class RecursiveOptionParser(optparse.OptionParser, object):
 
     def finalizetempoutputfile(self, options, outputfile, fulloutputpath):
         """Write the temp outputfile to its final destination."""
-        outputfile.reset()
+        outputfile.seek(0, 0)
         outputstring = outputfile.read()
         outputfile = self.openoutputfile(options, fulloutputpath)
         outputfile.write(outputstring)


### PR DESCRIPTION
BytesIO has no reset method.  So simply seek to the start of the file.

Fixes #3419