### PR TITLE
Appveyor for Windows CI build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,26 +1,11 @@
 environment:
-
   matrix:
-
-    # For Python versions available on Appveyor, see
-    # http://www.appveyor.com/docs/installed-software#python
-    # The list here is complete (excluding Python 2.6, which
-    # isn't covered by this document) at the time of writing.
-
     - PYTHON: "C:\\Python27"
-    # - PYTHON: "C:\\Python33"
-    # - PYTHON: "C:\\Python34"
-    # - PYTHON: "C:\\Python35"
-    # - PYTHON: "C:\\Python27-x64"
-    # - PYTHON: "C:\\Python33-x64"
-      # DISTUTILS_USE_SDK: "1"
-    # - PYTHON: "C:\\Python34-x64"
-      # DISTUTILS_USE_SDK: "1"
-    # - PYTHON: "C:\\Python35-x64"
 
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install wheel"
+  # lxml 3.6.0 has binary release for Windows
   - "%PYTHON%\\python.exe -m pip install lxml==3.6.0"
   - "%PYTHON%\\python.exe -m pip install -r requirements\\dev.txt"
   - "%PYTHON%\\python.exe -m pip freeze"
@@ -28,30 +13,7 @@ install:
 build: off
 
 test_script:
-  # Put your test command here.
-  # If you don't need to build C extensions on 64-bit Python 3.3 or 3.4,
-  # you can remove "build.cmd" from the front of the command, as it's
-  # only needed to support those cases.
-  # Note that you must use the environment variable %PYTHON% to refer to
-  # the interpreter you're using - Appveyor does not do anything special
-  # to put the Python evrsion you want to use on PATH.
   - "%PYTHON%\\python.exe -m compileall -q -f ."
   - "%PYTHON%\\python.exe setup.py --quiet build"
   - "%PYTHON%\\python.exe -m pip install ."
   - "%PYTHON%\\python.exe -m pytest -r EfsxX"
-
-# after_test:
-  # This step builds your wheels.
-  # Again, you only need build.cmd if you're building C extensions for
-  # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
-  # interpreter
-  # - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
-
-# artifacts:
-  # bdist_wheel puts your built wheel in the dist directory
-  # - path: dist\*
-
-#on_success:
-#  You can use this step to upload your artifacts to a public website.
-#  See Appveyor's documentation for more details. Or you can simply
-#  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ environment:
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install wheel"
+  - "%PYTHON%\\python.exe -m pip install lxml==3.6.0"
   - "%PYTHON%\\python.exe -m pip install -r requirements\\dev.txt"
   - "%PYTHON%\\python.exe -m pip freeze"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,56 @@
+environment:
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+    # The list here is complete (excluding Python 2.6, which
+    # isn't covered by this document) at the time of writing.
+
+    - PYTHON: "C:\\Python27"
+    # - PYTHON: "C:\\Python33"
+    # - PYTHON: "C:\\Python34"
+    # - PYTHON: "C:\\Python35"
+    # - PYTHON: "C:\\Python27-x64"
+    # - PYTHON: "C:\\Python33-x64"
+      # DISTUTILS_USE_SDK: "1"
+    # - PYTHON: "C:\\Python34-x64"
+      # DISTUTILS_USE_SDK: "1"
+    # - PYTHON: "C:\\Python35-x64"
+
+install:
+  # We need wheel installed to build wheels
+  - "%PYTHON%\\python.exe -m pip install wheel"
+  - "%PYTHON%\\python.exe -m pip install -r requirements/dev.tx"
+  - "%PYTHON%\\python.exe -m pip freeze"
+
+build: off
+
+test_script:
+  # Put your test command here.
+  # If you don't need to build C extensions on 64-bit Python 3.3 or 3.4,
+  # you can remove "build.cmd" from the front of the command, as it's
+  # only needed to support those cases.
+  # Note that you must use the environment variable %PYTHON% to refer to
+  # the interpreter you're using - Appveyor does not do anything special
+  # to put the Python evrsion you want to use on PATH.
+  - "%PYTHON%\\python.exe -m compileall -q -f ."
+  - "%PYTHON%\\python.exe setup.py --quiet build"
+  - "%PYTHON%\\python.exe -m pip install ."
+  - "%PYTHON%\\python.exe py.test --cov=. -r EfsxX"
+
+# after_test:
+  # This step builds your wheels.
+  # Again, you only need build.cmd if you're building C extensions for
+  # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
+  # interpreter
+  # - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+
+# artifacts:
+  # bdist_wheel puts your built wheel in the dist directory
+  # - path: dist\*
+
+#on_success:
+#  You can use this step to upload your artifacts to a public website.
+#  See Appveyor's documentation for more details. Or you can simply
+#  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ test_script:
   - "%PYTHON%\\python.exe -m compileall -q -f ."
   - "%PYTHON%\\python.exe setup.py --quiet build"
   - "%PYTHON%\\python.exe -m pip install ."
-  - "%PYTHON%\\python.exe py.test --cov=. -r EfsxX"
+  - "%PYTHON%\\python.exe -m pytest -r EfsxX"
 
 # after_test:
   # This step builds your wheels.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install wheel"
-  - "%PYTHON%\\python.exe -m pip install -r requirements/dev.tx"
+  - "%PYTHON%\\python.exe -m pip install -r requirements\\dev.txt"
   - "%PYTHON%\\python.exe -m pip freeze"
 
 build: off


### PR DESCRIPTION
Noticed that 2.0 says there is Windows suport, so I thought I'd add in a Windows CI setup.
- The commits haven't been cleaned up/squashed till I saw if there was interested
- Currently has 52 failures https://ci.appveyor.com/project/nschonni/translate/build/1.0.8

This could eventually be used to produce the InnoSetup package for tagged builds and uploaded as an artifact for release attachment.