### PR TITLE
Improve country name handling in lang translations

### DIFF
--- a/translate/lang/data.py
+++ b/translate/lang/data.py
@@ -434,10 +434,12 @@ def tr_lang(langcode=None):
         match = dialect_name_re.match(name)
         if match:
             language, country = match.groups()
-            return u"%s (%s)" % (_fix_language_name(langfunc(language)),
-                                 countryfunc(country))
-        else:
-            return _fix_language_name(langfunc(name))
+            if country != "macrolanguage":
+                return (
+                    u"%s (%s)"
+                    % (_fix_language_name(langfunc(language)),
+                       countryfunc(country)))
+        return _fix_language_name(langfunc(name))
 
     return handlelanguage
 


### PR DESCRIPTION
this prevents languages with dialects from showing as `langname (macrolanguage)`

there are other cases where the part of the name in brackets doesnt refer to a country which we might also want to exclude in this way