### PR TITLE
Add setcontext for ts format

### DIFF
--- a/translate/storage/test_ts2.py
+++ b/translate/storage/test_ts2.py
@@ -251,3 +251,28 @@ class TestTSfile(test_base.TestTranslationStore):
         """test that ts files are read and output properly"""
         tsfile = ts.tsfile.parsestring(TS_NUMERUS)
         assert bytes(tsfile).decode('utf-8') == TS_NUMERUS
+
+    def test_context(self):
+        tsfile = ts.tsfile.parsestring(TS_NUMERUS)
+        unit = tsfile.units[0]
+
+        contexts = [unit.getcontextname()]
+        commentnode = unit.xmlelement.find(unit.namespaced("comment"))
+        if commentnode is not None and commentnode.text is not None:
+            contexts.append(commentnode.text)
+        message_id = unit.xmlelement.get('id')
+        if message_id is not None:
+            contexts.append(message_id)
+        context = '\n'.join(filter(None, contexts))
+        assert unit.getcontext() == context
+        # setting the context does nothing atm - if the unit is inserted
+        unit.setcontext("FOO")
+        assert unit.getcontext() == context
+
+        # setting the context on a non-inserted unit works tho
+        newunit = unit.__class__("New unit")
+        assert newunit.getcontext() == ""
+        newunit.setcontext("")
+        assert newunit.getcontext() == ""
+        newunit.setcontext("Some context")
+        assert newunit.getcontext() == "Some context"

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -94,6 +94,7 @@ class tsunit(lisa.LISAunit):
     }
 
     statemap_r = dict((i[1], i[0]) for i in six.iteritems(statemap))
+    _context = None
 
     def createlanguageNode(self, lang, text, purpose):
         """Returns an xml Element setup with given parameters."""
@@ -271,11 +272,24 @@ class tsunit(lisa.LISAunit):
     def getcontextname(self):
         parent = self.xmlelement.getparent()
         if parent is None:
+            if self._context:
+                return self._context
             return None
         context = parent.find("name")
         if context is None:
             return None
         return context.text
+
+    def setcontext(self, value):
+        if value == self.getcontextname():
+            return
+        parent = self.xmlelement.getparent()
+        if parent is None:
+            self._context = value
+        # TODO: if unit is inserted to ts store
+        # it should put unit in correct context
+        # if unit is already in store it should move
+        # and adjust store as necessary
 
     def getcontext(self):
         contexts = [self.getcontextname()]


### PR DESCRIPTION
this allows you to get/set context for a ts unit only when the unit
is not part of a tsfile

it allows pootle to use ttk to derive the correct `id`, but it doesnt
add the required implementation for ts to work when changing a units
context, or inserting a unit that has had its context set