### PR TITLE
Use splitlines instead of implicit iterating on file

### DIFF
--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -586,7 +586,7 @@ class pounit(pocommon.pounit):
         return len(self.msgid_plural) > 0
 
     def parse(self, src):
-        return poparser.parse_unit(poparser.ParseState(BytesIO(src), pounit), self)
+        return poparser.parse_unit(poparser.ParseState(src.splitlines(True), pounit), self)
 
     def _getmsgpartstr(self, partname, partlines, partcomments=""):
         if isinstance(partlines, dict):
@@ -772,8 +772,9 @@ class pofile(pocommon.pofile):
             self.filename = input.name
         elif not getattr(self, 'filename', ''):
             self.filename = ''
-        if isinstance(input, bytes):
-            input = BytesIO(input)
+        if not isinstance(input, bytes):
+            input = input.read()
+        input = iter(input.splitlines(True))
         # clear units to get rid of automatically generated headers before parsing
         self.units = []
         poparser.parse_units(poparser.ParseState(input, self.create_unit), self)

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -383,3 +383,10 @@ msgstr[1] "toetse"
         pofile = self.poparse(posource)
         assert len(pofile.units) == 1
         assert pofile.units[0].source == 'test me'
+
+    def test_mac_newlines(self):
+        """checks that mac newlines are properly parsed"""
+        posource = b'\rmsgid "test me"\rmsgstr ""\r'
+        pofile = self.poparse(posource)
+        assert len(pofile.units) == 1
+        assert pofile.units[0].source == 'test me'


### PR DESCRIPTION
When the file is open in binary mode (what usually is), the implicit
iterator works only on platform native newlines. For example that means
that parser would fail to parse po files with unix newlines on Windows.

On the other side the splitlines uses universal newlines handling
correctly any newlines on any platform.

Fixes #3751