### PR TITLE
Fix parsing of Gettext po files with first entry in unicode

### DIFF
--- a/translate/storage/poparser.py
+++ b/translate/storage/poparser.py
@@ -356,6 +356,12 @@ def parse_header(parse_state, store):
         return None
     set_encoding(parse_state, store, first_unit)
     decode_header(first_unit, parse_state.decode)
+    # Fix encoding of next line in parser
+    # It was originally parsed with  SINGLE_BYTE_ENCODING
+    # but we need to convert it to actual encoding
+    parse_state.next_line = parse_state.decode(
+        parse_state.next_line.encode(SINGLE_BYTE_ENCODING)
+    )
     return first_unit
 
 

--- a/translate/storage/test_po.py
+++ b/translate/storage/test_po.py
@@ -1014,3 +1014,21 @@ msgstr ""
         unit = pofile.units[1]
         assert unit.source == u'The actual source text'
         assert unit.target.startswith(u'_: ')
+
+    def test_unicode(self):
+        posource = b'''
+msgid ""
+msgstr ""
+"Content-Type: application/x-publican; charset=UTF-8\\n"
+
+msgid "Rapha\xc3\xabl"
+msgstr ""
+
+msgid "Rapha\xc3\xabl2"
+msgstr ""
+'''
+        pofile = self.poparse(posource)
+        unit = pofile.units[2]
+        assert unit.source == u'Raphaël2'
+        unit = pofile.units[1]
+        assert unit.source == u'Raphaël'


### PR DESCRIPTION
The headers is first parsed with iso-8859-1 and the parser always
parses next line using this encoding. This needs to be parsed again once
we know proper encoding of the file.

This fixes #3450