### PR TITLE
Skip some checks for some languages for some checker

### DIFF
--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -413,6 +413,13 @@ class UnitChecker(object):
         """
         return test(unit)
 
+    def get_ignored_filters(self):
+        """Return checker's ignored filters for current language."""
+        # Extract checker name, for example 'mozilla' from MozillaChecker.
+        checker_name = str(self.__class__.__name__).lower()[:-len("checker")]
+        return list(set(self.config.lang.ignoretests.get(checker_name, []) +
+                        self.config.lang.ignoretests.get('all', [])))
+
     def run_filters(self, unit, categorised=False):
         """Run all the tests in this suite.
 
@@ -423,7 +430,7 @@ class UnitChecker(object):
         """
         self.results_cache = {}
         failures = {}
-        ignores = self.config.lang.ignoretests[:]
+        ignores = self.get_ignored_filters()
         functionnames = self.defaultfilters.keys()
         priorityfunctionnames = self.preconditions.keys()
         otherfunctionnames = filter(lambda functionname: functionname not in self.preconditions, functionnames)

--- a/translate/filters/test_checks.py
+++ b/translate/filters/test_checks.py
@@ -1351,3 +1351,26 @@ def test_dialogsizes():
     assert fails(mozillachecker.dialogsizes, 'height: 12em;', 'height: 24xx;')
     assert fails(mozillachecker.dialogsizes, 'height: 12.5em;', 'height: 12,5em;')
     assert fails(mozillachecker.dialogsizes, 'width: 36em; height: 18em;', 'width: 30em; min-height: 20em;')
+
+
+def test_skip_checks_per_language_in_some_checkers():
+    """Test some checks are skipped for some languages in Mozilla checker."""
+    from translate.storage import base
+
+    str1, str2, __ = strprep(u"&Check for updates", u"আপডেইটসমূহৰ বাবে নিৰীক্ষণ কৰক")
+    unit = base.TranslationUnit(str1)
+    unit.target = str2
+
+    mozillachecker = checks.MozillaChecker(
+        checkerconfig=checks.CheckerConfig(targetlanguage="as")
+    )
+    failures = mozillachecker.run_filters(unit)
+    # Accelerators check is disabled for Assamese in MozillaChecker.
+    assert 'accelerators' not in failures.keys()
+
+    stdchecker = checks.StandardChecker(
+        checkerconfig=checks.CheckerConfig(accelmarkers="&", targetlanguage="as")
+    )
+    failures = stdchecker.run_filters(unit)
+    # But it is not in StandardChecker.
+    assert 'accelerators' in failures.keys()

--- a/translate/lang/am.py
+++ b/translate/lang/am.py
@@ -46,4 +46,6 @@ class am(common.Common):
         u",": u"፣",
     }
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/anp.py
+++ b/translate/lang/anp.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Angika language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Angika_language
+"""
+
+from translate.lang import common
+
+
+class anp(common.Common):
+    """This class represents Angika."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/ar.py
+++ b/translate/lang/ar.py
@@ -59,7 +59,9 @@ class ar(common.Common):
         (u"9", u"٩"),  # U+0669 Arabic-Indic digit nine.
     )
 
-    ignoretests = ["startcaps", "simplecaps", "acronyms"]
+    ignoretests = {
+        'all': ["acronyms", "simplecaps", "startcaps"],
+    }
 
     @classmethod
     def punctranslate(cls, text):

--- a/translate/lang/bho.py
+++ b/translate/lang/bho.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Bhojpuri language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Bhojpuri_language
+"""
+
+from translate.lang import common
+
+
+class bho(common.Common):
+    """This class represents Bhojpuri."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/bn.py
+++ b/translate/lang/bn.py
@@ -57,4 +57,6 @@ class bn(common.Common):
         (u"9", u"৯"),  # U+09EF Bengali digit nine.
     )
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/bn_bd.py
+++ b/translate/lang/bn_bd.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Bengali (Bangladesh) language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Bengali_language
+"""
+
+from translate.lang import common
+
+
+class bn_bd(common.Common):
+    """This class represents Bengali (Bangladesh)."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/bn_in.py
+++ b/translate/lang/bn_in.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Bengali (India) language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Bengali_language
+"""
+
+from translate.lang import common
+
+
+class bn_in(common.Common):
+    """This class represents Bengali (India)."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/bo.py
+++ b/translate/lang/bo.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Tibetan language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Standard_Tibetan
+"""
+
+from translate.lang import common
+
+
+class bo(common.Common):
+    """This class represents Tibetan."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/brx.py
+++ b/translate/lang/brx.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Bodo language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Bodo_language
+"""
+
+from translate.lang import common
+
+
+class brx(common.Common):
+    """This class represents Bodo."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/code_as.py
+++ b/translate/lang/code_as.py
@@ -40,3 +40,7 @@ class code_as(common.Common):
         (u"8", u"৮"),  # U+09EE Bengali digit eight.
         (u"9", u"৯"),  # U+09EF Bengali digit nine.
     )
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/code_or.py
+++ b/translate/lang/code_or.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2007 Zuza Software Foundation
+# Copyright 2007, 2016 Zuza Software Foundation
 #
 # This file is part of translate.
 #
@@ -46,4 +46,5 @@ class code_or(common.Common):
 
     ignoretests = {
         'all': ["simplecaps", "startcaps"],
+        'mozilla': ["accelerators"],
     }

--- a/translate/lang/code_or.py
+++ b/translate/lang/code_or.py
@@ -44,4 +44,6 @@ class code_or(common.Common):
         u".\n": u"।\n",
     }
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/common.py
+++ b/translate/lang/common.py
@@ -188,8 +188,16 @@ class Common(object):
     """A tuple of number transformation rules that can be used by
     numbertranslate()."""
 
-    ignoretests = []
-    """List of pofilter tests for this language that must be ignored."""
+    ignoretests = {}
+    """Dictionary of tests to ignore in some or all checkers.
+
+    Keys are checker names and values are list of names for the ignored tests
+    in the checker. A special 'all' checker name can be used to tell that the
+    tests must be ignored in all the checkers.
+
+    Listed checkers to ignore tests on must be lowercase strings for the
+    checker name, for example "mozilla" for MozillaChecker or "libreoffice" for
+    LibreOfficeChecker."""
 
     checker = None
     """A language specific checker (see filters.checks).

--- a/translate/lang/de.py
+++ b/translate/lang/de.py
@@ -28,4 +28,6 @@ from translate.lang import common
 class de(common.Common):
     """This class represents German."""
 
-    ignoretests = ["simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps"],
+    }

--- a/translate/lang/doi.py
+++ b/translate/lang/doi.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Dogri language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Dogri_language
+"""
+
+from translate.lang import common
+
+
+class doi(common.Common):
+    """This class represents Dogri."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/fa.py
+++ b/translate/lang/fa.py
@@ -91,7 +91,9 @@ class fa(common.Common):
         (u"9", u"۹"),  # U+06F9 Extended Arabic-Indic digit nine.
     )
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }
     #TODO: check persian numerics
     #TODO: zwj and zwnj?
 

--- a/translate/lang/gu.py
+++ b/translate/lang/gu.py
@@ -28,4 +28,6 @@ from translate.lang import common
 class gu(common.Common):
     """This class represents Gujarati."""
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/gu.py
+++ b/translate/lang/gu.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2010 Zuza Software Foundation
+# Copyright 2010, 2016 Zuza Software Foundation
 #
 # This file is part of translate.
 #
@@ -30,4 +30,5 @@ class gu(common.Common):
 
     ignoretests = {
         'all': ["simplecaps", "startcaps"],
+        'mozilla': ["accelerators"],
     }

--- a/translate/lang/he.py
+++ b/translate/lang/he.py
@@ -28,4 +28,6 @@ from translate.lang import common
 class he(common.Common):
     """This class represents Hebrew."""
 
-    ignoretests = ["startcaps", "simplecaps", "acronyms"]
+    ignoretests = {
+        'all': ["acronyms", "simplecaps", "startcaps"],
+    }

--- a/translate/lang/hi.py
+++ b/translate/lang/hi.py
@@ -28,4 +28,6 @@ from translate.lang import common
 class hi(common.Common):
     """This class represents Hindi."""
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/hi.py
+++ b/translate/lang/hi.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2010 Zuza Software Foundation
+# Copyright 2010, 2016 Zuza Software Foundation
 #
 # This file is part of translate.
 #
@@ -30,4 +30,5 @@ class hi(common.Common):
 
     ignoretests = {
         'all': ["simplecaps", "startcaps"],
+        'mozilla': ["accelerators"],
     }

--- a/translate/lang/hy.py
+++ b/translate/lang/hy.py
@@ -54,7 +54,9 @@ class hy(common.Common):
         "?": "՞",
     }
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }
 
     mozilla_nplurals = 2
     mozilla_pluralequation = "n!=1 ? 1 : 0"

--- a/translate/lang/ja.py
+++ b/translate/lang/ja.py
@@ -49,4 +49,6 @@ class ja(common.Common):
         u",\n": u"、\n",
     }
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/kfy.py
+++ b/translate/lang/kfy.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Kumaoni language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Kumaoni_language
+"""
+
+from translate.lang import common
+
+
+class kfy(common.Common):
+    """This class represents Kumaoni."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/km.py
+++ b/translate/lang/km.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2007 Zuza Software Foundation
+# Copyright 2007, 2016 Zuza Software Foundation
 #
 # This file is part of translate.
 #
@@ -54,6 +54,7 @@ class km(common.Common):
 
     ignoretests = {
         'all': ["simplecaps", "startcaps"],
+        'mozilla': ["accelerators"],
     }
 
     mozilla_nplurals = 2

--- a/translate/lang/km.py
+++ b/translate/lang/km.py
@@ -52,7 +52,9 @@ class km(common.Common):
         u"?": u"\u00a0?",
     }
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }
 
     mozilla_nplurals = 2
     mozilla_pluralequation = "n!=1 ? 1 : 0"

--- a/translate/lang/kn.py
+++ b/translate/lang/kn.py
@@ -28,4 +28,6 @@ from translate.lang import common
 class kn(common.Common):
     """This class represents Kannada."""
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/kn.py
+++ b/translate/lang/kn.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2008 Zuza Software Foundation
+# Copyright 2008, 2016 Zuza Software Foundation
 #
 # This file is part of translate.
 #
@@ -30,4 +30,5 @@ class kn(common.Common):
 
     ignoretests = {
         'all': ["simplecaps", "startcaps"],
+        'mozilla': ["accelerators"],
     }

--- a/translate/lang/ko.py
+++ b/translate/lang/ko.py
@@ -28,4 +28,6 @@ from translate.lang import common
 class ko(common.Common):
     """This class represents Korean."""
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/kok.py
+++ b/translate/lang/kok.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Konkani language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Konkani_language
+"""
+
+from translate.lang import common
+
+
+class kok(common.Common):
+    """This class represents Konkani."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/ks.py
+++ b/translate/lang/ks.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Kashmiri language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Kashmiri_language
+"""
+
+from translate.lang import common
+
+
+class ks(common.Common):
+    """This class represents Kashmiri."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/lo.py
+++ b/translate/lang/lo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2013 Zuza Software Foundation
+# Copyright 2013, 2016 Zuza Software Foundation
 #
 # This file is part of translate.
 #
@@ -27,6 +27,10 @@ from translate.lang import common
 
 class lo(common.Common):
     """This class represents Lao."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }
 
     mozilla_nplurals = 2
     mozilla_pluralequation = "n!=1 ? 1 : 0"

--- a/translate/lang/mai.py
+++ b/translate/lang/mai.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Maithili language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Maithili_language
+"""
+
+from translate.lang import common
+
+
+class mai(common.Common):
+    """This class represents Maithili."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/ml.py
+++ b/translate/lang/ml.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2008 Zuza Software Foundation
+# Copyright 2008, 2016 Zuza Software Foundation
 #
 # This file is part of translate.
 #
@@ -30,4 +30,5 @@ class ml(common.Common):
 
     ignoretests = {
         'all': ["simplecaps", "startcaps"],
+        'mozilla': ["accelerators"],
     }

--- a/translate/lang/ml.py
+++ b/translate/lang/ml.py
@@ -28,4 +28,6 @@ from translate.lang import common
 class ml(common.Common):
     """This class represents Malayalam."""
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/mni.py
+++ b/translate/lang/mni.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Meithei language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Meithei_language
+"""
+
+from translate.lang import common
+
+
+class mni(common.Common):
+    """This class represents Meithei (Manipuri)."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/mr.py
+++ b/translate/lang/mr.py
@@ -28,4 +28,6 @@ from translate.lang import common
 class mr(common.Common):
     """This class represents Marathi."""
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/mr.py
+++ b/translate/lang/mr.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2010 Zuza Software Foundation
+# Copyright 2010, 2016 Zuza Software Foundation
 #
 # This file is part of translate.
 #
@@ -30,4 +30,5 @@ class mr(common.Common):
 
     ignoretests = {
         'all': ["simplecaps", "startcaps"],
+        'mozilla': ["accelerators"],
     }

--- a/translate/lang/my.py
+++ b/translate/lang/my.py
@@ -32,4 +32,6 @@ class my(common.Common):
         u".": u"။",
     }
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/my.py
+++ b/translate/lang/my.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2013 Zuza Software Foundation
+# Copyright 2013, 2016 Zuza Software Foundation
 #
 # This file is part of the Translate Toolkit.
 #
@@ -34,4 +34,5 @@ class my(common.Common):
 
     ignoretests = {
         'all': ["simplecaps", "startcaps"],
+        'mozilla': ["accelerators"],
     }

--- a/translate/lang/ne.py
+++ b/translate/lang/ne.py
@@ -45,4 +45,6 @@ class ne(common.Common):
         u"?": u" ?",
     }
 
-    ignoretests = ["startcaps", "simplecaps", "accelerators"]
+    ignoretests = {
+        'all': ["accelerators", "simplecaps", "startcaps"],
+    }

--- a/translate/lang/nqo.py
+++ b/translate/lang/nqo.py
@@ -45,7 +45,9 @@ class nqo(common.Common):
         u"!": u"߹",
     }
 
-    ignoretests = ["startcaps", "simplecaps", "acronyms"]
+    ignoretests = {
+        'all': ["acronyms", "simplecaps", "startcaps"],
+    }
 
     @classmethod
     def punctranslate(cls, text):

--- a/translate/lang/pa.py
+++ b/translate/lang/pa.py
@@ -45,4 +45,6 @@ class pa(common.Common):
         u".\n": u"।\n",
     }
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/sa.py
+++ b/translate/lang/sa.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Sanskrit language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Sanskrit
+"""
+
+from translate.lang import common
+
+
+class sa(common.Common):
+    """This class represents Sanskrit."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/sat.py
+++ b/translate/lang/sat.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Santali language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Santali_language
+"""
+
+from translate.lang import common
+
+
+class sat(common.Common):
+    """This class represents Santali."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/sd.py
+++ b/translate/lang/sd.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Sindhi language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Sindhi_language
+"""
+
+from translate.lang import common
+
+
+class sd(common.Common):
+    """This class represents Sindhi."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/shn.py
+++ b/translate/lang/shn.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Shan language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Shan_language
+"""
+
+from translate.lang import common
+
+
+class shn(common.Common):
+    """This class represents Shan."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/si.py
+++ b/translate/lang/si.py
@@ -28,4 +28,6 @@ from translate.lang import common
 class si(common.Common):
     """This class represents Sinhala."""
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/ta.py
+++ b/translate/lang/ta.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2010 Zuza Software Foundation
+# Copyright 2010, 2016 Zuza Software Foundation
 #
 # This file is part of Virtaal.
 #
@@ -30,4 +30,5 @@ class ta(common.Common):
 
     ignoretests = {
         'all': ["simplecaps", "startcaps"],
+        'mozilla': ["accelerators"],
     }

--- a/translate/lang/ta.py
+++ b/translate/lang/ta.py
@@ -28,4 +28,6 @@ from translate.lang import common
 class ta(common.Common):
     """This class represents Tamil."""
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/te.py
+++ b/translate/lang/te.py
@@ -28,4 +28,6 @@ from translate.lang import common
 class te(common.Common):
     """This class represents Telugu."""
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/test_factory.py
+++ b/translate/lang/test_factory.py
@@ -34,7 +34,7 @@ def test_getlanguage():
     assert language.fullname == 'Icelandic'
 
     language = factory.getlanguage('or')
-    assert "startcaps" in language.ignoretests
+    assert "startcaps" in language.ignoretests['all']
 
     #Test with a language code contains '@'
     language = factory.getlanguage('ca@valencia')

--- a/translate/lang/th.py
+++ b/translate/lang/th.py
@@ -35,4 +35,6 @@ class th(common.Common):
 
     # No capitalisation. While we can't do sentence segmentation, sentencecount
     # is useless.
-    ignoretests = ["startcaps", "simplecaps", "sentencecount"]
+    ignoretests = {
+        'all': ["sentencecount", "simplecaps", "startcaps"],
+    }

--- a/translate/lang/ug.py
+++ b/translate/lang/ug.py
@@ -36,4 +36,6 @@ class ug(common.Common):
         u"?": u"؟",
     }
 
-    ignoretests = ["startcaps", "simplecaps", "acronyms"]
+    ignoretests = {
+        'all': ["acronyms", "simplecaps", "startcaps"],
+    }

--- a/translate/lang/ur.py
+++ b/translate/lang/ur.py
@@ -39,4 +39,6 @@ class ur(common.Common):
         #u"%": u"٪",
     }
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/yue.py
+++ b/translate/lang/yue.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Zuza Software Foundation
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+"""This module represents the Yue language.
+
+.. seealso:: https://en.wikipedia.org/wiki/Yue_Chinese
+"""
+
+from translate.lang import common
+
+
+class yue(common.Common):
+    """This class represents Yue."""
+
+    ignoretests = {
+        'mozilla': ["accelerators"],
+    }

--- a/translate/lang/zh.py
+++ b/translate/lang/zh.py
@@ -66,4 +66,6 @@ class zh(common.Common):
     def length_difference(cls, length):
         return 10 - length / 2
 
-    ignoretests = ["startcaps", "simplecaps"]
+    ignoretests = {
+        'all': ["simplecaps", "startcaps"],
+    }

--- a/translate/lang/zh_cn.py
+++ b/translate/lang/zh_cn.py
@@ -28,4 +28,6 @@ from translate.lang.zh import zh
 class zh_cn(zh):
     specialchars = u"←→↔×÷©…—‘’“”【】《》"
 
-    ignoretests = ["startcaps", "simplecaps", "acronyms"]
+    ignoretests = {
+        'all': ["acronyms", "simplecaps", "startcaps"],
+    }

--- a/translate/lang/zh_hk.py
+++ b/translate/lang/zh_hk.py
@@ -28,4 +28,6 @@ from translate.lang.zh import zh
 class zh_hk(zh):
     specialchars = u"←→↔×÷©…—‘’“”「」『』【】《》"
 
-    ignoretests = ["startcaps", "simplecaps", "acronyms"]
+    ignoretests = {
+        'all': ["acronyms", "simplecaps", "startcaps"],
+    }

--- a/translate/lang/zh_tw.py
+++ b/translate/lang/zh_tw.py
@@ -28,4 +28,6 @@ from translate.lang.zh import zh
 class zh_tw(zh):
     specialchars = u"←→↔×÷©…—‘’“”「」『』【】《》"
 
-    ignoretests = ["startcaps", "simplecaps", "acronyms"]
+    ignoretests = {
+        'all': ["acronyms", "simplecaps", "startcaps"],
+    }


### PR DESCRIPTION
This is necessary in order to disable accelerator checks for Indic
languages in Mozilla, and to disable checks that yield too many
false positives for some languages.