### PR TITLE
Add codecov.io support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ matrix:
 #  - sudo apt-get install python-aeidon
 install:
   - pip install coveralls
+  - pip install codecov
   - if [[ $MINVERSION ]]; then make requirements/min-versions.txt; cat requirements/min-versions.txt;  CFLAGS="-O0" pip install -r requirements/min-versions.txt; fi
   - if [[ ! $MINVERSION ]]; then  CFLAGS="-O0" pip install -r requirements/dev.txt; fi
   # Still need to handle with indexing engines
@@ -69,7 +70,8 @@ script:
   - if [[ $META ]]; then pycodestyle; fi
   - if [[ $META ]]; then make docs; fi
 after_success:
-  coveralls
+  - coveralls
+  - codecov
 notifications:
   email:
     on_failure: always


### PR DESCRIPTION
IMHO it is way more usable than coveralls you're using right now. One feature that I like is adding coverage as a status to pull requests, both for patch and overall. I see you're using it for Pootle already, so it might be good idea to have it on translate-toolkit as well.

It needs to be enabled on the codecov.io side as well (and granted access to the GitHub project).

I've kept the coveralls integration in place for now, it can be removed later.