### PR TITLE
Improve newlines handling in Android

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -34,8 +34,8 @@ from translate.misc.multistring import multistring
 from babel.core import Locale, UnknownLocaleError
 
 EOF = None
-WHITESPACE = ' \t'  # Whitespace that we collapse.
-MULTIWHITESPACE = re.compile('[ \t]{2}')
+WHITESPACE = ' \n\t'  # Whitespace that we collapse.
+MULTIWHITESPACE = re.compile('[ \n\t]{2}(?!\\\\n)')
 
 
 @six.python_2_unicode_compatible
@@ -230,6 +230,9 @@ class AndroidResourceUnit(base.TranslationUnit):
         if len(text) == 0:
             return ''
         text = text.replace('\\', '\\\\')
+        # This will add non intrusive real newlines to
+        # ones in translation improving readability of result
+        text = text.replace('\n', '\n\\n')
         text = text.replace('\t', '\\t')
         text = text.replace('\'', '\\\'')
         text = text.replace('"', '\\"')

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -47,17 +47,17 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
 
     def test_escape_message_with_newline(self):
         string = 'message\nwith newline'
-        xml = '<string name="teststring">message\nwith newline</string>\n\n'
+        xml = '<string name="teststring">message\n\\nwith newline</string>\n\n'
         self.__check_escape(string, xml)
 
     def test_escape_quotes_with_newline(self):
         string = '\'message\'\nwith newline'
-        xml = '<string name="teststring">\\\'message\\\'\nwith newline</string>\n\n'
+        xml = '<string name="teststring">\\\'message\\\'\n\\nwith newline</string>\n\n'
         self.__check_escape(string, xml)
 
     def test_escape_message_with_newline_in_xml(self):
         string = 'message\n\nwith newline in xml\n'
-        xml = ('<string name="teststring">message\n\nwith newline in xml\n'
+        xml = ('<string name="teststring">message\n\\n\n\\nwith newline in xml\n\\n'
                '</string>\n\n')
         self.__check_escape(string, xml)
 
@@ -105,7 +105,7 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
 
     def test_escape_html_code_quote_newline(self):
         string = 'some \n<b>html code</b> \'here\''
-        xml = ('<string name="teststring">some \n<b>html code</b> \\\'here\\\''
+        xml = ('<string name="teststring">some \n\\n<b>html code</b> \\\'here\\\''
                '</string>\n\n')
         self.__check_escape(string, xml)
 
@@ -135,8 +135,8 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
     def test_plural_escape_message_with_newline(self):
         mString = multistring(['one message\nwith newline', 'other message\nwith newline'])
         xml = ('<plurals name="teststring">\n\t'
-               '<item quantity="one">one message\nwith newline</item>\n\t'
-               '<item quantity="other">other message\nwith newline</item>\n'
+               '<item quantity="one">one message\n\\nwith newline</item>\n\t'
+               '<item quantity="other">other message\n\\nwith newline</item>\n'
                '</plurals>\n\n')
         self.__check_escape(mString, xml, 'en')
 
@@ -199,7 +199,7 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
         self.__check_parse(string, xml)
 
     def test_parse_message_with_newline_in_xml(self):
-        string = 'message\n\nwith\n\nnewline\n\nin xml'
+        string = 'message \nwith\n newline\n in xml'
         xml = ('<string name="teststring">message\n\\nwith\\n\nnewline\\n\nin xml'
                '</string>\n\n')
         self.__check_parse(string, xml)
@@ -274,7 +274,7 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
         At least it seems to be what Android does.
         """
         string = 'newline\nin string'
-        xml = '<string name="teststring">newline\nin string</string>\n\n'
+        xml = '<string name="teststring">newline\\nin string</string>\n\n'
         self.__check_parse(string, xml)
 
     def test_parse_not_translatable_string(self):


### PR DESCRIPTION
The original report #3262 was invalid, the format does not work this
way, so this reverts commit a5ffe4c02d0d1b64930baca6512e29665d0d7e42.

Changes:

- \n is the only thing which is parsed as newline
- newline is stored as \n, together with real newline for better readability

See https://github.com/WeblateOrg/weblate/issues/1418 for discussion, most importantly https://github.com/WeblateOrg/weblate/issues/1418#issuecomment-290725588 is statement from original reporter of #3262.