### PR TITLE
Fixed parsing of unicode values in YAML lists

### DIFF
--- a/translate/storage/test_yaml.py
+++ b/translate/storage/test_yaml.py
@@ -45,6 +45,15 @@ class TestYAMLResourceStore(test_monolingual.TestMonolingualStore):
 
         assert out.getvalue() == u'key: zkouška\n'.encode('utf-8')
 
+    def test_parse_unicode_list(self):
+        store = yaml.YAMLFile()
+        store.parse(u'list:\n- zkouška')
+
+        out = BytesIO()
+        store.serialize(out)
+
+        assert out.getvalue() == u'list:\n- zkouška\n'.encode('utf-8')
+
     def test_ordering(self):
         store = yaml.YAMLFile()
         store.parse('''

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -21,6 +21,7 @@ r"""Class that manages YAML data files for translation
 """
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import uuid
 from collections import OrderedDict
@@ -181,7 +182,7 @@ class YAMLFile(base.TranslationStore):
             elif isinstance(data, list):
                 for k, v in enumerate(data):
                     key = '[{0}]'.format(k)
-                    yield (' / '.join((prev, key)), str(v))
+                    yield (' / '.join((prev, key)), six.text_type(v))
             elif data is None:
                 pass
             else:


### PR DESCRIPTION
Using str is not a good idea on Python 2 as it fails on unicode literals.