### PR TITLE
Avoid running sphinx in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ docs:
 	git submodule update --init
 	# The following creates the HTML docs.
 	# NOTE: cd and make must be in the same line.
-	cd ${DOCS_DIR}; make SPHINXOPTS="-T -W -q -j 4" html ${TAIL}
+	cd ${DOCS_DIR}; make SPHINXOPTS="-T -W -q" html ${TAIL}
 
 docs-review: docs
 	python -mwebbrowser file://$(shell pwd)/${DOCS_DIR}/_build/html/index.html


### PR DESCRIPTION
This hides real error in some cases making it harder to figure out real
cause of build failure.

Right now the build is failing because of missing virtaal documentation
which is linked through intersphinx, see
https://github.com/translate/virtaal/issues/3277