### PR TITLE
Correctly set filenode when adding units to xliff store

### DIFF
--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -797,6 +797,14 @@ class xlifffile(lisa.LISAfile):
         bodynode = etree.SubElement(filenode, self.namespaced("body"))
         return bodynode
 
+    def addunit(self, unit, new=True):
+        parts = unit.getid().split("\x04")
+        if len(parts) > 1:
+            filename, unitid = parts[0], "\x04".join(parts[1:])
+            self.switchfile(filename, createifmissing=True)
+            unit.setid(unitid)
+        super(xlifffile, self).addunit(unit, new=new)
+
     def addsourceunit(self, source, filename="NoName", createifmissing=False):
         """adds the given trans-unit to the last used body node if the filename
         has changed it uses the slow method instead (will create the nodes


### PR DESCRIPTION
currently ttk creates a `unit.getid()` with filename + `\x04` + unitid

but when you addunit with a unitid as above it ignores the filename part and puts all units into a `NoName` filenode

this PR corrects that so that xliff files more closely roundtrip