### PR TITLE
Fix po2ts encoding issues

### DIFF
--- a/tests/cli/data/test_po2ts/one.po
+++ b/tests/cli/data/test_po2ts/one.po
@@ -1,0 +1,7 @@
+#: simple.cpp
+msgid "One"
+msgstr "Een"
+
+#: unicode.cpp
+msgid "†wo"
+msgstr "†wee"

--- a/tests/cli/data/test_po2ts/out.txt
+++ b/tests/cli/data/test_po2ts/out.txt
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS>
+    <context>
+        <name>simple.cpp</name>
+        <message>
+            <source>One</source>
+            <translation>Een</translation>
+        </message>
+    </context>
+    <context>
+        <name>unicode.cpp</name>
+        <message>
+            <source>†wo</source>
+            <translation>†wee</translation>
+        </message>
+    </context>
+</TS>

--- a/tests/cli/test_po2ts.sh
+++ b/tests/cli/test_po2ts.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source $(dirname $0)/test.inc.sh
+
+po2ts --progress=none $one $out
+check_results

--- a/translate/convert/po2ts.py
+++ b/translate/convert/po2ts.py
@@ -69,7 +69,7 @@ def convertpo(inputfile, outputfile, templatefile, context):
         return 0
     convertor = po2ts()
     outputstring = convertor.convertstore(inputstore, templatefile, context)
-    outputfile.write(outputstring)
+    outputfile.write(outputstring.encode('utf-8'))
     return 1
 
 

--- a/translate/convert/test_po2ts.py
+++ b/translate/convert/test_po2ts.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from translate.convert import po2ts, test_convert
 from translate.misc import wStringIO
 from translate.storage import po
@@ -29,6 +31,18 @@ msgstr "asdf"'''
         assert "<source>Term</source>" in tsfile
         assert "<translation>asdf</translation>" in tsfile
         assert "<comment>" not in tsfile
+
+    def test_simple_unicode_unit(self):
+        """checks that a simple unit with unicode strings"""
+        minipo = r'''#: unicode.cpp
+msgid "ßource"
+msgstr "†arget"'''
+        tsfile = self.po2ts(minipo)
+        print(tsfile)
+        print(type(tsfile))
+        assert u"<name>unicode.cpp</name>" in tsfile
+        assert u"<source>ßource</source>" in tsfile
+        assert u"<translation>†arget</translation>" in tsfile
 
     def test_fullunit(self):
         """check that an entry with various settings is converted correctly"""


### PR DESCRIPTION
This fixes an issues with po2ts in which we don't encode the output to UTF-8 when required for writing to file.  This was either fallout from Python 3 changes or lack of Unicode testing in po2ts.

@Artoria2e5 the changes to fix your reported issue are just those in f50aace4e62e37bdc9d122f8b59da4d7b7b5bc68 if you want to patch your local installation of Translate Toolkit