### PR TITLE
Add phpfile tests for strings within array()

### DIFF
--- a/translate/convert/po2php.py
+++ b/translate/convert/po2php.py
@@ -75,10 +75,14 @@ class rephp(object):
         elif line.strip()[:2] == '//' or line.strip()[:2] == '/*':
             returnline = quote.rstripeol(line) + eol
         elif line.lower().replace(" ", "").find('array(') != -1:
-            self.inarray = True
-            self.prename = line[:line.find('=')].strip() + "->"
-            self.equaldel = "=>"
-            self.enddel = ","
+            # If this is a nested array.
+            if self.inarray:
+                self.prename += line[:line.find('=')].strip() + "->"
+            else:
+                self.inarray = True
+                self.prename = line[:line.find('=')].strip() + "->"
+                self.equaldel = "=>"
+                self.enddel = ","
             returnline = quote.rstripeol(line) + eol
         elif self.inarray and line.find(');') != -1:
             self.inarray = False

--- a/translate/convert/test_php2po.py
+++ b/translate/convert/test_php2po.py
@@ -136,6 +136,108 @@ $lang['prefPanel-smime'] = 'Security';'''
         pounit = self.singleelement(pofile)
         assert pounit.getlocations() == ["$lang[ 'credit' ]"]
 
+    def test_named_array(self):
+        phptemplate = '''$strings = array(\n'id-1' => 'source-1',\n);'''
+        phpsource = '''$strings = array(\n'id-1' => 'target-1',\n);'''
+        pofile = self.php2po(phpsource, phptemplate)
+        pounit = self.singleelement(pofile)
+        assert pounit.getlocations() == ["$strings->'id-1'"]
+
+    def test_unnamed_array(self):
+        phptemplate = '''return array(\n'id-1' => 'source-1',\n);'''
+        phpsource = '''return array(\n'id-1' => 'target-1',\n);'''
+        pofile = self.php2po(phpsource, phptemplate)
+        pounit = self.singleelement(pofile)
+        assert pounit.getlocations() == ["'id-1'"]
+
+    def test_named_nested_arrays(self):
+        phptemplate = '''$strings = array(
+            'name1' => 'source1',
+            'list1' => array(
+                'l1' => 'source_l1_1',
+                'l2' => 'source_l1_2',
+                'l3' => 'source_l1_3',
+            ),
+            'list2' => array(
+                'l1' => 'source_l2_1',
+                'l2' => 'source_l2_2',
+                'l3' => 'source_l2_3',
+            ),
+            'name2' => 'source2',
+        );'''
+        phpsource = '''$strings = array(
+            'name1' => 'target1',
+            'list1' => array(
+                'l1' => 'target_l1_1',
+                'l2' => 'target_l1_2',
+                'l3' => 'target_l1_3',
+            ),
+            'list2' => array(
+                'l1' => 'target_l2_1',
+                'l2' => 'target_l2_2',
+                'l3' => 'target_l2_3',
+            ),
+            'name2' => 'target2',
+        );'''
+        pofile = self.php2po(phpsource, phptemplate)
+        expected = {
+            "$strings->'name1'": ("source1", "target1"),
+            "$strings->'list1'->'l1'": ("source_l1_1", "target_l1_1"),
+            "$strings->'list1'->'l2'": ("source_l1_2", "target_l1_2"),
+            "$strings->'list1'->'l3'": ("source_l1_3", "target_l1_3"),
+            "$strings->'list2'->'l1'": ("source_l2_1", "target_l2_1"),
+            "$strings->'list2'->'l2'": ("source_l2_2", "target_l2_2"),
+            "$strings->'list2'->'l3'": ("source_l2_3", "target_l2_3"),
+            "$strings->'name2'": ("source2", "target2"),
+        }
+        for pounit in [x for x in pofile.units if x.source != '']:
+            assert ((pounit.source, pounit.target) ==
+                    expected.get(pounit.getlocations()[0]))
+
+    def test_unnamed_nested_arrays(self):
+        phptemplate = '''return array(
+            'name1' => 'source1',
+            'list1' => array(
+                'l1' => 'source_l1_1',
+                'l2' => 'source_l1_2',
+                'l3' => 'source_l1_3',
+            ),
+            'list2' => array(
+                'l1' => 'source_l2_1',
+                'l2' => 'source_l2_2',
+                'l3' => 'source_l2_3',
+            ),
+            'name2' => 'source2',
+        );'''
+        phpsource = '''return array  (
+            'name1' => 'target1',
+            'list1' => array(
+                'l1' => 'target_l1_1',
+                'l2' => 'target_l1_2',
+                'l3' => 'target_l1_3',
+            ),
+            'list2' => array(
+                'l1' => 'target_l2_1',
+                'l2' => 'target_l2_2',
+                'l3' => 'target_l2_3',
+            ),
+            'name2' => 'target2',
+        );'''
+        pofile = self.php2po(phpsource, phptemplate)
+        expected = {
+            "'name1'": ("source1", "target1"),
+            "'list1'->'l1'": ("source_l1_1", "target_l1_1"),
+            "'list1'->'l2'": ("source_l1_2", "target_l1_2"),
+            "'list1'->'l3'": ("source_l1_3", "target_l1_3"),
+            "'list2'->'l1'": ("source_l2_1", "target_l2_1"),
+            "'list2'->'l2'": ("source_l2_2", "target_l2_2"),
+            "'list2'->'l3'": ("source_l2_3", "target_l2_3"),
+            "'name2'": ("source2", "target2"),
+        }
+        for pounit in [x for x in pofile.units if x.source != '']:
+            assert ((pounit.source, pounit.target) ==
+                    expected.get(pounit.getlocations()[0]))
+
 
 class TestPhp2POCommand(test_convert.TestConvertCommand, TestPhp2PO):
     """Tests running actual php2po commands on files"""

--- a/translate/convert/test_po2php.py
+++ b/translate/convert/test_po2php.py
@@ -141,6 +141,63 @@ msgstr "stringetjie"
         print(phpfile)
         assert "".join(phpfile) == phpexpected
 
+    def test_named_nested_array(self):
+        """check that we can handle nested arrays"""
+        posource = '''#: $lang->'codes'->'name'\nmsgid "value"\nmsgstr "waarde"\n'''
+        phptemplate = '''$lang = array(\n    'codes' => array(\n        'name' => 'value',\n),\n);\n'''
+        phpexpected = '''$lang = array(\n    'codes' => array(\n        'name' => 'waarde',\n),\n);\n'''
+        phpfile = self.merge2php(phptemplate, posource)
+        print(phpfile)
+        assert "".join(phpfile) == phpexpected
+
+    def test_unnamed_nested_arrays(self):
+        posource = '''
+#: 'name1'
+msgid "source1"
+msgstr "target1"
+
+#: 'list1'->'l1'
+msgid "source_l1_1"
+msgstr "target_l1_1"
+
+#: 'list1'->'list2'->'l1'
+msgid "source_l1_l2_l1"
+msgstr "target_l1_l2_l1"
+
+#: 'list1'->'l3'
+msgid "source_l1_3"
+msgstr "target_l1_3"
+
+#: 'name2'
+msgid "source2"
+msgstr "target2"
+'''
+        phptemplate = '''return array(
+            'name1' => 'source1',
+            'list1' => array(
+                'l1' => 'source_l1_1',
+                'list2' => array(
+                    'l1' => 'source_l1_l2_l1',
+                ),
+                'l3' => 'source_l1_3',
+            ),
+            'name2' => 'source2',
+        );'''
+        phpexpected = '''return array(
+            'name1' => 'target1',
+            'list1' => array(
+                'l1' => 'target_l1_1',
+                'list2' => array(
+                    'l1' => 'target_l1_l2_l1',
+                ),
+                'l3' => 'target_l1_3',
+            ),
+            'name2' => 'target2',
+        );\n'''
+        phpfile = self.merge2php(phptemplate, posource)
+        print(phpfile)
+        assert "".join(phpfile) == phpexpected
+
     @mark.xfail(reason="Need to review if we want this behaviour")
     def test_merging_propertyless_template(self):
         """check that when merging with a template with no property values that we copy the template"""

--- a/translate/storage/php.py
+++ b/translate/storage/php.py
@@ -284,7 +284,7 @@ class phpfile(base.TranslationStore):
             # If a nested array ends in the current line, reset prename to its
             # parent array default value by stripping out the last part.
             if inarray and line.find('),') != -1:
-                prename = prename[:prename.find("->")+2]
+                prename = re.sub(r'[^>]+->$', '', prename)
                 continue
 
             # If the current line hosts a define syntax translation.

--- a/translate/storage/php.py
+++ b/translate/storage/php.py
@@ -260,14 +260,16 @@ class phpfile(base.TranslationStore):
             # If an array starts in the current line and is using array syntax
             if (line.lower().replace(" ", "").find('array(') != -1 and
                 line.lower().replace(" ", "").find('array()') == -1):
+                eqpos = line.find('=')
                 # If this is a nested array.
                 if inarray:
-                    prename = prename + line[:line.find('=')].strip() + "->"
+                    prename = prename + line[:eqpos].strip() + "->"
                 else:
                     equaldel = "=>"
                     enddel = ","
                     inarray = True
-                    prename = line[:line.find('=')].strip() + "->"
+                    if eqpos != -1:
+                        prename = prename + line[:eqpos].strip() + "->"
                 continue
 
             # If an array ends in the current line, reset variables to default

--- a/translate/storage/test_php.py
+++ b/translate/storage/test_php.py
@@ -500,10 +500,15 @@ $month_mar = 'Mar';"""
                 'Contacts' => 'Contacts',
                 'Accounts' => 'Accounts',
             ),
+            'tools' => array  (
+                'Pen' => 'Pen',
+                'Brush' => 'Brush',
+                'Pencil' => 'Pencil',
+            ),
             'FAQ' => 'FAQ',
         );'''
         phpfile = self.phpparse(phpsource)
-        assert len(phpfile.units) == 5
+        assert len(phpfile.units) == 8
         phpunit = phpfile.units[0]
         assert phpunit.name == "$app_list_strings->'Mailbox'"
         assert phpunit.source == "Mailbox"
@@ -517,8 +522,52 @@ $month_mar = 'Mar';"""
         assert phpunit.name == "$app_list_strings->'moduleList'->'Accounts'"
         assert phpunit.source == "Accounts"
         phpunit = phpfile.units[4]
+        assert phpunit.name == "$app_list_strings->'tools'->'Pen'"
+        assert phpunit.source == "Pen"
+        phpunit = phpfile.units[5]
+        assert phpunit.name == "$app_list_strings->'tools'->'Brush'"
+        assert phpunit.source == "Brush"
+        phpunit = phpfile.units[6]
+        assert phpunit.name == "$app_list_strings->'tools'->'Pencil'"
+        assert phpunit.source == "Pencil"
+        phpunit = phpfile.units[7]
         assert phpunit.name == "$app_list_strings->'FAQ'"
         assert phpunit.source == "FAQ"
+
+    def test_parsing_unnamed_nested_arrays(self):
+        """parse the unnamed nested array."""
+
+        phpsource = '''return array  (
+            'name1' => 'target1',
+            'list1' => array(
+                'l1' => 'target_l1_1',
+                'l2' => 'target_l1_2',
+                'l3' => 'target_l1_3',
+            ),
+            'list2' => array(
+                'l1' => 'target_l2_1',
+                'l2' => 'target_l2_2',
+                'l3' => 'target_l2_3',
+            ),
+            'name2' => 'target2',
+        );'''
+        phpfile = self.phpparse(phpsource)
+        assert len(phpfile.units) == 8
+        phpunit = phpfile.units[0]
+        assert phpunit.name == "'name1'"
+        assert phpunit.source == "target1"
+        phpunit = phpfile.units[1]
+        assert phpunit.name == "'list1'->'l1'"
+        assert phpunit.source == "target_l1_1"
+        phpunit = phpfile.units[2]
+        assert phpunit.name == "'list1'->'l2'"
+        assert phpunit.source == "target_l1_2"
+        phpunit = phpfile.units[3]
+        assert phpunit.name == "'list1'->'l3'"
+        assert phpunit.source == "target_l1_3"
+        phpunit = phpfile.units[4]
+        assert phpunit.name == "'list2'->'l1'"
+        assert phpunit.source == "target_l2_1"
 
     @mark.xfail(reason="Bug #2647")
     def test_parsing_nested_arrays_with_array_declaration_in_next_line(self):


### PR DESCRIPTION
This PR adds:
- some tests to `TestPhp2PO`;
- allow to use `'app'->'string1'` location instead of `return+array->'app'->'string1'` for the following example:
```php
<?php
return array(
    'app' => array(
		'string1' => 'Source',
    ),
);
```
It fixes inconsistence how we define locations with phpfile parser and po2php converter.
It's worth to add test to cover this inconsistence specifically.