### PR TITLE
pypo: Consitent wrapping on / with Gettext

### DIFF
--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -76,6 +76,7 @@ wrapper = textwrap.TextWrapper(
     drop_whitespace=False)
 wrapper.wordsep_re = re.compile(
     r'(\s+|'                                  # any whitespace
+    r'[a-z0-9A-Z_-]+/|'                       # nicely split long URLs
     r'\w*\\.|'                                # any escape should not be split
     r'[\w\!\'\&\.\,\?]+\s+|'                  # space should go with a word
     r'[^\s\w]*\w+[a-zA-Z]-(?=\w+[a-zA-Z])|'   # hyphenated words

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -181,6 +181,17 @@ msgstr ""
         print(str(unit))
         assert str(unit) == expected
 
+    def test_wrap_on_slash(self):
+        """test that we wrap on /"""
+        string = "1/3/5/7/N/" * 11
+        expected = '''msgid ""
+"1/3/5/7/N/1/3/5/7/N/1/3/5/7/N/1/3/5/7/N/1/3/5/7/N/1/3/5/7/N/1/3/5/7/N/1/3/5/"
+"7/N/1/3/5/7/N/1/3/5/7/N/1/3/5/7/N/"
+msgstr ""
+'''
+        unit = self.UnitClass(string)
+        assert str(unit) == expected
+
     def test_spacing_max_line(self):
         """Test that the spacing of text is done the same as msgcat."""
         idstring = "Creates a new document using an existing template iiiiiiiiiiiiiiiiiiiiiii or "


### PR DESCRIPTION
Gettext seems to prefer wrap lines after /, while translate-toolkit doesn't

This is visible especially when having URLs in the string, example can be seen here:

```diff
--- a/weblate/langdata/locale/cs/LC_MESSAGES/django.po
+++ b/weblate/langdata/locale/cs/LC_MESSAGES/django.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Weblate 2.20\n"
 "Report-Msgid-Bugs-To: weblate@lists.cihar.com\n"
-"POT-Creation-Date: 2018-02-23 10:36+0000\n"
+"POT-Creation-Date: 2018-03-05 15:49+0000\n"
 "PO-Revision-Date: 2018-02-23 11:35+0000\n"
 "Last-Translator: Pavel Borecki <@gmail.com>\n"
-"Language-Team: Czech "
-"<https://hosted.weblate.org/projects/weblate/languages/cs/>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/weblate/languages/"
+"cs/>\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
```

See also https://github.com/WeblateOrg/weblate/commit/0e7b64f18d1ed4a58fcca2ca84985c1fd35fab9b#diff-bb7f8052f00249a6555b1557586a105b