### PR TITLE
pypo: Add tests for parsing files with different newlines

### DIFF
--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -369,3 +369,17 @@ msgstr[1] "toetse"
         store.units[0].settarget('Hello ' * 100)
         # Should contain additional newlines now
         assert bytes(store) != posource
+
+    def test_unix_newlines(self):
+        """checks that unix newlines are properly parsed"""
+        posource = b'\nmsgid "test me"\nmsgstr ""\n'
+        pofile = self.poparse(posource)
+        assert len(pofile.units) == 1
+        assert pofile.units[0].source == 'test me'
+
+    def test_dos_newlines(self):
+        """checks that dos newlines are properly parsed"""
+        posource = b'\r\nmsgid "test me"\r\nmsgstr ""\r\n'
+        pofile = self.poparse(posource)
+        assert len(pofile.units) == 1
+        assert pofile.units[0].source == 'test me'


### PR DESCRIPTION
Note that this currently *is* broken on Windows - if the file has unix newlines, it won't get properly parsed, see https://github.com/translate/translate/issues/3751