### PR TITLE
Fix JSON tests

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -68,7 +68,7 @@ TODO:
 """
 
 import json
-import os
+import uuid
 from collections import OrderedDict
 
 import six
@@ -81,9 +81,10 @@ class JsonUnit(base.TranslationUnit):
     """A JSON entry"""
 
     def __init__(self, source=None, ref=None, item=None, **kwargs):
-        self._id = None
-        self._item = str(os.urandom(30)) if item is None else item
-        self._ref = {} if ref is None else ref
+        identifier = str(uuid.uuid4())
+        self._id = '.' + identifier
+        self._item = identifier if item is None else item
+        self._ref = OrderedDict() if ref is None else ref
         if ref is None and item is None:
             self._ref[self._item] = ""
         if source:
@@ -249,6 +250,9 @@ class JsonNestedFile(JsonFile):
 
 class WebExtensionJsonUnit(base.TranslationUnit):
     def __init__(self, source=None, ref=None, item=None):
+        identifier = str(uuid.uuid4())
+        self._id = '.' + identifier
+        self._item = identifier if item is None else item
         if ref:
             self._node = ref
             if 'description' in ref:

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -137,6 +137,12 @@ class JsonUnit(base.TranslationUnit):
     def getlocations(self):
         return [self.getid()]
 
+    def __str__(self):
+        """Converts to a string representation."""
+        return ", ".join([
+            "%s: %s" % (k, self.__dict__[k]) for k in sorted(self.__dict__.keys()) if k not in ('_store', '_ref')
+        ])
+
 
 class JsonFile(base.TranslationStore):
     """A JSON file"""
@@ -285,6 +291,12 @@ class WebExtensionJsonUnit(base.TranslationUnit):
             self._node['description'] = self.notes
         else:
             del self._node['description']
+
+    def __str__(self):
+        """Converts to a string representation."""
+        return ", ".join([
+            "%s: %s" % (k, self.__dict__[k]) for k in sorted(self.__dict__.keys()) if k not in ('_store', '_ref')
+        ])
 
 
 class WebExtensionJsonFile(JsonFile):

--- a/translate/storage/test_base.py
+++ b/translate/storage/test_base.py
@@ -84,7 +84,8 @@ class TestTranslationUnit:
         assert unit1 != unit3
         assert unit4 != unit5
         if unit1.__class__.__name__ in ('RESXUnit', 'dtdunit', 'TxtUnit',
-                                        'JsonUnit', 'l20nunit', 'YAMLUnit'):
+                                        'JsonUnit', 'l20nunit', 'YAMLUnit',
+                                        'WebExtensionJsonUnit'):
             # unit1 will generally equal unit6 for monolingual formats (resx, dtd, txt, l20n)
             # with the default comparison method which compare units by their
             # target and source properties only.

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import sys
 from io import BytesIO
 from translate.misc.multistring import multistring
 from translate.storage import jsonl10n, test_monolingual
@@ -43,7 +42,7 @@ class TestJSONResourceStore(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         store.parse('{"key": "value"}')
         out = BytesIO()
-        src = store.serialize(out)
+        store.serialize(out)
 
         assert out.getvalue() == b'{\n    "key": "value"\n}\n'
 
@@ -66,7 +65,7 @@ class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):
         store = self.StoreClass()
         store.parse('{"key": {"second": "value"}}')
         out = BytesIO()
-        src = store.serialize(out)
+        store.serialize(out)
 
         assert out.getvalue() == b'{\n    "key": {\n        "second": "value"\n    }\n}\n'
 
@@ -93,7 +92,7 @@ class TestWebExtensionStore(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         store.parse('{"key": {"message": "value", "description": "note"}}')
         out = BytesIO()
-        src = store.serialize(out)
+        store.serialize(out)
 
         assert out.getvalue() == b'{\n    "key": {\n        "message": "value",\n        "description": "note"\n    }\n}\n'
 
@@ -101,7 +100,7 @@ class TestWebExtensionStore(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         store.parse('{"key": {"message": "value"}}')
         out = BytesIO()
-        src = store.serialize(out)
+        store.serialize(out)
 
         assert out.getvalue() == b'{\n    "key": {\n        "message": "value"\n    }\n}\n'
 
@@ -110,7 +109,7 @@ class TestWebExtensionStore(test_monolingual.TestMonolingualStore):
         store.parse('{"key": {"message": "value", "description": "note"}}')
         store.units[0].settarget('another')
         out = BytesIO()
-        src = store.serialize(out)
+        store.serialize(out)
 
         assert out.getvalue() == b'{\n    "key": {\n        "message": "another",\n        "description": "note"\n    }\n}\n'
 
@@ -122,7 +121,7 @@ class TestI18NextStore(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         store.parse(JSON_I18NEXT)
         out = BytesIO()
-        src = store.serialize(out)
+        store.serialize(out)
 
         assert out.getvalue() == JSON_I18NEXT
 
@@ -139,7 +138,7 @@ class TestI18NextStore(test_monolingual.TestMonolingualStore):
         store.units[2].target = 'Ahoj'
         store.units[3].target = 'Nazdar'
         out = BytesIO()
-        src = store.serialize(out)
+        store.serialize(out)
 
         assert out.getvalue() == JSON_I18NEXT_PLURAL
 
@@ -157,6 +156,6 @@ class TestI18NextStore(test_monolingual.TestMonolingualStore):
             "the plural form 5"
         ])
         out = BytesIO()
-        src = store.serialize(out)
+        store.serialize(out)
 
         assert out.getvalue() == JSON_I18NEXT

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -36,7 +36,7 @@ class TestJSONResourceUnit(test_monolingual.TestMonolingualUnit):
     UnitClass = jsonl10n.JsonUnit
 
 
-class TestJSONResourceStore(test_monolingual.TestMonolingualUnit):
+class TestJSONResourceStore(test_monolingual.TestMonolingualStore):
     StoreClass = jsonl10n.JsonFile
 
     def test_serialize(self):
@@ -86,7 +86,7 @@ class TestWebExtensionUnit(test_monolingual.TestMonolingualUnit):
     UnitClass = jsonl10n.WebExtensionJsonUnit
 
 
-class TestWebExtensionStore(test_monolingual.TestMonolingualUnit):
+class TestWebExtensionStore(test_monolingual.TestMonolingualStore):
     StoreClass = jsonl10n.WebExtensionJsonFile
 
     def test_serialize(self):
@@ -115,7 +115,7 @@ class TestWebExtensionStore(test_monolingual.TestMonolingualUnit):
         assert out.getvalue() == b'{\n    "key": {\n        "message": "another",\n        "description": "note"\n    }\n}\n'
 
 
-class TestI18NextStore(test_monolingual.TestMonolingualUnit):
+class TestI18NextStore(test_monolingual.TestMonolingualStore):
     StoreClass = jsonl10n.I18NextFile
 
     def test_serialize(self):


### PR DESCRIPTION
Fixes wrongly used base class in JSON tests and resulting test failures.

I've just spotted this bug in code as I've made same mistake in #3500 and the same problem is in resx (see #3504).
