### PR TITLE
[ts] Reduce format differences with files saved from Qt Linguist

### DIFF
--- a/docs/formats/ts.rst
+++ b/docs/formats/ts.rst
@@ -16,9 +16,9 @@ References
 The format is XML and seems to only have been documented properly since Qt 4.3
 
 * `Current DTD Specification
-  <http://qt-project.org/doc/qt-5.0/qtlinguist/linguist-ts-file-format.html>`_ for Wt 5.0,
+  <http://doc.qt.io/qt-5/linguist-ts-file-format.html>`_ for Qt 5,
   older versions; `Qt 4.3
-  <http://doc.qt.digia.com/4.3/linguist-ts-file-format.html>`_
+  <http://doc.qt.io/archives/4.3/linguist-ts-file-format.html>`_
 * http://svn.ez.no/svn/ezcomponents/trunk/Translation/docs/linguist-format.txt
 
 .. _ts#complete:

--- a/requirements/recommended.txt
+++ b/requirements/recommended.txt
@@ -2,7 +2,7 @@
 # Recommended #
 ###############
 
-# lxml - for XML processing (XLIFF, TMX, TBX, Android)
+# lxml - for XML processing (XLIFF, TMX, TBX, ts, Android)
 lxml>=3.0
 
 # Faster matching in e.g. pot2po

--- a/translate/storage/test_ts2.py
+++ b/translate/storage/test_ts2.py
@@ -20,19 +20,21 @@
 """Tests for Qt Linguist storage class
 
 Reference implementation & tests:
-gitorious:qt5-tools/src/qttools/tests/auto/linguist/lconvert/data
+http://code.qt.io/cgit/qt/qttools.git/tree/tests/auto/linguist/lconvert/data
 """
 
 from translate.storage import test_base, ts2 as ts
 from translate.storage.placeables import parse, xliff
 
 
-TS_NUMERUS = """<?xml version='1.0' encoding='utf-8'?>
+TS_NUMERUS = """<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
     <name>Dialog2</name>
     <message numerus="yes">
+        <location filename="../tools/qtconfig/mainwindow.cpp" line="+202"/>
+        <location filename="../somewhere-else.cpp" line="+2"/>
         <source>%n files</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -140,7 +142,7 @@ class TestTSfile(test_base.TestTranslationStore):
 
     def test_edit(self):
         """test editing works well"""
-        tsstr = '''<?xml version='1.0' encoding='utf-8'?>
+        tsstr = '''<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <!DOCTYPE TS>
 <TS version="2.0" language="hu">
 <context>

--- a/translate/storage/ts.py
+++ b/translate/storage/ts.py
@@ -22,11 +22,11 @@
 
 Currently this module supports the old format of .ts files. Some applictaions
 use the newer .ts format which are documented here:
-`TS file format 4.3 <http://doc.qt.digia.com/4.3/linguist-ts-file-format.html>`_,
+`TS file format 4.3 <http://doc.qt.io/archives/4.3/linguist-ts-file-format.html>`_,
 `Example <http://svn.ez.no/svn/ezcomponents/trunk/Translation/docs/linguist-format.txt>`_
 
-`Specification of the valid variable entries <http://qt-project.org/doc/qt-5.0/qtcore/qstring.html#arg>`_,
-`2 <http://qt-project.org/doc/qt-5.0/qtcore/qstring.html#arg-2>`_
+`Specification of the valid variable entries <http://doc.qt.io/qt-5/qstring.html#arg>`_,
+`2 <http://doc.qt.io/qt-5/qstring.html#arg-2>`_
 """
 
 import six

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -23,13 +23,13 @@ This will eventually replace the older ts.py which only supports the older
 format. While converters haven't been updated to use this module, we retain
 both.
 
-`TS file format 4.3 <http://doc.qt.digia.com/4.3/linguist-ts-file-format.html>`_,
-`4.8 <http://qt-project.org/doc/qt-4.8/linguist-ts-file-format.html>`_,
-`5.0 <http://qt-project.org/doc/qt-5.0/qtlinguist/linguist-ts-file-format.html>`_.
+`TS file format 4.3 <http://doc.qt.io/archives/4.3/linguist-ts-file-format.html>`_,
+`4.8 <http://doc.qt.io/qt-4.8/linguist-ts-file-format.html>`_,
+`5 <http://doc.qt.io/qt-5/linguist-ts-file-format.html>`_.
 `Example <http://svn.ez.no/svn/ezcomponents/trunk/Translation/docs/linguist-format.txt>`_.
 
-`Specification of the valid variable entries <http://qt-project.org/doc/qt-5.0/qtcore/qstring.html#arg>`_,
-`2 <http://qt-project.org/doc/qt-5.0/qtcore/qstring.html#arg-2>`_
+`Specification of the valid variable entries <http://doc.qt.io/qt-5/qstring.html#arg>`_,
+`2 <http://doc.qt.io/qt-5/qstring.html#arg-2>`_
 """
 
 import six

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -488,5 +488,6 @@ class tsfile(lisa.LISAfile):
         # Qt Linguist does self-close the "location" elements though
         for e in root.xpath("//*[not(./node()) and not(text()) and not(name() = 'location')]"):
             e.text = ""
+        out.write("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
         out.write(etree.tostring(root, doctype=doctype, pretty_print=True,
-                                 xml_declaration=True, encoding='utf-8'))
+                                 xml_declaration=None, encoding='utf-8'))

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -485,7 +485,8 @@ class tsfile(lisa.LISAfile):
         doctype = self.document.docinfo.doctype
         # Iterate over empty tags without children and force empty text
         # This will prevent self-closing tags in pretty_print mode
-        for e in root.xpath("//*[not(./node()) and not(text())]"):
+        # Qt Linguist does self-close the "location" elements though
+        for e in root.xpath("//*[not(./node()) and not(text()) and not(name() = 'location')]"):
             e.text = ""
         out.write(etree.tostring(root, doctype=doctype, pretty_print=True,
                                  xml_declaration=True, encoding='utf-8'))


### PR DESCRIPTION
Normally our .ts files are edited in Qt Linguist. When they are however saved by for example Weblate, the files contain many formatting differences that make it hard to see what actual edits have been made to the translations (basically you first have to open and re-save the file in Qt Linguist, and then make a diff again).

With this change, the difference is much smaller, but improvements could still be made regarding how ' and " are exported for example (Qt Linguist writes `&apos;` and `&quot;`), as well as the header format:
```diff
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
```