### PR TITLE
Use common_name for lang/country if available

### DIFF
--- a/translate/lang/data.py
+++ b/translate/lang/data.py
@@ -393,8 +393,12 @@ def get_language_iso_name(language_code):
     """Return language ISO name."""
     try:
         if len(language_code) == 2:
-            return pycountry.languages.get(alpha_2=language_code).name
-        return pycountry.languages.get(alpha_3=language_code).name
+            language = pycountry.languages.get(alpha_2=language_code)
+        else:
+            language = pycountry.languages.get(alpha_3=language_code)
+        if hasattr(language, 'common_name'):
+            return language.common_name
+        return language.name
     except KeyError:
         return u""
 

--- a/translate/lang/data.py
+++ b/translate/lang/data.py
@@ -379,8 +379,12 @@ def get_country_iso_name(country_code):
     country_code = country_code.upper()
     try:
         if len(country_code) == 2:
-            return pycountry.countries.get(alpha_2=country_code).name
-        return pycountry.countries.get(alpha_3=country_code).name
+            country = pycountry.countries.get(alpha_2=country_code)
+        else:
+            country = pycountry.countries.get(alpha_3=country_code)
+        if hasattr(country, 'common_name'):
+            return country.common_name
+        return country.name
     except KeyError:
         return u""
 

--- a/translate/lang/test_data.py
+++ b/translate/lang/test_data.py
@@ -77,6 +77,10 @@ def test_country_iso_name():
     assert data.get_country_iso_name("zzz") == u''
     assert data.get_country_iso_name("zzzz") == u''
 
+    # Use common name if available
+    assert data.get_country_iso_name("TW") == u'Taiwan'
+    assert data.get_country_iso_name("TW") != u'Taiwan, Province of China'
+
 
 def test_language_iso_name():
     """Test language ISO names."""

--- a/translate/lang/test_data.py
+++ b/translate/lang/test_data.py
@@ -92,3 +92,7 @@ def test_language_iso_name():
     assert data.get_language_iso_name("z") == u''
     assert data.get_language_iso_name("zzz") == u''
     assert data.get_language_iso_name("zzzz") == u''
+
+    # Use common name if available
+    assert data.get_language_iso_name("bn") == u'Bangla'
+    assert data.get_language_iso_name("bn") != u'Bengali'

--- a/translate/lang/test_data.py
+++ b/translate/lang/test_data.py
@@ -85,6 +85,7 @@ def test_country_iso_name():
 def test_language_iso_name():
     """Test language ISO names."""
     assert data.get_language_iso_name("af") == u'Afrikaans'
+    assert data.get_language_iso_name("afr") == u'Afrikaans'
     assert data.get_language_iso_name("cak") == u'Kaqchikel'
     assert data.get_language_iso_name("en") == u'English'
     assert data.get_language_iso_name("pt") == u'Portuguese'


### PR DESCRIPTION
Ensure we get 'Taiwan' not 'Taiwan, Province of China'.  Which impacts which translations we'll pick up.