### PR TITLE
Make DeprecationWarning a failure in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
   - if [[ ! $META ]]; then python -m compileall -q -f .; fi     # Compile all the files
   - if [[ ! $META ]]; then python setup.py --quiet build; fi
   - if [[ ! $META ]]; then pip install .; fi
-  - if [[ ! $META ]]; then py.test --cov=. -r EfsxX; fi
+  - if [[ ! $META ]]; then py.test --cov=. -r EfsxX -W error::DeprecationWarning ; fi
   - if [[ ! $META ]]; then make test-functional; fi
   - if [[ $META ]]; then pycodestyle; fi
   - if [[ $META ]]; then pydocstyle; fi

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -186,7 +186,8 @@ class htmlfile(html_parser.HTMLParser, base.TranslationStore):
         else:
             self.callback = callback
         self.includeuntaggeddata = includeuntaggeddata
-        html_parser.HTMLParser.__init__(self)
+        htmlargs = {'convert_charrefs': True} if six.PY34 else {}
+        html_parser.HTMLParser.__init__(self, **htmlargs)
 
         if inputfile is not None:
             htmlsrc = inputfile.read()

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -815,7 +815,7 @@ class pofile(pocommon.pofile):
                     if not thepo.msgctxt == id_dict[id].msgctxt:
                         uniqueunits.append(thepo)
                     else:
-                        logger.warn(
+                        logger.warning(
                             "Duplicate unit found with msgctx of '%s' and source '%s'",
                             thepo.msgctxt,
                             thepo.source)


### PR DESCRIPTION
I think this would be useful to avoid using deprecated interfaces.

Depends on #3711 and #3710