### PR TITLE
Stop testing with changing Africa/Windhoek TZ

### DIFF
--- a/translate/storage/test_poheader.py
+++ b/translate/storage/test_poheader.py
@@ -122,13 +122,6 @@ def test_timezones():
         # Typically "+0200"
         assert poheader.tzstring() == time.strftime("%z")
 
-        os.environ['TZ'] = 'Africa/Windhoek'
-        time.tzset()
-        assert time.timezone == -3600
-        # Typically "+0100"
-        # For some reason python's %z doesn't know about Windhoek DST
-        #assert poheader.tzstring() == time.strftime("%z")
-
         os.environ['TZ'] = 'UTC'
         time.tzset()
         assert time.timezone == 0


### PR DESCRIPTION
The Africa/Windhoek TZ is changing; Namibia changes its TZ definitions in 2018
and so this test fails when run after 2018-04-01.

From tzdata Release 2017c - 2017-10-20 14:49:34 -0700:

    Namibia will switch from +01 with DST to +02 all year on
    2017-09-03 at 02:00.  This affects UT offsets starting 2018-04-01
    at 02:00.  (Thanks to Steffen Thorsen.)

This particular test isn't hitting code paths not addressed by other tests
so removing it is simplest.

Closes: https://github.com/translate/translate/issues/3754