### PR TITLE
Fix installation instructions for Windows

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -109,7 +109,7 @@ virtualenvs.
 4. `mkvirtualenv ttk` where "ttk" is the name for the new virtualenv
 5. `pip install translate-toolkit` to install latest stable or `pip install
    --pre translate-toolkit` to try a pre-release
-6. `pip install "lxml>=3.5"` to be able to use XLIFF or other XML formats
+6. `pip install lxml>=3.5` to be able to use XLIFF or other XML formats
 7. `po2prop --version` to double check you have the right version
 
 Next times you need to use Translate Toolkit just remember to:


### PR DESCRIPTION
The > does not have to be quoted on Windows.

Fixes #3707