### PR TITLE
ts: Write quotes as entities

### DIFF
--- a/translate/storage/test_ts2.py
+++ b/translate/storage/test_ts2.py
@@ -54,6 +54,12 @@ TS_NUMERUS = """<?xml version="1.0" encoding="utf-8"?>
         <source>func3</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&quot;Qt Linguist&apos;s&quot; format ain&apos;t that easy.
+The other line&apos;s translation may have quotes, too (&quot;&apos;&quot;,
+&apos;&quot;&apos;)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>
 """

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -502,6 +502,19 @@ class tsfile(lisa.LISAfile):
         # Qt Linguist does self-close the "location" elements though
         for e in root.xpath("//*[not(./node()) and not(text()) and not(name() = 'location')]"):
             e.text = ""
+        # For conformance with Qt output, write XML declaration with double quotes
         out.write(str('<?xml version="1.0" encoding="utf-8"?>\n').encode('utf-8'))
-        out.write(etree.tostring(root, doctype=doctype, pretty_print=True,
-                                 xml_declaration=None, encoding='utf-8'))
+        # For conformance with Qt output, post-process etree.tostring output,
+        # replacing ' with &apos; and " with &quot; in text elements
+        treestring = etree.tostring(root, doctype=doctype, pretty_print=True,
+                                    xml_declaration=False, encoding='unicode')
+        pos = 0
+        while pos >= 0:
+            nextpos = treestring.find('<', pos)
+            value = treestring[pos:nextpos].replace("'", "&apos;").replace('"', "&quot;")
+            out.write(value.encode('utf-8'))
+            pos = nextpos
+            nextpos = treestring.find('>', pos)
+            out.write(treestring[pos:nextpos].encode('utf-8'))
+            pos = nextpos
+        out.write(treestring[pos:].encode('utf-8'))

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -507,14 +507,15 @@ class tsfile(lisa.LISAfile):
         # For conformance with Qt output, post-process etree.tostring output,
         # replacing ' with &apos; and " with &quot; in text elements
         treestring = etree.tostring(root, doctype=doctype, pretty_print=True,
-                                    xml_declaration=False, encoding='unicode')
+                                    xml_declaration=False, encoding='utf-8')
         pos = 0
         while pos >= 0:
-            nextpos = treestring.find('<', pos)
-            value = treestring[pos:nextpos].replace("'", "&apos;").replace('"', "&quot;")
-            out.write(value.encode('utf-8'))
+            nextpos = treestring.find(b'<', pos)
+            out.write(
+                treestring[pos:nextpos].replace(b"'", b"&apos;").replace(b'"', b"&quot;")
+            )
             pos = nextpos
-            nextpos = treestring.find('>', pos)
-            out.write(treestring[pos:nextpos].encode('utf-8'))
+            nextpos = treestring.find(b'>', pos)
+            out.write(treestring[pos:nextpos])
             pos = nextpos
-        out.write(treestring[pos:].encode('utf-8'))
+        out.write(treestring[pos:])


### PR DESCRIPTION
This is improvement on top of #3470. It removes not necessary encoding/decoding of unicode strings gaining about 20% of performance.