### PR TITLE
Fixes for pofilter to work with python 3.

### DIFF
--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -807,11 +807,18 @@ class pofile(pocommon.pofile):
         at_start = True
         try:
             for unit in self.units:
-                if not at_start:
-                    out.write(b'\n')
-                else:
-                    at_start = False
-                out.write(unit._getoutput().encode(self.encoding))
+                try:
+                    if not at_start:
+                        out.write(b'\n')
+                    else:
+                        at_start = False
+                    out.write(unit._getoutput().encode(self.encoding))
+                except TypeError:
+                    if not at_start:
+                        out.write('\n')
+                    else:
+                        at_start = False
+                    out.write(unit._getoutput())
         except UnicodeEncodeError as e:
             if self.encoding == 'utf-8':
                 raise


### PR DESCRIPTION
This fixes pofilter to work with python3

How to reproduce the bug:

clone the translate repo somewhere and cd into it

```
virtualenv -p python3 venv_p3
source venv_p3/bin/activate

# then create a test file like below:

echo 'msgid "bla"
msgstr "bla ş"

msgid "cow"
msgstr "bla nici un"

msgid "identical"
msgstr "identical"

msgid "cow2"
msgstr "bla nici un bla ş"' > ro.po

./setup.py build && ./setup.py install

pofilter -i ro.po --errorlevel=traceback
```

=================
OUTPUT
=================

```
pofilter -i ro.po --errorlevel=traceback
processing 1 files...
msgid ""
msgstr ""
"Project-Id-Version: PACKAGE VERSION\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2017-01-28 20:22+0300\n"
"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
"Language-Team: LANGUAGE <LL@li.org>\n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"X-Generator: Translate Toolkit 2.0.0\n"
pofilter: WARNING: Error processing: input ro.po, output None, template None: Traceback (most recent call last):

  File "/home/jobava/Documente/pootle/translate/venv_python3/lib/python3.4/site-packages/translate_toolkit-2.0.0-py3.4.egg/translate/misc/optrecurse.py", line 520, in recursiveprocess
    fulltemplatepath)

  File "/home/jobava/Documente/pootle/translate/venv_python3/lib/python3.4/site-packages/translate_toolkit-2.0.0-py3.4.egg/translate/misc/optrecurse.py", line 576, in processfile
    **passthroughoptions):

  File "/home/jobava/Documente/pootle/translate/venv_python3/lib/python3.4/site-packages/translate_toolkit-2.0.0-py3.4.egg/translate/filters/pofilter.py", line 219, in runfilter
    tofile.serialize(outputfile)

  File "/home/jobava/Documente/pootle/translate/venv_python3/lib/python3.4/site-packages/translate_toolkit-2.0.0-py3.4.egg/translate/storage/pypo.py", line 811, in serialize
    out.write(b'\n')

TypeError: must be str, not bytes
```