### PR TITLE
Handle gracefully empty location tag in QT ts

### DIFF
--- a/translate/storage/test_ts2.py
+++ b/translate/storage/test_ts2.py
@@ -183,13 +183,24 @@ class TestTSfile(test_base.TestTranslationStore):
         <source>Choose style and palette based on your desktop settings.</source>
         <translation>Stílus és paletta alapú kiválasztása az asztali beállításokban.</translation>
     </message>
+    <message>
+        <location />
+        <source>Choose style and palette based on your desktop settings.</source>
+        <translation>Stílus és paletta alapú kiválasztása az asztali beállításokban.</translation>
+    </message>
+    <message>
+        <source>Choose style and palette based on your desktop settings.</source>
+        <translation>Stílus és paletta alapú kiválasztása az asztali beállításokban.</translation>
+    </message>
 </context>
 </TS>
 '''
         tsfile = ts.tsfile.parsestring(tsstr)
-        assert len(tsfile.units) == 2
+        assert len(tsfile.units) == 4
         assert tsfile.units[0].getlocations() == ['../tools/qtconfig/mainwindow.cpp:+202']
         assert tsfile.units[1].getlocations() == ['+5']
+        assert tsfile.units[2].getlocations() == []
+        assert tsfile.units[3].getlocations() == []
 
     def test_merge_with_fuzzies(self):
         """test that merge with fuzzy works well"""

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -326,7 +326,8 @@ class tsunit(lisa.LISAunit):
                     location += ':' + line
                 else:
                     location = line
-            locations.append(location)
+            if location:
+                locations.append(location)
         return locations
 
     def merge(self, otherunit, overwrite=False, comments=True, authoritative=False):


### PR DESCRIPTION
It's not desirable to return None as a location in case the tag is
completely empty.