### PR TITLE
RFC: Remove USECPO=1 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
     - USECPO=0 MINVERSION=1 META=
     - USECPO=0 MINVERSION= META=
     - USECPO=0 MINVERSION= META=1
-    - USECPO=1 MINVERSION= META=
     #- USECPO=2
 matrix:
   exclude:
@@ -40,17 +39,6 @@ matrix:
       env: USECPO=0 MINVERSION=1 META=1
     - python: 3.6
       env: USECPO=0 MINVERSION= META=1
-  allow_failures:
-    - python: 2.7
-      env: USECPO=1 MINVERSION= META=
-    - python: 3.3
-      env: USECPO=1 MINVERSION= META=
-    - python: 3.4
-      env: USECPO=1 MINVERSION= META=
-    - python: 3.5
-      env: USECPO=1 MINVERSION= META=
-    - python: 3.6
-      env: USECPO=1 MINVERSION= META=
 #before_install:
 #  # Ubuntu used by Travis only supports python3-aeidon.
 #  - sudo apt-get install python-aeidon


### PR DESCRIPTION
These are failing and just wasting build resources.

AFAIK nobody is working on making this work, they can be easily added back once somebody does.