### PR TITLE
.lang: parse MAX_LENGTH into comments

### DIFF
--- a/translate/storage/mozilla_lang.py
+++ b/translate/storage/mozilla_lang.py
@@ -108,7 +108,11 @@ class LangStore(txt.TxtFile):
                 self.is_active = True
                 continue
 
-            if line.startswith("## ") and not line.startswith('## TAG'):
+            header_meta_data = (
+                line.startswith("## ")
+                and not line.startswith('## TAG')
+                and not line.startswith('## MAX_LENGTH'))
+            if header_meta_data:
                 self._headers.append(line)
                 continue
 
@@ -131,9 +135,10 @@ class LangStore(txt.TxtFile):
             is_comment = (
                 line.startswith('#')
                 and (not line.startswith("##")
-                     or line.startswith('## TAG')))
+                     or line.startswith('## TAG')
+                     or line.startswith('## MAX_LENGTH')))
             if is_comment:
-                # Read comments, *including* meta tags (i.e. '## TAG')
+                # Read comments, *including* meta tags (e.g. '## TAG')
                 comment += line[1:].strip() + "\n"
 
             if line.startswith(';'):

--- a/translate/storage/test_mozilla_lang.py
+++ b/translate/storage/test_mozilla_lang.py
@@ -285,3 +285,17 @@ class TestMozLangFile(test_base.TestTranslationStore):
         assert (
             "# TAG: another_important_tag"
             in store.units[0].getnotes(origin="developer").split("\n"))
+
+    def test_maxlength(self):
+        """Ensure we can handle MAX_LENGTH meta data"""
+        lang = ("## MAX_LENGTH: 80\n"
+                "# Comment\n"
+                ";Source\n"
+                "Target\n"
+                "\n\n")
+        store = self.StoreClass.parsestring(lang)
+        assert not store.getlangheaders()
+        assert bytes(store).decode('utf-8') == lang
+        assert (
+            "# MAX_LENGTH: 80"
+            in store.units[0].getnotes(origin="developer").split("\n"))


### PR DESCRIPTION
Currently we skip MAX_LENGTH