### PR TITLE
Avoid escaping some chars in po files

### DIFF
--- a/translate/storage/pocommon.py
+++ b/translate/storage/pocommon.py
@@ -42,7 +42,7 @@ def extract_msgid_comment(text):
 
 def quote_plus(text):
     """Quote the query fragment of a URL; replacing ' ' with '+'"""
-    return parse.quote_plus(text.encode("utf-8"))
+    return parse.quote_plus(text.encode("utf-8"), safe='()/:,')
 
 
 def unquote_plus(text):

--- a/translate/storage/test_pocommon.py
+++ b/translate/storage/test_pocommon.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 from translate.storage import pocommon
 
@@ -10,6 +11,10 @@ def test_roundtrip_quote_plus():
         assert quote == quoted
         unquote = pocommon.unquote_plus(quoted)
         assert unquote == text
-    roundtrip_quote_plus(u"abc", u"abc")
-    roundtrip_quote_plus(u"key space", u"key+space")
-    roundtrip_quote_plus(u"key ḓey", u"key+%E1%B8%93ey")
+    roundtrip_quote_plus("abc", "abc")
+    roundtrip_quote_plus("key space", "key+space")
+    roundtrip_quote_plus("key ḓey", "key+%E1%B8%93ey")
+    roundtrip_quote_plus(
+        "path/file.c(2):3,path space/file.h:4",
+        "path/file.c(2):3,path+space/file.h:4"
+    )


### PR DESCRIPTION
These really do not have to be escaped in the po file, so keep them as
they are.

The list probably could be extended, but this is what I've spotted while reviewing https://github.com/translate/translate/pull/3673