### PR TITLE
Clean docs generated from storage/factory.py functions

### DIFF
--- a/translate/convert/pot2po.py
+++ b/translate/convert/pot2po.py
@@ -35,7 +35,7 @@ from translate.tools import pretranslate
 
 def convertpot(input_file, output_file, template_file, tm=None,
                min_similarity=75, fuzzymatching=True, classes=None,
-               classes_str=factory.classes_str, **kwargs):
+               classes_str=None, **kwargs):
     """Main conversion function."""
     input_store = factory.getobject(input_file, classes=classes,
                                     classes_str=classes_str)

--- a/translate/storage/factory.py
+++ b/translate/storage/factory.py
@@ -31,7 +31,7 @@ decompressclass = {
 }
 
 
-classes_str = {
+_classes_str = {
     "csv": ("csvl10n", "csvfile"),
     "tab": ("omegat", "OmegaTFileTab"), "utf8": ("omegat", "OmegaTFile"),
     "po": ("po", "pofile"), "pot": ("po", "pofile"),
@@ -87,7 +87,7 @@ def _examine_txt(storefile):
     return pseudo_extension
 
 
-hiddenclasses = {"txt": _examine_txt}
+_hiddenclasses = {"txt": _examine_txt}
 
 
 def _guessextention(storefile):
@@ -135,12 +135,16 @@ def _getname(storefile):
 
 
 def getclass(storefile, localfiletype=None, ignore=None, classes=None,
-             classes_str=classes_str, hiddenclasses=hiddenclasses):
+             classes_str=None, hiddenclasses=None):
     """Factory that returns the applicable class for the type of file
     presented.  Specify ignore to ignore some part at the back of the name
     (like .gz).
     """
     storefilename = _getname(storefile)
+    if classes_str is None:
+        classes_str = _classes_str
+    if hiddenclasses is None:
+        hiddenclasses = _hiddenclasses
     if ignore and storefilename.endswith(ignore):
         storefilename = storefilename[:-len(ignore)]
     ext = localfiletype
@@ -175,7 +179,7 @@ def getclass(storefile, localfiletype=None, ignore=None, classes=None,
 
 
 def getobject(storefile, localfiletype=None, ignore=None, classes=None,
-              classes_str=classes_str, hiddenclasses=hiddenclasses):
+              classes_str=None, hiddenclasses=None):
     """Factory that returns a usable object for the type of file presented.
 
     :type storefile: file or str
@@ -183,7 +187,10 @@ def getobject(storefile, localfiletype=None, ignore=None, classes=None,
 
     Specify ignore to ignore some part at the back of the name (like .gz).
     """
-
+    if classes_str is None:
+        classes_str = _classes_str
+    if hiddenclasses is None:
+        hiddenclasses = _hiddenclasses
     if isinstance(storefile, six.string_types):
         if os.path.isdir(storefile) or storefile.endswith(os.path.sep):
             from translate.storage import directory


### PR DESCRIPTION
Including the `classes_str` in the function signature of the factory means that sphinx includes the entire dict in each entry which is then hard to read. The inclusion of the `_examine_txt` function also results in a memory address being output by sphinx. The memory address is both ugly and non-reproducible so that the docs change slightly each time they are built.

In the [Reproducible Builds](https://reproducible-builds.org/) project, work is being done to help ensure that software can be reproduced, bit-for-bit as part of a chain of trust between author and user. Sphinx itself has already received numerous patches so that its output is now deterministic and with this change applied, `translate-toolkit` becomes reproducible too.