### PR TITLE
Improve resx skeleton

### DIFF
--- a/translate/storage/resx.py
+++ b/translate/storage/resx.py
@@ -187,6 +187,12 @@ class RESXFile(lisa.LISAfile):
   <resheader name="version">
     <value>2.0</value>
   </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
 </root>
 '''
     namespace = ''


### PR DESCRIPTION
It seems that resheader.reader and resheader.writer are necessary for
Visual Studio to properly load the file.