### PR TITLE
mozlang: last unit is followed by trailing newlines

### DIFF
--- a/docs/formats/index.rst
+++ b/docs/formats/index.rst
@@ -45,6 +45,7 @@ Other translation formats
    catkeys
    android
    resx
+   mozilla_lang
 
 * :doc:`csv`
 * :doc:`ini` (including Inno Setup .isl dialect)
@@ -60,6 +61,7 @@ Other translation formats
 * Haiku :doc:`catkeys` (from version 1.8)
 * :doc:`android` (supports storage, not conversion)
 * :doc:`resx` .NET Resource files (.resx)
+* Mozilla :doc:`.lang <mozilla_lang>` files
 
 .. _formats#translation_memory_formats:
 

--- a/docs/formats/mozilla_lang.rst
+++ b/docs/formats/mozilla_lang.rst
@@ -1,0 +1,19 @@
+.. _mozilla_lang:
+
+Mozilla .lang files
+*******************
+
+Mozilla's custom `.lang
+<https://github.com/mozilla-l10n/langchecker/wiki/.lang-files-format>`_ format
+is used for some of their websites.
+
+
+.. _mozilla_langd#references:
+
+References
+==========
+
+* .lang `specification
+  <https://github.com/mozilla-l10n/langchecker/wiki/.lang-files-format>`_
+* `www.mozilla.org repository
+  <https://github.com/mozilla-l10n/www.mozilla.org>`_ of translations

--- a/translate/convert/test_po2mozlang.py
+++ b/translate/convert/test_po2mozlang.py
@@ -18,7 +18,7 @@ class TestPO2Lang(object):
     def test_simple(self):
         """check the simplest case of merging a translation"""
         posource = '''#: prop\nmsgid "Source"\nmsgstr "Target"\n'''
-        prop_expected = ''';Source\nTarget\n'''
+        prop_expected = ''';Source\nTarget\n\n\n'''
         prop_result = self.po2lang(posource)
         print(prop_result)
         assert prop_result == prop_expected
@@ -26,7 +26,7 @@ class TestPO2Lang(object):
     def test_comment(self):
         """Simple # comments"""
         posource = '''#. Comment\n#: prop\nmsgid "Source"\nmsgstr "Target"\n'''
-        prop_expected = '''# Comment\n;Source\nTarget\n'''
+        prop_expected = '''# Comment\n;Source\nTarget\n\n\n'''
         prop_result = self.po2lang(posource)
         print(prop_result)
         assert prop_result == prop_expected
@@ -34,7 +34,7 @@ class TestPO2Lang(object):
     def test_fuzzy(self):
         """What happens with a fuzzy string"""
         posource = '''#. Comment\n#: prop\n#, fuzzy\nmsgid "Source"\nmsgstr "Target"\n'''
-        prop_expected = '''# Comment\n;Source\nSource\n'''
+        prop_expected = '''# Comment\n;Source\nSource\n\n\n'''
         prop_result = self.po2lang(posource)
         print(prop_result)
         assert prop_result == prop_expected
@@ -42,7 +42,7 @@ class TestPO2Lang(object):
     def test_ok_marker(self):
         """The {ok} marker"""
         posource = '''#: prop\nmsgid "Same"\nmsgstr "Same"\n'''
-        prop_expected = ''';Same\nSame {ok}\n'''
+        prop_expected = ''';Same\nSame {ok}\n\n\n'''
         prop_result = self.po2lang(posource)
         print(prop_result)
         assert prop_result == prop_expected

--- a/translate/storage/mozilla_lang.py
+++ b/translate/storage/mozilla_lang.py
@@ -112,8 +112,6 @@ class LangStore(txt.TxtFile):
     def serialize(self, out):
         if self.is_active or self.mark_active:
             out.write(b"## active ##\n")
-        for idx, unit in enumerate(self.units):
-            if idx > 0:
-                out.write(b"\n\n\n")
+        for unit in self.units:
             out.write(six.text_type(unit).encode('utf-8'))
-        out.write(b"\n")
+            out.write(b"\n\n\n")

--- a/translate/storage/mozilla_lang.py
+++ b/translate/storage/mozilla_lang.py
@@ -20,7 +20,11 @@
 # Original Author: Dan Schafer <dschafer@mozilla.com>
 # Date: 10 Jun 2008
 
-"""A class to manage Mozilla .lang files."""
+"""A class to manage Mozilla .lang files.
+
+See https://github.com/mozilla-l10n/langchecker/wiki/.lang-files-format for
+specifications on the format.
+"""
 
 import six
 

--- a/translate/storage/test_mozilla_lang.py
+++ b/translate/storage/test_mozilla_lang.py
@@ -52,7 +52,8 @@ class TestMozLangFile(test_base.TestTranslationStore):
         """General test of layout of the format"""
         lang = ("# Comment\n"
                 ";Source\n"
-                "Target\n")
+                "Target\n"
+                "\n\n")
         store = self.StoreClass.parsestring(lang)
         store.mark_active = False
         unit = store.units[0]
@@ -65,7 +66,8 @@ class TestMozLangFile(test_base.TestTranslationStore):
         """Test the ## active ## flag"""
         lang = ("## active ##\n"
                 ";Source\n"
-                "Target\n")
+                "Target\n"
+                "\n\n")
         store = self.StoreClass.parsestring(lang)
         assert store.is_active
         assert bytes(store).decode('utf-8') == lang
@@ -77,22 +79,25 @@ class TestMozLangFile(test_base.TestTranslationStore):
                 "# Second comment\n"
                 "# Third comment\n"
                 ";Source\n"
-                "Target\n")
+                "Target\n"
+                "\n\n")
         store = self.StoreClass.parsestring(lang)
         assert bytes(store).decode('utf-8') == lang
 
     def test_template(self):
         """A template should have source == target, though it could be blank"""
         lang = (";Source\n"
-                "Source\n")
+                "Source\n"
+                "\n\n")
         store = self.StoreClass.parsestring(lang)
         unit = store.units[0]
         assert unit.source == "Source"
         assert unit.target == ""
         assert bytes(store).decode('utf-8') == lang
         lang2 = (";Source\n"
-                 "\n"
-                 ";Source2\n")
+                 "\n\n"
+                 ";Source2\n"
+                 "\n\n")
         store2 = self.StoreClass.parsestring(lang2)
         assert store2.units[0].source == "Source"
         assert store2.units[0].target == ""


### PR DESCRIPTION
Based on files in the wild the final unit is, like all units, followed
by newlines.