### PR TITLE
Add support for Xapian 1.4 and Python 3

### DIFF
--- a/translate/search/indexing/CommonIndexer.py
+++ b/translate/search/indexing/CommonIndexer.py
@@ -164,8 +164,8 @@ class CommonDatabase(object):
         # turn a dict into a list if necessary
         if isinstance(args, dict):
             args = args.items()
-        # turn 'args' into a list if necessary
-        if not isinstance(args, list):
+        elif not isinstance(args, list):
+            # turn 'args' into a list if necessary
             args = [args]
         # combine all given queries
         result = []

--- a/translate/search/indexing/XapianIndexer.py
+++ b/translate/search/indexing/XapianIndexer.py
@@ -487,10 +487,11 @@ def _extract_fieldvalues(match, result_and_fieldnames):
     # fill the dict
     for term in match["document"].termlist():
         for fname in fieldnames:
-            if ((fname is None) and re.match("[^A-Z]", term.term)):
-                value = term.term
-            elif re.match("%s[^A-Z]" % str(fname).upper(), term.term):
-                value = term.term[len(fname):]
+            termstr = term.term.decode('utf-8')
+            if ((fname is None) and re.match("[^A-Z]", termstr)):
+                value = termstr
+            elif re.match("%s[^A-Z]" % str(fname).upper(), termstr):
+                value = termstr[len(fname):]
             else:
                 continue
             # we found a matching field/term

--- a/translate/search/indexing/XapianIndexer.py
+++ b/translate/search/indexing/XapianIndexer.py
@@ -137,14 +137,14 @@ class XapianDatabase(CommonIndexer.CommonDatabase):
         """generate a query based on an existing query object
 
         basically this function should just create a copy of the original
+        Since query objects are immutable, this function is a no-op
 
         :param query: the original query object
         :type query: xapian.Query
         :return: the resulting query object
         :rtype: xapian.Query
         """
-        # create a copy of the original query
-        return xapian.Query(query)
+        return query
 
     def _create_query_for_string(self, text, require_all=True, analyzer=None):
         """generate a query for a plain term of a string query

--- a/translate/search/indexing/XapianIndexer.py
+++ b/translate/search/indexing/XapianIndexer.py
@@ -31,28 +31,9 @@ you should checkout the following::
 It is not completely working, but it should give you a good start.
 """
 
-# xapian module versions before 1.0.13 hangs apache under mod_python
 import re
 import six
 import sys
-
-# detect if running under apache
-if 'apache' in sys.modules or '_apache' in sys.modules or 'mod_wsgi' in sys.modules:
-
-    def _str2version(version):
-        return [int(i) for i in version.split('.')]
-
-    import subprocess
-    # even checking xapian version leads to deadlock under apache, must figure version from command line
-    try:
-        command = subprocess.Popen(['xapian-check', '--version'], stdout=subprocess.PIPE)
-        stdout, stderr = command.communicate()
-        if _str2version(re.match('.*([0-9]+\.[0-9]+\.[0-9]+).*', stdout).groups()[0]) < [1, 0, 13]:
-            raise ImportError("Running under apache, can't load xapain")
-    except:
-        #FIXME: report is xapian-check command is missing?
-        raise ImportError("Running under apache, can't load xapian")
-
 from . import CommonIndexer
 import xapian
 import os

--- a/translate/search/indexing/__init__.py
+++ b/translate/search/indexing/__init__.py
@@ -62,7 +62,7 @@ def _get_available_indexers():
         mod_name = mod_file[:-3]
         # TODO - debug: "[Indexer]: trying to import indexing engines from '%s'" % mod_path
         try:
-            module = __import__(mod_name, globals(), {})
+            module = __import__(mod_name, globals(), {}, level=1)
         except ImportError:
             # maybe it is unusable or dependencies are missing
             continue


### PR DESCRIPTION
The recent release of Xapian 1.4 offers Python 3 support for Xapian. Since Xapian support has not been available until now, there are parts of the indexer code that have never been tested with Python 3.

The following patch set:
- Fixes the API usage to be compatible with Xapian 1.4; only one small change in the `translate-toolkit` (`_create_query_for_query`) is required as the (unneeded) copy constructor `xapian.Query(query)` is no longer exported. The copy wasn't needed with older Xapian either so this is backwards compatible.
- Fixes the usual little Python 2 to 3 gremlins with dicts, encoding and imports.

These patches are included in the upload of `translate-toolkit` 2.0.0~b5-2 in Debian `experimental` that enables Python 3 support for translate-toolkit and also its xapian indexer. All tests are passing with both Python 2.7 and 3.5 with the Xapian support enabled.

(The change to `_create_query_for_query` will need to be backported to `translate-toolkit` 1.13 unless version 2.0.0 actually gets released soon to be included in the upcoming Debian release...)
