### PR TITLE
Get only name attribute when it exists

### DIFF
--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -743,8 +743,9 @@ class TranslationStore(object):
         """
         fileobj = getattr(self, "fileobj", None)
         if fileobj:
-            filename = getattr(fileobj, "name",
-                               getattr(fileobj, "filename", None))
+            filename = getattr(fileobj, "name", None)
+            if not filename:
+                filename = getattr(fileobj, "filename", None)
             if filename:
                 self.filename = filename
 


### PR DESCRIPTION
This avoids raising 'DeprecationWarning: use the name attribute' on some
files.