### PR TITLE
multistring: fix list coercion to text

### DIFF
--- a/translate/misc/multistring.py
+++ b/translate/misc/multistring.py
@@ -91,7 +91,9 @@ class multistring(six.text_type):
         return self.__cmp__(otherstring) == 0
 
     def __repr__(self):
-        _repr = "multistring([" + u",".join(self.strings) + "])"
+        _repr = u"multistring(%r)" % (
+            [six.text_type(item) for item in self.strings]
+        )
         return _repr.encode('utf-8') if six.PY2 else _repr
 
     def __str__(self):


### PR DESCRIPTION
At the moment code such as `'%s' % [multistring(u'føø')]` fails: the
representation of `multistring` is used when coercing the list to text, however
there are decoding errors.

This commit adjusts the representation of `multistring`s so that a) coercing
lists containing `multistring`s is fixed, and b) the representation allows to
re-create the original object.

On b), this is what the official docs on `repr()` suggest at
https://docs.python.org/2/library/functions.html#repr:
>  For many types, this function makes an attempt to return a string that would
>  yield an object with the same value when passed to eval(), otherwise the
>  representation is a string enclosed in angle brackets that contains the name
>  of the type of the object together with additional information often
>  including the name and address of the object.