### PR TITLE
Multistring hash (for plurals)

### DIFF
--- a/translate/misc/multistring.py
+++ b/translate/misc/multistring.py
@@ -82,7 +82,7 @@ class multistring(six.text_type):
             return cmp_compat(str(type(self)), str(type(otherstring)))
 
     def __hash__(self):
-        return hash(''.join(self.strings))
+        return hash(str(self))
 
     def __ne__(self, otherstring):
         return self.__cmp__(otherstring) != 0

--- a/translate/misc/test_multistring.py
+++ b/translate/misc/test_multistring.py
@@ -97,3 +97,12 @@ class TestMultistring:
             assert six.text_type([t(u"tést")]) == u"[multistring(['tést'])]"
         else:
             assert six.text_type([t(u"tést")]) == u"[multistring([u't\\xe9st'])]"
+
+    def test_multistring_hash(self):
+        t = multistring.multistring
+        foo = t([u"foo", u"bar"])
+        foodict = {foo: "baz"}
+        assert u"foo" in foodict
+        foodict2 = {"foo": "baz"}
+        assert foo in foodict2
+        assert hash(str(foo)) == hash(foo)


### PR DESCRIPTION
Previously you were able to do `str in dict_with_plural_multistring_key` and because the str and multistring hashes matched it would find the dict element.

This PR adds a test to demonstrate how ttk behaviour version has changed, and a fix to restore old beviour