### PR TITLE
Add Kabyle language

### DIFF
--- a/translate/lang/data.py
+++ b/translate/lang/data.py
@@ -102,6 +102,7 @@ languages = {
     'jbo': ('Lojban', 1, '0'),
     'jv': ('Javanese', 2, '(n != 1)'),
     'ka': ('Georgian', 1, '0'),
+    'kab': ('Kabyle', 1, '(n > 1)'),
     'kk': ('Kazakh', 2, 'n != 1'),
     'kl': ('Greenlandic', 2, '(n != 1)'),
     'km': ('Central Khmer', 1, '0'),


### PR DESCRIPTION
Adding kabyle entry in the languages dictionary.
Please note that Kabyle hase two codes on CLDR: kab and kab_DZ
We are working on kab code in the CLDR project version 32 (now on submission).
The two codes are also considered on Mozilla Firefox I localized. The priority is for kab.
We used kab as is suggested on iso 639-2 for language codes.
______
This update is for wablate. We are going to localize OpenSuse, so we need this change.