### PR TITLE
Fix local, editable installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -147,8 +147,7 @@ or, running the tools from the source directory:
 
 .. code-block:: console
 
-   $ ./setuppath # Only needed the first time
-   $ . setpath  # Do this once for a session
+   $ sudo pip3 install -e .
 
 
 .. _installation#verify_installed_version:


### PR DESCRIPTION
The current instructions are wrong, as the referenced file does not seem to exist.

The provided solution is a more modern approach, I believe, and works both inside and outside a virtual environment.