### PR TITLE
Avoid resolving external entities while parsing XML

### DIFF
--- a/translate/convert/po2idml.py
+++ b/translate/convert/po2idml.py
@@ -48,7 +48,7 @@ def translate_idml(template, input_file, translatable_files):
         the etrees for each of those translatable files.
         """
         idml_data = open_idml(template)
-        parser = etree.XMLParser(strip_cdata=False)
+        parser = etree.XMLParser(strip_cdata=False, resolve_entities=False)
         return dict((filename, etree.fromstring(data, parser).getroottree())
                     for filename, data in six.iteritems(idml_data))
 

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -261,7 +261,8 @@ class AndroidResourceUnit(base.TranslationUnit):
         if '<' in target:
             try:
                 # Try to handle it as legacy XML
-                newstring = etree.fromstring('<string>%s</string>' % target)
+                parser = etree.XMLParser(strip_cdata=False, resolve_entities=False)
+                newstring = etree.fromstring('<string>%s</string>' % target, parser)
             except Exception:
                 # Fallback to string with XML escaping
                 xmltarget.text = self.escape(target)
@@ -463,7 +464,7 @@ class AndroidResourceFile(lisa.LISAfile):
             xml.seek(0)
             posrc = xml.read()
             xml = posrc
-        parser = etree.XMLParser(strip_cdata=False)
+        parser = etree.XMLParser(strip_cdata=False, resolve_entities=False)
         self.document = etree.fromstring(xml, parser).getroottree()
         self._encoding = self.document.docinfo.encoding
         self.initbody()

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -315,7 +315,7 @@ class LISAfile(base.TranslationStore):
             xml.seek(0)
             posrc = xml.read()
             xml = posrc
-        parser = etree.XMLParser(strip_cdata=False)
+        parser = etree.XMLParser(strip_cdata=False, resolve_entities=False)
         self.document = etree.fromstring(xml, parser).getroottree()
         self.encoding = self.document.docinfo.encoding
         self.initbody()

--- a/translate/storage/placeables/lisa.py
+++ b/translate/storage/placeables/lisa.py
@@ -101,7 +101,8 @@ def xml_to_strelem(dom_node, xml_space="preserve"):
     if dom_node is None:
         return StringElem()
     if isinstance(dom_node, six.string_types):
-        dom_node = etree.fromstring(dom_node)
+        parser = etree.XMLParser(resolve_entities=False)
+        dom_node = etree.fromstring(dom_node, parser)
     normalize_xml_space(dom_node, xml_space, remove_start=True)
     result = StringElem()
     sub = result.sub  # just an optimisation
@@ -213,7 +214,8 @@ def strelem_to_xml(parent_node, elem):
 
 def parse_xliff(pstr):
     try:
-        return xml_to_strelem(etree.fromstring('<source>%s</source>' % (pstr)))
+        parser = etree.XMLParser(resolve_entities=False)
+        return xml_to_strelem(etree.fromstring('<source>%s</source>' % (pstr), parser))
     except Exception as exc:
         raise
         return None

--- a/translate/storage/poxliff.py
+++ b/translate/storage/poxliff.py
@@ -376,7 +376,8 @@ class PoXliffFile(xliff.xlifffile, poheader.poheader):
             xml.seek(0)
             xmlsrc = xml.read()
             xml = xmlsrc
-        self.document = etree.fromstring(xml).getroottree()
+        parser = etree.XMLParser(resolve_entities=False)
+        self.document = etree.fromstring(xml, parser).getroottree()
         self.initbody()
         root_node = self.document.getroot()
         assert root_node.tag == self.namespaced(self.rootNode)

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -416,3 +416,26 @@ class TestXLIFFfile(test_base.TestTranslationStore):
                  </trans-unit>'''
         xlifffile = xliff.xlifffile.parsestring(xlfsource)
         assert xlifffile.units[0].istranslatable()
+
+    def test_entities(self):
+        xlfsource = '''<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE foo [ <!ELEMENT foo ANY > <!ENTITY xxe SYSTEM "file:///etc/passwd" >]>
+<xliff version="1.1" xmlns="urn:oasis:names:tc:xliff:document:1.1">
+        <file original="doc.txt" source-language="en-US">
+                <body>
+                    <trans-unit id="1" xml:space="preserve" translate="yes">
+                        <source>&xxe;</source>
+                        <target/>
+                    </trans-unit>
+                    <trans-unit id="2" xml:space="preserve" translate="yes">
+                        <source>&amp;</source>
+                        <target/>
+                    </trans-unit>
+                </body>
+        </file>
+</xliff>'''
+        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        assert xlifffile.units[0].istranslatable()
+        assert xlifffile.units[0].source == ''
+        assert xlifffile.units[1].istranslatable()
+        assert xlifffile.units[1].source == '&'


### PR DESCRIPTION
The lxml allows defining external entities by default and that can lead
to including content of external files using them. This can be really
problematic for services dealing with user uploaded files such as Pootle
or Weblate.

This is least intrusive fix, but maybe it would be better to use [defusedxml](https://pypi.python.org/pypi/defusedxml) instead of lxml directly.

You can find more information about this kind of vulnerability here: https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing