### PR TITLE
Fix Travis failures (install Gettext and fix pytest docs URL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,3 +76,7 @@ notifications:
   email:
     on_failure: always
     on_success: change
+addons:
+  apt:
+    packages:
+      - gettext

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -328,7 +328,7 @@ coverage_write_headline = False
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/2.7', None),
-    'pytest': ('http://pytest.org/latest/', None),
+    'pytest': ('https://docs.pytest.org/en/latest/', None),
     'django': ('http://django.readthedocs.org/en/latest/', None),
     'pootle': ('http://docs.translatehouse.org/projects/pootle/en/latest/', None),
     'virtaal': ('http://docs.translatehouse.org/projects/virtaal/en/latest/', None),


### PR DESCRIPTION
Getext does not seem to be installed automatically on Travis now, but
it's used by tests.