### PR TITLE
Checks: remove bidi markers before puncspacing test

### DIFF
--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -862,7 +862,27 @@ class StandardChecker(TranslationChecker):
             return True
 
         str2 = self.filteraccelerators(self.filtervariables(str2))
+        # Substitute: nbsp
         str2 = str2.replace(u"\u00a0", u" ")
+        # Strip: Bidi markers and ZW* chars
+        str2 = str2.translate(
+            {ord(c): None for c in (
+                # Bidi markers
+                u"\u200e",  # LRM
+                u"\u200f",  # RLM
+                u"\u202b",  # RLE
+                u"\u202a",  # LRE
+                u"\u202e",  # RLO
+                u"\u202d",  # LRO
+                u"\u202c",  # PDF
+                u"\u2069",  # PDI
+                u"\u2068",  # FSI
+                u"\u2067",  # RLI
+                u"\u2066",  # LRI
+                # ZW*
+                u"\u200d",  # ZWJ
+                u"\u200c",  # ZWNJ
+            )})
 
         for puncchar in self.config.punctuation:
             plaincount1 = str1.count(puncchar)

--- a/translate/filters/test_checks.py
+++ b/translate/filters/test_checks.py
@@ -667,6 +667,25 @@ def test_puncspacing():
     assert passes(frchecker.puncspacing, u"Do \"this\"", u"Do «\u00a0this\u00a0»")
     assert fails(frchecker.puncspacing, "Do \"this\"", "Do «this»")
 
+    # Handle Bidi markers as non-characters
+    hechecker = checks.StandardChecker(checks.CheckerConfig(targetlanguage="he"))
+    assert passes(hechecker.puncspacing, "hi. there", u"שלום.\u200f לך")  # RLM
+    assert passes(hechecker.puncspacing, "hi. there", u"שלום.\u200e לך")  # LRM
+    assert passes(hechecker.puncspacing, "hi. there", u"שלום.\u202b לך")  # RLE
+    assert passes(hechecker.puncspacing, "hi. there", u"שלום.\u202a לך")  # LRE
+    assert passes(hechecker.puncspacing, "hi. there", u"שלום.\u202e לך")  # RLO
+    assert passes(hechecker.puncspacing, "hi. there", u"שלום.\u202d לך")  # LRO
+    assert passes(hechecker.puncspacing, "hi. there", u"שלום.\u202c לך")  # PDF
+    assert passes(hechecker.puncspacing, "hi. there", u"שלום.\u2069 לך")  # PDI
+    assert passes(hechecker.puncspacing, "hi. there", u"שלום.\u2068 לך")  # FSI
+    assert passes(hechecker.puncspacing, "hi. there", u"שלום.\u2067 לך")  # RLI
+    assert passes(hechecker.puncspacing, "hi. there", u"שלום.\u2066 לך")  # LRI
+
+    # ZWJ and ZWNJ handling as non-characters
+    archecker = checks.StandardChecker(checks.CheckerConfig(targetlanguage="ar"))
+    assert passes(archecker.puncspacing, "hi. there", u"السلام.\u200d عليكم")  # ZWJ
+    assert passes(archecker.puncspacing, "hi. there", u"السلام.\u200c عليكم")  # ZWNJ
+
 
 def test_purepunc():
     """tests messages containing only punctuation"""


### PR DESCRIPTION
Strip out directionality markers before performing the puncspacing test.

Fixes #3635