### PR TITLE
Improved behavior on corrupted properties files

### DIFF
--- a/translate/convert/test_po2prop.py
+++ b/translate/convert/test_po2prop.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from pytest import mark
+
 from translate.convert import po2prop, test_convert
 from translate.misc import wStringIO
 from translate.storage import po
@@ -58,6 +60,25 @@ class TestPO2Prop(object):
         posource = '''#: prop\nmsgid "value"\nmsgstr "waarde"\n'''
         proptemplate = '''prop  =  value\n'''
         propexpected = '''prop  =  waarde\n'''
+        propfile = self.merge2prop(proptemplate, posource)
+        print(propfile)
+        assert propfile == propexpected
+
+    def test_no_value(self):
+        """check that we can handle keys without value"""
+        posource = '''#: KEY\nmsgctxt "KEY"\nmsgid ""\nmsgstr ""\n'''
+        proptemplate = '''KEY = \n'''
+        propexpected = '''KEY = \n'''
+        propfile = self.merge2prop(proptemplate, posource)
+        print(propfile)
+        assert propfile == propexpected
+
+    @mark.xfail(reason="This doesn't work as expected right now")
+    def test_no_separator(self):
+        """check that we can handle keys without separator"""
+        posource = '''#: KEY\nmsgctxt "KEY"\nmsgid ""\nmsgstr ""\n'''
+        proptemplate = '''KEY\n'''
+        propexpected = '''KEY\n'''
         propfile = self.merge2prop(proptemplate, posource)
         print(propfile)
         assert propfile == propexpected

--- a/translate/convert/test_prop2po.py
+++ b/translate/convert/test_prop2po.py
@@ -60,6 +60,24 @@ class TestProp2PO(object):
         assert pounit.source == "Save file"
         assert pounit.target == ""
 
+    def test_no_value_entry(self):
+        """checks that a properties entry without value is converted"""
+        propsource = 'KEY = \n'
+        pofile = self.prop2po(propsource)
+        pounit = self.singleelement(pofile)
+        assert pounit.getcontext() == "KEY"
+        assert pounit.source == ""
+        assert pounit.target == ""
+
+    def test_no_separator_entry(self):
+        """checks that a properties entry without separator is converted"""
+        propsource = 'KEY\n'
+        pofile = self.prop2po(propsource)
+        pounit = self.singleelement(pofile)
+        assert pounit.getcontext() == "KEY"
+        assert pounit.source == ""
+        assert pounit.target == ""
+
     def test_tab_at_end_of_string(self):
         """check that we preserve tabs at the end of a string"""
         propsource = r"TAB_AT_END=This setence has a tab at the end.\t"

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -643,6 +643,7 @@ class propfile(base.TranslationStore):
                 if delimiter_pos == -1:
                     newunit.name = self.personality.key_strip(line)
                     newunit.value = u""
+                    newunit.delimiter = u""
                     self.addunit(newunit)
                     newunit = propunit("", self.personality.name)
                 else:

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -407,3 +407,20 @@ key=value
         assert propunit.name == u'VALUE'
         assert propunit.source == u'I am a "value"'
         assert bytes(propfile) == propsource
+
+    def test_serialize_missing_delimiter(self):
+        propsource = 'key\n'.encode('utf-8')
+        propfile = self.propparse(propsource, personality="java-utf8")
+        propunit = propfile.units[0]
+        assert propunit.name == u'key'
+        assert propunit.value == u''
+        assert propunit.delimiter == u''
+        assert bytes(propfile) == propsource
+
+    def test_serialize_missing_value(self):
+        propsource = 'key=\n'.encode('utf-8')
+        propfile = self.propparse(propsource, personality="java-utf8")
+        propunit = propfile.units[0]
+        assert propunit.name == u'key'
+        assert propunit.value == u''
+        assert bytes(propfile) == propsource


### PR DESCRIPTION
When the properties file contains only key and lacks value, the
find_delimiter returns None as delimiter and it can be later serialized
as None string into the file. By setting delimiter to empty string, we
keep the file as is.