### PR TITLE
JSON: Add support for customizing json.dumps args

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -142,6 +142,11 @@ class JsonFile(base.TranslationStore):
         self._filter = filter
         self.filename = ''
         self._file = u''
+        self.dump_args = {
+            'separators': (',', ': '),
+            'indent': 4,
+            'ensure_ascii': False,
+        }
         if inputfile is not None:
             self.parse(inputfile)
 
@@ -155,8 +160,7 @@ class JsonFile(base.TranslationStore):
         units = OrderedDict()
         for unit in self.unit_iter():
             merge(units, unit.getvalue())
-        out.write(json.dumps(units, separators=(',', ': '),
-                             indent=4, ensure_ascii=False).encode(self.encoding))
+        out.write(json.dumps(units, **self.dump_args).encode(self.encoding))
         out.write(b'\n')
 
     def _extract_translatables(self, data, stop=None, prev="", name_node=None,

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -64,6 +64,25 @@ class TestJSONResourceStore(test_monolingual.TestMonolingualStore):
         assert store.units[0].source == 'foo'
         assert store.units[2].source == 'baz'
 
+    def test_args(self):
+        store = self.StoreClass()
+        store.parse('''{
+    "foo": "foo",
+    "bar": "bar",
+    "baz": "baz"
+}''')
+        store.dump_args['sort_keys'] = True
+
+        out = BytesIO()
+        store.serialize(out)
+
+        assert out.getvalue() == b'''{
+    "bar": "bar",
+    "baz": "baz",
+    "foo": "foo"
+}
+'''
+
 
 class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):
     StoreClass = jsonl10n.JsonNestedFile


### PR DESCRIPTION
This can be used for example to force different indentation or keys
sorting.