### PR TITLE
Add option to podebug to avoid rewriting placeholders

### DIFF
--- a/translate/storage/placeables/general.py
+++ b/translate/storage/placeables/general.py
@@ -171,6 +171,24 @@ class FormattingPlaceable(Ph):
     parse = classmethod(regex_parse)
 
 
+class DoubleAtPlaceable(Ph):
+    istranslatable = False
+    iseditable = False
+    # Matches placeholders that use two at symbols @@placeable@@.
+    regex = re.compile(r"@@.*?@@", re.VERBOSE)
+    parse = classmethod(regex_parse)
+
+
+class BracePlaceable(Ph):
+    istranslatable = False
+    iseditable = False
+    # Matches placeholders that use two braces {{placeable}} or one brace {placeable}.
+    # The negative character groups with closing brace [^}] stop the regex from counting several placeholders
+    # as one (e.g. '{open}something{closed}' should produce two distinct BracePlaceables '{open}' and '{closed}')
+    regex = re.compile(r"{{[^}]*}}|{[^}]*}", re.VERBOSE)
+    parse = classmethod(regex_parse)
+
+
 class UrlPlaceable(Ph):
     """Placeable handling URI."""
 

--- a/translate/storage/placeables/strelem.py
+++ b/translate/storage/placeables/strelem.py
@@ -400,7 +400,7 @@ class StringElem(object):
             if sub.isleaf() and filter(sub):
                 elems.append(sub)
             else:
-                elems.extend(sub.depth_first())
+                elems.extend(sub.depth_first(filter))
         return elems
 
     def encode(self, encoding=sys.getdefaultencoding()):

--- a/translate/storage/placeables/test_general.py
+++ b/translate/storage/placeables/test_general.py
@@ -117,4 +117,30 @@ def test_placeable_formatting():
     assert fp.parse(u'There were %1$d cows')[1] == fp([u'%1$d'])
 
 
+def test_placeable_doubleat():
+    dap = general.DoubleAtPlaceable
+    assert dap.parse(u'There were @@number@@ cows')[1] == dap([u'@@number@@'])
+    assert dap.parse(u'There were @@number1@@ cows and @@number2@@ sheep')[1] == dap([u'@@number1@@'])
+    assert dap.parse(u'There were @@number1@@ cows and @@number2@@ sheep')[3] == dap([u'@@number2@@'])
+
+
+def test_placeable_brace():
+    bp = general.BracePlaceable
+    # Double braces
+    assert bp.parse(u'There were {{number}} cows')[1] == bp([u'{{number}}'])
+    assert bp.parse(u'There were {{number1}} cows and {{number2}} sheep')[1] == bp([u'{{number1}}'])
+    assert bp.parse(u'There were {{number1}} cows and {{number2}} sheep')[3] == bp([u'{{number2}}'])
+
+    # Single braces
+    assert bp.parse(u'There were {number} cows')[1] == bp([u'{number}'])
+    assert bp.parse(u'There were {number1} cows and {number2} sheep')[1] == bp([u'{number1}'])
+    assert bp.parse(u'There were {number1} cows and {number2} sheep')[3] == bp([u'{number2}'])
+
+    # Mixed single and double braces
+    assert bp.parse(u'There were {number1} cows and {{number2}} sheep')[1] == bp([u'{number1}'])
+    assert bp.parse(u'There were {number1} cows and {{number2}} sheep')[3] == bp([u'{{number2}}'])
+    assert bp.parse(u'There were {{number1}} cows and {number2} sheep')[1] == bp([u'{{number1}}'])
+    assert bp.parse(u'There were {{number1}} cows and {number2} sheep')[3] == bp([u'{number2}'])
+
+
 # TODO: PythonFormattingPlaceable, JavaMessageFormatPlaceable, UrlPlaceable, XMLTagPlaceable

--- a/translate/tools/test_podebug.py
+++ b/translate/tools/test_podebug.py
@@ -72,6 +72,31 @@ class TestPODebug:
         """Test the unicode rewrite function"""
         assert six.text_type(self.debug.rewrite_unicode(u"Test")) == u"Ŧḗşŧ"
 
+    def test_rewrite_unicode_preserves_at_placeholders(self):
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert six.text_type(debug.rewrite_unicode(u"@@ph@@Test @@ph@@")) == u"@@ph@@Ŧḗşŧ @@ph@@"
+
+    def test_rewrite_unicode_preserves_single_brace_placeholders(self):
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert six.text_type(debug.rewrite_unicode(u"{ph}Test {ph}")) == u"{ph}Ŧḗşŧ {ph}"
+
+    def test_rewrite_unicode_preserves_double_brace_placeholders(self):
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert six.text_type(debug.rewrite_unicode(u"{{ph}}Test {{ph}}")) == u"{{ph}}Ŧḗşŧ {{ph}}"
+
+    def test_rewrite_unicode_preserves_html(self):
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert six.text_type(debug.rewrite_unicode(u"<style0>Test</style0>")) == u"<style0>Ŧḗşŧ</style0>"
+
+    def test_rewrite_unicode_preserves_multiple_styles_of_placeholder(self):
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert six.text_type(debug.rewrite_unicode(u"<b>{{ph}}Test{ph}@@ph@@Test</b>")) == u"<b>{{ph}}Ŧḗşŧ{ph}@@ph@@Ŧḗşŧ</b>"
+
     def test_rewrite_flipped(self):
         """Test the unicode rewrite function"""
         assert six.text_type(self.debug.rewrite_flipped(u"Test")) == u"\u202e⊥ǝsʇ"
@@ -80,6 +105,32 @@ class TestPODebug:
         # Chars < ! and > z are returned as is
         assert six.text_type(self.debug.rewrite_flipped(u" ")) == u"\u202e "
         assert six.text_type(self.debug.rewrite_flipped(u"©")) == u"\u202e©"
+
+    def test_rewrite_flipped_preserves_at_placeholders(self):
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert six.text_type(debug.rewrite_flipped(u"@@ph@@Test @@ph@@")) == u"\u202e@@ph@@⊥ǝsʇ @@ph@@"
+
+    def test_rewrite_flipped_preserves_single_brace_placeholders(self):
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert six.text_type(debug.rewrite_flipped(u"{ph}Test {ph}")) == u"\u202e{ph}⊥ǝsʇ {ph}"
+
+    def test_rewrite_flipped_preserves_double_brace_placeholders(self):
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert six.text_type(debug.rewrite_flipped(u"{{ph}}Test {{ph}}")) == u"\u202e{{ph}}⊥ǝsʇ {{ph}}"
+
+    def test_rewrite_flipped_preserves_html(self):
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert six.text_type(debug.rewrite_flipped(u"<style0>Test </style0>")) == u"\u202e<style0>⊥ǝsʇ </style0>"
+
+    def test_rewrite_flipped_multiple_styles_of_placeholder(self):
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert six.text_type(
+            debug.rewrite_flipped(u"<b>{{ph}}Test{ph}@@ph@@Test</b>")) == u"\u202e<b>{{ph}}⊥ǝsʇ{ph}@@ph@@⊥ǝsʇ</b>"
 
     def test_rewrite_chef(self):
         """Test the chef rewrite function


### PR DESCRIPTION
This change adds the optional `--preserveplaceholders` flag to podebug, which when enabled ensures that "unicode" and "flipped" rewrites are not applied to sub-strings identified as placeholders. In this way, placeholders remain unchanged in the output so that systems working with the rewritten strings can still inject data at run-time as normal.

At the moment it can identify and preserve placeholders in four 'styles' that are in use at Skyscanner:
- `{{doublebraces}}`
- `{singlebraces}`
- `@@doubleatsymbols@@`
- `<htmltags>`

All of these are held in a single regex that should be easy to extend if other styles are required in future.