### PR TITLE
Change YAML files look

### DIFF
--- a/translate/storage/test_yaml.py
+++ b/translate/storage/test_yaml.py
@@ -17,22 +17,22 @@ class TestYAMLResourceStore(test_monolingual.TestMonolingualStore):
 
     def test_serialize(self):
         store = yaml.YAMLFile()
-        store.parse('key: value')
+        store.parse('key: "value"')
         out = BytesIO()
         store.serialize(out)
 
-        assert out.getvalue() == b'key: value\n'
+        assert out.getvalue() == b'key: "value"\n'
 
     def test_edit(self):
         store = yaml.YAMLFile()
-        store.parse('key: value')
+        store.parse('key: "value"')
 
         store.units[0].settarget('second')
 
         out = BytesIO()
         store.serialize(out)
 
-        assert out.getvalue() == b'key: second\n'
+        assert out.getvalue() == b'key: "second"\n'
 
     def test_edit_unicode(self):
         store = yaml.YAMLFile()
@@ -43,7 +43,7 @@ class TestYAMLResourceStore(test_monolingual.TestMonolingualStore):
         out = BytesIO()
         store.serialize(out)
 
-        assert out.getvalue() == u'key: zkouška\n'.encode('utf-8')
+        assert out.getvalue() == u'key: "zkouška"\n'.encode('utf-8')
 
     def test_parse_unicode_list(self):
         store = yaml.YAMLFile()
@@ -52,7 +52,7 @@ class TestYAMLResourceStore(test_monolingual.TestMonolingualStore):
         out = BytesIO()
         store.serialize(out)
 
-        assert out.getvalue() == u'list:\n- zkouška\n'.encode('utf-8')
+        assert out.getvalue() == u'list:\n- "zkouška"\n'.encode('utf-8')
 
     def test_ordering(self):
         store = yaml.YAMLFile()
@@ -69,9 +69,9 @@ baz: baz
         store = yaml.YAMLFile()
         store.parse('''
 foo:
-    bar: bar
+    bar: "bar"
     baz:
-        boo: booo
+        boo: "booo"
 ''')
 
         assert store.units[0].getid() == 'foo / bar'
@@ -83,9 +83,9 @@ foo:
         store.serialize(out)
 
         assert out.getvalue() == b'''foo:
-  bar: bar
+  bar: "bar"
   baz:
-    boo: booo
+    boo: "booo"
 '''
 
 
@@ -96,17 +96,17 @@ class TestRubyYAMLResourceStore(test_monolingual.TestMonolingualStore):
         data = '''en-US:
   date:
     formats:
-      default: '%Y-%m-%d'
-      short: '%b %d'
-      long: '%B %d, %Y'
+      default: "%Y-%m-%d"
+      short: "%b %d"
+      long: "%B %d, %Y"
     day_names:
-    - Sunday
-    - Monday
-    - Tuesday
-    - Wednesday
-    - Thursday
-    - Friday
-    - Saturday
+    - "Sunday"
+    - "Monday"
+    - "Tuesday"
+    - "Wednesday"
+    - "Thursday"
+    - "Friday"
+    - "Saturday"
 '''
         store = yaml.RubyYAMLFile()
         store.parse(data)
@@ -117,11 +117,11 @@ class TestRubyYAMLResourceStore(test_monolingual.TestMonolingualStore):
 
     def test_ruby(self):
         data = '''en:
-  language_name: English
-  language_name_english: English
+  language_name: "English"
+  language_name_english: "English"
   message:
-    unsubscribe: Unsubscribe from our emails
-    from_app: from %{app_name}
+    unsubscribe: "Unsubscribe from our emails"
+    from_app: "from %{app_name}"
 '''
         store = yaml.RubyYAMLFile()
         store.parse(data)


### PR DESCRIPTION
- In most cases frameworks do not wrap lines at all.
- The values are usually enclosed in double quotes.
