### PR TITLE
multistring: restore decoding bytes

### DIFF
--- a/docs/releases/dev.rst
+++ b/docs/releases/dev.rst
@@ -124,6 +124,11 @@ API changes
 API deprecation
 ---------------
 
+- Passing non-ASCII bytes to the ``multistring`` class has been deprecated, as
+  well as the ``encoding`` argument to it.
+  Applications should always construct ``multistring`` objects by passing
+  characters (``unicode`` in Python 2, ``str`` in Python 3), not bytes. Support
+  for passing non-ASCII bytes will be removed in the next version.
 - ``TxtFile.getoutput()`` and ``dtdfile.getoutput()`` have been deprecated.
   Either call ``bytes(<file_instance>)`` or use the
   ``file_instance.serialize()`` API if you need to get the serialized store

--- a/translate/misc/deprecation.py
+++ b/translate/misc/deprecation.py
@@ -21,6 +21,10 @@ import warnings
 from functools import wraps
 
 
+class RemovedInTTK2Warning(DeprecationWarning):
+    pass
+
+
 def deprecated(message=""):
     """Decorator that marks functions and methods as deprecated.
 

--- a/translate/misc/test_multistring.py
+++ b/translate/misc/test_multistring.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+import six
 
 from translate.misc import multistring
 
@@ -64,3 +65,12 @@ class TestMultistring:
         t = multistring.multistring
         assert str(t("test")) == "test"
         assert str(t(u"téßt")) == "téßt"
+
+    def test_unicode_coercion(self):
+        t = multistring.multistring
+        assert six.text_type(t("test")) == u"test"
+        assert six.text_type(t(u"test")) == u"test"
+        assert six.text_type(t("téßt")) == u"téßt"
+        assert six.text_type(t(u"téßt")) == u"téßt"
+        assert six.text_type(t(["téßt", "blāh"])) == u"téßt"
+        assert six.text_type(t([u"téßt"])) == u"téßt"


### PR DESCRIPTION
We've hit an issue in Pootle which can only be reproduced with TTK master (https://github.com/translate/pootle/issues/4594). The real cause of this is unclear (@phlax mentioned this is originating somewhere in `Store.update()`), and it seems like coercing `multistring`s with non-ASCII data to unicode fails.

In that sense, I'm not sure whether `multistring` should accept bytes in its constructor or not, however previously this [used to work via the `autoencode` class](https://github.com/translate/pootle/blob/02c993c59fadde9f495934ce0a34b87d523ad5f1/pootle/apps/pootle_store/fields.py#L59-L79) (note the `UTF-8` argument to the constructor) which is now removed in master.

I have added a test and a patch for this, which when creating the object would decode bytes from UTF-8 if that was passed. This seems to align with the previous behavior, not sure if we should aim for that though...

@claudep we'd appreciate to hear your thoughts on this one, TIA :)