### PR TITLE
Checks: store categories in checker instances

### DIFF
--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -307,13 +307,13 @@ class UnitChecker(object):
 
     preconditions = {}
 
-    #: Categories where each checking function falls into
-    #: Function names are used as keys, categories are the values
-    categories = {}
-
     def __init__(self, checkerconfig=None, excludefilters=None,
                  limitfilters=None, errorhandler=None):
         self.errorhandler = errorhandler
+
+        #: Categories where each checking function falls into
+        #: Function names are used as keys, categories are the values
+        self.categories = {}
 
         if checkerconfig is None:
             self.setconfig(CheckerConfig())

--- a/translate/filters/decorators.py
+++ b/translate/filters/decorators.py
@@ -35,8 +35,8 @@ def critical(f):
 
     @wraps(f)
     def critical_f(self, *args, **kwargs):
-        if f.__name__ not in self.__class__.categories:
-            self.__class__.categories[f.__name__] = Category.CRITICAL
+        if f.__name__ not in self.categories:
+            self.categories[f.__name__] = Category.CRITICAL
 
         return f(self, *args, **kwargs)
 
@@ -47,8 +47,8 @@ def functional(f):
 
     @wraps(f)
     def functional_f(self, *args, **kwargs):
-        if f.__name__ not in self.__class__.categories:
-            self.__class__.categories[f.__name__] = Category.FUNCTIONAL
+        if f.__name__ not in self.categories:
+            self.categories[f.__name__] = Category.FUNCTIONAL
 
         return f(self, *args, **kwargs)
 
@@ -59,8 +59,8 @@ def cosmetic(f):
 
     @wraps(f)
     def cosmetic_f(self, *args, **kwargs):
-        if f.__name__ not in self.__class__.categories:
-            self.__class__.categories[f.__name__] = Category.COSMETIC
+        if f.__name__ not in self.categories:
+            self.categories[f.__name__] = Category.COSMETIC
 
         return f(self, *args, **kwargs)
 
@@ -71,8 +71,8 @@ def extraction(f):
 
     @wraps(f)
     def extraction_f(self, *args, **kwargs):
-        if f.__name__ not in self.__class__.categories:
-            self.__class__.categories[f.__name__] = Category.EXTRACTION
+        if f.__name__ not in self.categories:
+            self.categories[f.__name__] = Category.EXTRACTION
 
         return f(self, *args, **kwargs)
 


### PR DESCRIPTION
Having the categories in classes is problematic as it is shared across instances
and subsequent check runs end up modifying the list of categories, which is
misleading for 3rd party code that wants to access a list of categories for a
particular checker.

Fixes #3533.