### PR TITLE
Move all namespaces to <resources> tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Python 2.6 is no longer supported by the Python Software Foundation, while the
 Toolkit may work in versions before Python 2.7 this is not supported.
 
 The package lxml is needed for XML file processing. You should install version
-2.2.0 or later. <http://lxml.de/> Depending on your platform, the easiest way
+3.5.0 or later. <http://lxml.de/> Depending on your platform, the easiest way
 to install might be through your system's package management. Alternatively you
 can try ::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -109,7 +109,7 @@ virtualenvs.
 4. `mkvirtualenv ttk` where "ttk" is the name for the new virtualenv
 5. `pip install translate-toolkit` to install latest stable or `pip install
    --pre translate-toolkit` to try a pre-release
-6. `pip install "lxml>=3.0"` to be able to use XLIFF or other XML formats
+6. `pip install "lxml>=3.5"` to be able to use XLIFF or other XML formats
 7. `po2prop --version` to double check you have the right version
 
 Next times you need to use Translate Toolkit just remember to:

--- a/min-required.txt
+++ b/min-required.txt
@@ -1,6 +1,6 @@
-lxml==2.1.0  # >=1.3.4 should work
+lxml==3.5.0
 python-Levenshtein==0.10.2
-# If Python 
+# If Python
 iniparse==0.3.1
 vobject==0.6.6
 BeautifulSoup==3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 distribute==0.6.45
-lxml==3.2.1
+lxml==3.5.0
 python-Levenshtein==0.10.2

--- a/requirements/recommended.txt
+++ b/requirements/recommended.txt
@@ -3,7 +3,7 @@
 ###############
 
 # lxml - for XML processing (XLIFF, TMX, TBX, Android)
-lxml>=3.0
+lxml>=3.5
 
 # Faster matching in e.g. pot2po
 python-Levenshtein>=0.11.1

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -508,5 +508,5 @@ class AndroidResourceFile(lisa.LISAfile):
         super(AndroidResourceFile, self).addunit(unit, new)
         # Move aliased namespaces to the <resources> tag
         # The top_nsmap was introduced in LXML 3.5.0
-        if do_cleanup and etree.LXML_VERSION >= (3, 5, 0):
+        if do_cleanup:
             etree.cleanup_namespaces(self.body, top_nsmap=newns)

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -489,3 +489,24 @@ class AndroidResourceFile(lisa.LISAfile):
             self.settargetlanguage(target_lang)
 
         return target_lang
+
+    def addunit(self, unit, new=True):
+        """Adds unit to the document
+
+        In addition to the standard addunit, it also tries to move
+        namespace definitions to the top <resources> element.
+        """
+        newns = {}
+        do_cleanup = False
+        if new:
+            newns = self.body.nsmap
+            for ns in unit.xmlelement.nsmap:
+                if ns not in newns:
+                    do_cleanup = True
+                    newns[ns] = unit.xmlelement.nsmap[ns]
+
+        super(AndroidResourceFile, self).addunit(unit, new)
+        # Move aliased namespaces to the <resources> tag
+        # The top_nsmap was introduced in LXML 3.5.0
+        if do_cleanup and etree.LXML_VERSION >= (3, 5, 0):
+            etree.cleanup_namespaces(self.body, top_nsmap=newns)

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -383,9 +383,6 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
         assert store.gettargetlanguage() is None
 
     def test_namespaces(self):
-        if etree.LXML_VERSION < (3, 5, 0):
-            # Not supported with older lxml
-            return
         content = '''<resources xmlns:tools="http://schemas.android.com/tools">
             <string name="string1" tools:ignore="PluralsCandidate">string1</string>
             <string name="string2">string2</string>

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -381,3 +381,18 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
 
         store.filename = 'invalid_directory'
         assert store.gettargetlanguage() is None
+
+    def test_namespaces(self):
+        if etree.LXML_VERSION < (3, 5, 0):
+            # Not supported with older lxml
+            return
+        content = '''<resources xmlns:tools="http://schemas.android.com/tools">
+            <string name="string1" tools:ignore="PluralsCandidate">string1</string>
+            <string name="string2">string2</string>
+        </resources>'''
+        store = self.StoreClass()
+        store.parse(content)
+        newstore = self.StoreClass()
+        newstore.addunit(store.units[0], new=True)
+        print(newstore)
+        assert b'<resources xmlns:tools="http://schemas.android.com/tools">' in bytes(newstore)


### PR DESCRIPTION
All standard namespaces need to be defined on <resources> tag rather
than on lower elements in Android string resources.