### PR TITLE
Add color support for pocount output

### DIFF
--- a/tests/cli/data/test_pocount/stderr.txt
+++ b/tests/cli/data/test_pocount/stderr.txt
@@ -1,4 +1,5 @@
 usage: pocount [-h] [--incomplete]
                [--full | --csv | --short | --short-strings | --short-words]
+               [--no-color]
                files [files ...]
 pocount: error: too few arguments

--- a/tests/cli/data/test_pocount_help/stdout.txt
+++ b/tests/cli/data/test_pocount_help/stdout.txt
@@ -1,5 +1,6 @@
 usage: pocount [-h] [--incomplete]
                [--full | --csv | --short | --short-strings | --short-words]
+               [--no-color]
                files [files ...]
 
 positional arguments:
@@ -15,3 +16,4 @@ Output format:
   --short          same as --short-strings
   --short-strings  statistics of strings in short format - one line per file
   --short-words    statistics of words in short format - one line per file
+  --no-color       show output without color

--- a/tests/cli/data/test_pocount_mutually_exclusive/stderr.txt
+++ b/tests/cli/data/test_pocount_mutually_exclusive/stderr.txt
@@ -1,4 +1,5 @@
 usage: pocount [-h] [--incomplete]
                [--full | --csv | --short | --short-strings | --short-words]
+               [--no-color]
                files [files ...]
 pocount: error: argument --csv: not allowed with argument --short

--- a/tests/cli/data/test_pocount_po_file/stdout.txt
+++ b/tests/cli/data/test_pocount_po_file/stdout.txt
@@ -1,9 +1,9 @@
-./data/test_pocount_po_file/one.po
-type              strings      words (source)    words (translation)
-translated:       1 (100%)          3 (100%)               3
-fuzzy:            0 (  0%)          0 (  0%)             n/a
-untranslated:     0 (  0%)          0 (  0%)             n/a
+Processing file : ./data/test_pocount_po_file/one.po
+Type               Strings      Words (source)    Words (translation)
+Translated:       1 (100%)          3 (100%)               3
+Fuzzy:            0 (  0%)          0 (  0%)             n/a
+Untranslated:     0 (  0%)          0 (  0%)             n/a
 Total:            1                 3                      3
 
-unreviewed:        1 (100%)          3 (100%)               3
+Unreviewed:       1 (100%)          3 (100%)               3
 

--- a/tests/cli/test_pocount_po_file.sh
+++ b/tests/cli/test_pocount_po_file.sh
@@ -2,5 +2,5 @@
 
 source $(dirname $0)/test.inc.sh
 
-pocount $one
+pocount $one --no-color
 check_results

--- a/translate/tools/pocount.py
+++ b/translate/tools/pocount.py
@@ -46,6 +46,38 @@ style_full, style_csv, style_short_strings, style_short_words = range(4)
 default_style = style_full
 
 
+class ConsoleColor:
+    """Class to implement color mode.
+    """
+    # print using color? Default to true
+    color_mode = True
+    COLOR_PURPLE = "\033[95m"
+    COLOR_GREEN = "\033[92m"
+    COLOR_YELLOW = "\033[93m"
+    COLOR_RED = "\033[91m"
+    COLOR_DEFAULT = "\033[0m"
+
+    @classmethod
+    def HEADER(cls):
+        return cls.COLOR_PURPLE if ConsoleColor.color_mode else ""
+
+    @classmethod
+    def OKGREEN(cls):
+        return cls.COLOR_GREEN if ConsoleColor.color_mode else ""
+
+    @classmethod
+    def WARNING(cls):
+        return cls.COLOR_YELLOW if ConsoleColor.color_mode else ""
+
+    @classmethod
+    def FAIL(cls):
+        return cls.COLOR_RED if ConsoleColor.color_mode else ""
+
+    @classmethod
+    def ENDC(cls):
+        return cls.COLOR_DEFAULT if ConsoleColor.color_mode else ""
+
+
 def calcstats_old(filename):
     """This is the previous implementation of calcstats() and is left for
     comparison and debuging purposes.
@@ -128,39 +160,62 @@ def summarize(title, stats, style=style_full, indent=8, incomplete_only=False):
         print()
     elif (style == style_short_strings):
         spaces = " " * (indent - len(title))
-        print("%s%s strings: total: %d\t| %dt\t%df\t%du\t| %d%%t\t%d%%f\t%d%%u" % (
-              title, spaces,
-              stats["total"], stats["translated"], stats["fuzzy"], stats["untranslated"],
-              percent(stats["translated"], stats["total"]),
-              percent(stats["fuzzy"], stats["total"]),
-              percent(stats["untranslated"], stats["total"])))
+        print("%s%s strings: total: %d\t| %st\t%sf\t%su\t| %st\t%sf\t%su" % (
+              ConsoleColor.HEADER() + title + ConsoleColor.ENDC(),
+              spaces,
+              stats["total"],
+              ConsoleColor.OKGREEN() + str(stats["translated"]) + ConsoleColor.ENDC(),
+              ConsoleColor.WARNING() + str(stats["fuzzy"]) + ConsoleColor.ENDC(),
+              ConsoleColor.FAIL() + str(stats["untranslated"]) + ConsoleColor.ENDC(),
+              ConsoleColor.OKGREEN() +
+              str(percent(stats["translated"], stats["total"]))
+              + "%" + ConsoleColor.ENDC(),
+              ConsoleColor.WARNING() +
+              str(percent(stats["fuzzy"], stats["total"]))
+              + "%" + ConsoleColor.ENDC(),
+              ConsoleColor.FAIL() +
+              str(percent(stats["untranslated"], stats["total"]))
+              + "%" + ConsoleColor.ENDC()))
     elif (style == style_short_words):
         spaces = " " * (indent - len(title))
-        print("%s%s source words: total: %d\t| %dt\t%df\t%du\t| %d%%t\t%d%%f\t%d%%u" % (
-            title, spaces,
-            stats["totalsourcewords"], stats["translatedsourcewords"], stats["fuzzysourcewords"], stats["untranslatedsourcewords"],
-            percent(stats["translatedsourcewords"], stats["totalsourcewords"]),
-            percent(stats["fuzzysourcewords"], stats["totalsourcewords"]),
-            percent(stats["untranslatedsourcewords"], stats["totalsourcewords"])))
+        print("%s%s source words: total: %d\t| %st\t%sf\t%su\t| %st\t%sf\t%su" % (
+            ConsoleColor.HEADER() + title + ConsoleColor.ENDC(),
+            spaces,
+            stats["totalsourcewords"],
+            ConsoleColor.OKGREEN() + str(stats["translatedsourcewords"]) + ConsoleColor.ENDC(),
+            ConsoleColor.WARNING() + str(stats["fuzzysourcewords"]) + ConsoleColor.ENDC(),
+            ConsoleColor.FAIL() + str(stats["untranslatedsourcewords"]) + ConsoleColor.ENDC(),
+            ConsoleColor.OKGREEN() +
+            str(percent(stats["translatedsourcewords"], stats["totalsourcewords"]))
+            + "%" + ConsoleColor.ENDC(),
+            ConsoleColor.WARNING() +
+            str(percent(stats["fuzzysourcewords"], stats["totalsourcewords"]))
+            + "%" + ConsoleColor.ENDC(),
+            ConsoleColor.FAIL() +
+            str(percent(stats["untranslatedsourcewords"], stats["totalsourcewords"]))
+            + "%" + ConsoleColor.ENDC()))
     else:  # style == style_full
-        print(title)
-        print("type              strings      words (source)    words (translation)")
-        print("translated:   %5d (%3d%%) %10d (%3d%%) %15d" % (
+        print("Processing file : " + ConsoleColor.HEADER() + title + ConsoleColor.ENDC())
+        print("Type               Strings      Words (source)    Words (translation)")
+        print(ConsoleColor.OKGREEN() + "Translated:   %5d (%3d%%) %10d (%3d%%) %15d" % (
             stats["translated"],
             percent(stats["translated"], stats["total"]),
             stats["translatedsourcewords"],
             percent(stats["translatedsourcewords"], stats["totalsourcewords"]),
-            stats["translatedtargetwords"]))
-        print("fuzzy:        %5d (%3d%%) %10d (%3d%%)             n/a" % (
+            stats["translatedtargetwords"])
+            + ConsoleColor.ENDC())
+        print(ConsoleColor.WARNING() + "Fuzzy:        %5d (%3d%%) %10d (%3d%%)             n/a" % (
             stats["fuzzy"],
             percent(stats["fuzzy"], stats["total"]),
             stats["fuzzysourcewords"],
-            percent(stats["fuzzysourcewords"], stats["totalsourcewords"])))
-        print("untranslated: %5d (%3d%%) %10d (%3d%%)             n/a" % (
+            percent(stats["fuzzysourcewords"], stats["totalsourcewords"])) +
+            ConsoleColor.ENDC())
+        print(ConsoleColor.FAIL() + "Untranslated: %5d (%3d%%) %10d (%3d%%)             n/a" % (
             stats["untranslated"],
             percent(stats["untranslated"], stats["total"]),
             stats["untranslatedsourcewords"],
-            percent(stats["untranslatedsourcewords"], stats["totalsourcewords"])))
+            percent(stats["untranslatedsourcewords"], stats["totalsourcewords"])) +
+            ConsoleColor.ENDC())
         print("Total:        %5d %17d %22d" % (
             stats["total"],
             stats["totalsourcewords"],
@@ -168,13 +223,13 @@ def summarize(title, stats, style=style_full, indent=8, incomplete_only=False):
         if "extended" in stats:
             print("")
             for state, e_stats in six.iteritems(stats["extended"]):
-                print("%s:    %5d (%3d%%) %10d (%3d%%) %15d" % (
-                    state, e_stats["units"], percent(e_stats["units"], stats["total"]),
+                print("%-11s   %5d (%3d%%) %10d (%3d%%) %15d" % (
+                    state.title()+":", e_stats["units"], percent(e_stats["units"], stats["total"]),
                     e_stats["sourcewords"], percent(e_stats["sourcewords"], stats["totalsourcewords"]),
                     e_stats["targetwords"]))
 
         if stats["review"] > 0:
-            print("review:       %5d %17d                    n/a" % (
+            print("review:          %5d %17d                    n/a" % (
                 stats["review"], stats["reviewsourcewords"]))
         print()
     return 0
@@ -294,12 +349,17 @@ def main():
         "--short-words", action="store_const",
         const=style_short_words, dest="style",
         help="statistics of words in short format - one line per file")
+    output_group.add_argument(
+        "--no-color", action="store_true",
+        help="show output without color"
+    )
 
     parser.add_argument("files", nargs="+")
 
     args = parser.parse_args()
 
     logging.basicConfig(format="%(name)s: %(levelname)s: %(message)s")
+    ConsoleColor.color_mode = not args.no_color
 
     summarizer(args.files, args.style, args.incomplete_only)
 


### PR DESCRIPTION
Hello, i see that issue #2162 is still uncompleted for a long time.

I am adding color support with ANSI color code that enabled by default, but can be toggled off with `pocount --no-color`.

Here are some screenshot

Edit: I also change the output text a bit, so I'm altering the test data too.
Edit 2: I'm beginner with testing and travis thing, sorry for the failing build. Will fix it soon.

![example 1](https://cloud.githubusercontent.com/assets/6151302/20003247/1974661e-a2b8-11e6-8cc8-d0840533a419.PNG)

![example 2](https://cloud.githubusercontent.com/assets/6151302/20003251/1c1b207e-a2b8-11e6-8b4f-dc2d5c812e65.PNG)

![example 3](https://cloud.githubusercontent.com/assets/6151302/20003256/217d537a-a2b8-11e6-9d48-529a74179772.PNG)

![example 4](https://cloud.githubusercontent.com/assets/6151302/20003261/29eeee4c-a2b8-11e6-9b19-216b4e077d49.PNG)

