### PR TITLE
Cleanup: Consistenly use pytest.raises as context manager

### DIFF
--- a/translate/convert/test_convert.py
+++ b/translate/convert/test_convert.py
@@ -103,7 +103,8 @@ class TestConvertCommand(object):
         helpfile = self.open_testfile("help.txt", "w")
         sys.stdout = helpfile
         try:
-            pytest.raises(SystemExit, self.run_command, help=True)
+            with pytest.raises(SystemExit):
+                self.run_command(help=True)
         finally:
             sys.stdout = stdout
         helpfile.close()

--- a/translate/convert/test_po2dtd.py
+++ b/translate/convert/test_po2dtd.py
@@ -111,7 +111,8 @@ msgstr "Dimpled Ring"
         simpledtd = '''<!ENTITY simple.label "Simple String">
 <!ENTITY simple.accesskey "S">'''
         warnings.simplefilter("error")
-        assert pytest.raises(Warning, self.merge2dtd, simpledtd, simplepo)
+        with pytest.raises(Warning):
+            self.merge2dtd(simpledtd, simplepo)
 
     def test_accesskeycase(self):
         """tests that access keys come out with the same case as the original, regardless"""

--- a/translate/lang/test_identify.py
+++ b/translate/lang/test_identify.py
@@ -179,5 +179,7 @@ class TestLanguageIdentifier(object):
 
     def test_bad_init_data(self):
         """Test __init__ with bad conf files and data dirs"""
-        assert raises(ValueError, LanguageIdentifier, model_dir='missing')
-        assert raises(ValueError, LanguageIdentifier, conf_file='missing')
+        with raises(ValueError):
+            LanguageIdentifier(model_dir='missing')
+        with raises(ValueError):
+            LanguageIdentifier(conf_file='missing')

--- a/translate/misc/test_multistring.py
+++ b/translate/misc/test_multistring.py
@@ -21,7 +21,8 @@ class TestMultistring:
         assert s2 == "test"
         assert s2.strings == ["test", u"mé"]
         assert s2 != s1
-        pytest.raises(ValueError, t, [])
+        with pytest.raises(ValueError):
+            t([])
 
     def test_repr(self):
         t = multistring.multistring

--- a/translate/storage/test_cpo.py
+++ b/translate/storage/test_cpo.py
@@ -75,7 +75,8 @@ class TestCPOUnit(test_po.TestPOUnit):
         unit.addnote("Thank you", origin="translator")
         assert unit.getnotes("translator") == "Which meaning of file?\nThank you"
         assert unit.getnotes() == "Which meaning of file?\nThank you\nVerb"
-        assert raises(ValueError, unit.getnotes, "devteam")
+        with raises(ValueError):
+            unit.getnotes("devteam")
 
     def test_notes_withcomments(self):
         """tests that when we add notes that look like comments that we treat them properly"""

--- a/translate/storage/test_html.py
+++ b/translate/storage/test_html.py
@@ -62,11 +62,14 @@ class TestHTMLParsing:
     h = html.htmlfile
 
     def test_mismatched_tags(self):
-        assert raises(base.ParseError, self.h.parsestring, "<h3><p>Some text<p></h3>")
+        with raises(base.ParseError):
+            self.h.parsestring("<h3><p>Some text<p></h3>")
         # First <tr> is not closed
-        assert raises(base.ParseError, self.h.parsestring, "<html><head></head><body><table><tr><th>Heading One</th><th>Heading Two</th><tr><td>One</td><td>Two</td></tr></table></body></html>")
+        with raises(base.ParseError):
+            self.h.parsestring("<html><head></head><body><table><tr><th>Heading One</th><th>Heading Two</th><tr><td>One</td><td>Two</td></tr></table></body></html>")
         # <tr> is not closed in <thead>
-        assert raises(base.ParseError, self.h.parsestring, """<table summary="This is the summary"><caption>A caption</caption><thead><tr><th abbr="Head 1">Heading One</th><th>Heading Two</th></thead><tfoot><tr><td>Foot One</td><td>Foot Two</td></tr></tfoot><tbody><tr><td>One</td><td>Two</td></tr></tbody></table>""")
+        with raises(base.ParseError):
+            self.h.parsestring("""<table summary="This is the summary"><caption>A caption</caption><thead><tr><th abbr="Head 1">Heading One</th><th>Heading Two</th></thead><tfoot><tr><td>Foot One</td><td>Foot Two</td></tr></tfoot><tbody><tr><td>One</td><td>Two</td></tr></tbody></table>""")
 
     def test_self_closing_tags(self):
         h = html.htmlfile()

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -120,7 +120,8 @@ class TestPYPOUnit(test_po.TestPOUnit):
         assert unit.getnotes("developer") == "Verb"
         assert unit.getnotes("translator") == "Which meaning of file?\nThank you"
         assert unit.getnotes() == "Which meaning of file?\nThank you\nVerb"
-        assert raises(ValueError, unit.getnotes, "devteam")
+        with raises(ValueError):
+            unit.getnotes("devteam")
 
     def test_notes_withcomments(self):
         """tests that when we add notes that look like comments that we treat them properly"""

--- a/translate/storage/test_qm.py
+++ b/translate/storage/test_qm.py
@@ -19,20 +19,20 @@ class TestQtFile(test_base.TestTranslationStore):
 
     def test_save(self):
         # QM does not implement saving
-        assert pytest.raises(Exception, self.StoreClass.savefile,
-                             self.StoreClass())
+        with pytest.raises(Exception):
+            self.StoreClass.savefile(self.StoreClass())
 
     def test_files(self):
         # QM does not implement saving
-        assert pytest.raises(Exception, self.StoreClass.savefile,
-                             self.StoreClass())
+        with pytest.raises(Exception):
+            self.StoreClass.savefile(self.StoreClass())
 
     def test_nonascii(self):
         # QM does not implement serialising
-        assert pytest.raises(Exception, self.StoreClass.serialize,
-                             self.StoreClass())
+        with pytest.raises(Exception):
+            self.StoreClass.serialize(self.StoreClass())
 
     def test_add(self):
         # QM does not implement serialising
-        assert pytest.raises(Exception, self.StoreClass.serialize,
-                             self.StoreClass())
+        with pytest.raises(Exception):
+            self.StoreClass.serialize(self.StoreClass())

--- a/translate/tools/test_pomerge.py
+++ b/translate/tools/test_pomerge.py
@@ -18,7 +18,8 @@ def test_str2bool():
     assert not pomerge.str2bool("no")
     assert not pomerge.str2bool("false")
     assert not pomerge.str2bool("0")
-    pytest.raises(ValueError, pomerge.str2bool, "2")
+    with pytest.raises(ValueError):
+        pomerge.str2bool("2")
 
 
 class TestPOMerge:
@@ -83,10 +84,10 @@ class TestPOMerge:
         templatefile = wStringIO.StringIO("")
         inputfile = wStringIO.StringIO("")
         outputfile = wStringIO.StringIO()
-        pytest.raises(ValueError, pomerge.mergestore, inputfile, outputfile,
-                      templatefile, mergeblanks="yay")
-        pytest.raises(ValueError, pomerge.mergestore, inputfile, outputfile,
-                      templatefile, mergecomments="yay")
+        with pytest.raises(ValueError):
+            pomerge.mergestore(inputfile, outputfile, templatefile, mergeblanks="yay")
+        with pytest.raises(ValueError):
+            pomerge.mergestore(inputfile, outputfile, templatefile, mergecomments="yay")
 
     def test_simplemerge(self):
         """checks that a simple po entry merges OK"""


### PR DESCRIPTION
The code is currently pretty inconsistent as pointed out in https://github.com/translate/translate/pull/3696#discussion_r152043518