### PR TITLE
Windows CI using AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27"
+
+install:
+  # We need wheel installed to build wheels
+  - "%PYTHON%\\python.exe -m pip install wheel"
+  # lxml 3.6.0 has binary release for Windows
+  - "%PYTHON%\\python.exe -m pip install lxml==3.6.0"
+  - "%PYTHON%\\python.exe -m pip install -r requirements\\dev.txt"
+  - "%PYTHON%\\python.exe -m pip freeze"
+
+build: off
+
+test_script:
+  - "%PYTHON%\\python.exe -m compileall -q -f ."
+  - "%PYTHON%\\python.exe setup.py --quiet build"
+  - "%PYTHON%\\python.exe -m pip install ."
+  - "%PYTHON%\\python.exe -m pytest -r EfsxX"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,29 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36-x64"
 
 install:
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   # We need wheel installed to build wheels
-  - "%PYTHON%\\python.exe -m pip install wheel"
-  # lxml 3.6.0 has binary release for Windows
-  - "%PYTHON%\\python.exe -m pip install lxml==3.6.0"
-  - "%PYTHON%\\python.exe -m pip install -r requirements\\dev.txt"
-  - "%PYTHON%\\python.exe -m pip freeze"
+  - "python.exe -m pip install wheel"
+  - "python.exe -m pip install -r requirements\\dev.txt"
+  - "python.exe -m pip freeze"
 
-build: off
+build_script:
+  # Build the compiled extension
+  - "python setup.py build"
 
 test_script:
-  - "%PYTHON%\\python.exe -m compileall -q -f ."
-  - "%PYTHON%\\python.exe setup.py --quiet build"
-  - "%PYTHON%\\python.exe -m pip install ."
-  - "%PYTHON%\\python.exe -m pytest -r EfsxX"
+  - "python.exe -m pip install ."
+  - "python.exe -m pytest -r EfsxX"
+
+after_test:
+  - "python.exe setup.py bdist_wheel bdist_wininst"
+
+artifacts:
+  # bdist_wheel puts your built wheel in the dist directory
+  - path: dist\*

--- a/translate/convert/test_convert.py
+++ b/translate/convert/test_convert.py
@@ -2,7 +2,6 @@
 
 import os
 import six
-import sys
 
 import pytest
 
@@ -97,19 +96,11 @@ class TestConvertCommand(object):
             assert newoptions == []
         return "\n".join(newoptions)
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help (returning the help_string so further tests can be done)"""
-        stdout = sys.stdout
-        helpfile = self.open_testfile("help.txt", "w")
-        sys.stdout = helpfile
-        try:
-            with pytest.raises(SystemExit):
-                self.run_command(help=True)
-        finally:
-            sys.stdout = stdout
-        helpfile.close()
-        help_string = self.read_testfile("help.txt").decode('utf-8')
-        print(help_string)
+        with pytest.raises(SystemExit):
+            self.run_command(help=True)
+        help_string, err = capsys.readouterr()
         convertsummary = self.convertmodule.__doc__.split("\n")[0]
         # the convertsummary might be wrapped. this will probably unwrap it
         assert convertsummary in help_string.replace("\n", " ")

--- a/translate/convert/test_convert.py
+++ b/translate/convert/test_convert.py
@@ -101,6 +101,8 @@ class TestConvertCommand(object):
         with pytest.raises(SystemExit):
             self.run_command(help=True)
         help_string, err = capsys.readouterr()
+        # normalize newlines
+        help_string = help_string.replace('\r\n', '\n').replace('\r', '\n')
         convertsummary = self.convertmodule.__doc__.split("\n")[0]
         # the convertsummary might be wrapped. this will probably unwrap it
         assert convertsummary in help_string.replace("\n", " ")

--- a/translate/convert/test_csv2po.py
+++ b/translate/convert/test_csv2po.py
@@ -128,9 +128,9 @@ class TestCSV2POCommand(test_convert.TestConvertCommand, TestCSV2PO):
     """Tests running actual csv2po commands on files"""
     convertmodule = csv2po
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--charset=CHARSET")

--- a/translate/convert/test_dtd2po.py
+++ b/translate/convert/test_dtd2po.py
@@ -367,9 +367,9 @@ class TestDTD2POCommand(test_convert.TestConvertCommand, TestDTD2PO):
     convertmodule = dtd2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE", last=True)

--- a/translate/convert/test_html2po.py
+++ b/translate/convert/test_html2po.py
@@ -429,9 +429,9 @@ class TestHTML2POCommand(test_convert.TestConvertCommand, TestHTML2PO):
     convertmodule = html2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")
         options = self.help_check(options, "--keepcomments")

--- a/translate/convert/test_ical2po.py
+++ b/translate/convert/test_ical2po.py
@@ -420,8 +420,8 @@ class TestIcal2POCommand(test_convert.TestConvertCommand, TestIcal2PO):
     convertmodule = ical2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")

--- a/translate/convert/test_ini2po.py
+++ b/translate/convert/test_ini2po.py
@@ -142,9 +142,9 @@ class TestIni2POCommand(test_convert.TestConvertCommand, TestIni2PO):
     convertmodule = ini2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")

--- a/translate/convert/test_json2po.py
+++ b/translate/convert/test_json2po.py
@@ -77,9 +77,9 @@ class TestJson2POCommand(test_convert.TestConvertCommand, TestJson2PO):
     convertmodule = json2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")

--- a/translate/convert/test_l20n2po.py
+++ b/translate/convert/test_l20n2po.py
@@ -116,8 +116,8 @@ class TestL20n2POCommand(test_convert.TestConvertCommand, TestL20n2PO):
     convertmodule = l20n2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")

--- a/translate/convert/test_moz2po.py
+++ b/translate/convert/test_moz2po.py
@@ -10,9 +10,9 @@ class TestMoz2POCommand(test_convert.TestConvertCommand, TestMoz2PO):
     convertmodule = moz2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE", last=True)

--- a/translate/convert/test_mozlang2po.py
+++ b/translate/convert/test_mozlang2po.py
@@ -137,9 +137,9 @@ class TestLang2POCommand(test_convert.TestConvertCommand, TestLang2PO):
     convertmodule = mozlang2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--encoding=ENCODING")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE",

--- a/translate/convert/test_oo2po.py
+++ b/translate/convert/test_oo2po.py
@@ -175,9 +175,9 @@ class TestOO2POCommand(test_convert.TestConvertCommand, TestOO2PO):
     """Tests running actual oo2po commands on files"""
     convertmodule = oo2po
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "--source-language=LANG")
         options = self.help_check(options, "--language=LANG")
         options = self.help_check(options, "-P, --pot")

--- a/translate/convert/test_oo2xliff.py
+++ b/translate/convert/test_oo2xliff.py
@@ -19,9 +19,9 @@ class TestOO2POCommand(test_convert.TestConvertCommand, TestOO2XLIFF):
     """Tests running actual oo2xliff commands on files"""
     convertmodule = oo2xliff
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "--source-language=LANG")
         options = self.help_check(options, "--language=LANG")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")

--- a/translate/convert/test_php2po.py
+++ b/translate/convert/test_php2po.py
@@ -274,9 +274,9 @@ class TestPhp2POCommand(test_convert.TestConvertCommand, TestPhp2PO):
     convertmodule = php2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE", last=True)

--- a/translate/convert/test_po2csv.py
+++ b/translate/convert/test_po2csv.py
@@ -135,7 +135,7 @@ class TestPO2CSVCommand(test_convert.TestConvertCommand, TestPO2CSV):
     """Tests running actual po2csv commands on files"""
     convertmodule = po2csv
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "--columnorder=COLUMNORDER", last=True)

--- a/translate/convert/test_po2dtd.py
+++ b/translate/convert/test_po2dtd.py
@@ -525,9 +525,9 @@ class TestPO2DTDCommand(test_convert.TestConvertCommand, TestPO2DTD):
         test_convert.TestConvertCommand.teardown_method(self, method)
         TestPO2DTD.teardown_method(self, method)
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--fuzzy")
         options = self.help_check(options, "--threshold=PERCENT")

--- a/translate/convert/test_po2html.py
+++ b/translate/convert/test_po2html.py
@@ -125,9 +125,9 @@ class TestPO2HtmlCommand(test_convert.TestConvertCommand, TestPO2Html):
     """Tests running actual po2oo commands on files"""
     convertmodule = po2html
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2ical.py
+++ b/translate/convert/test_po2ical.py
@@ -339,9 +339,9 @@ class TestPO2IcalCommand(test_convert.TestConvertCommand, TestPO2Ical):
     convertmodule = po2ical
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2ini.py
+++ b/translate/convert/test_po2ini.py
@@ -282,9 +282,9 @@ class TestPO2IniCommand(test_convert.TestConvertCommand, TestPO2Ini):
     convertmodule = po2ini
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2l20n.py
+++ b/translate/convert/test_po2l20n.py
@@ -125,9 +125,9 @@ class TestPO2L20nCommand(test_convert.TestConvertCommand, TestPO2L20n):
     convertmodule = po2l20n
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--fuzzy")
         options = self.help_check(options, "--threshold=PERCENT")

--- a/translate/convert/test_po2moz.py
+++ b/translate/convert/test_po2moz.py
@@ -10,9 +10,9 @@ class TestPO2MozCommand(test_convert.TestConvertCommand, TestPO2Moz):
     convertmodule = po2moz
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "-l LOCALE, --locale=LOCALE")
         options = self.help_check(options, "--removeuntranslated")

--- a/translate/convert/test_po2mozlang.py
+++ b/translate/convert/test_po2mozlang.py
@@ -180,9 +180,9 @@ class TestPO2LangCommand(test_convert.TestConvertCommand, TestPO2Lang):
     convertmodule = po2mozlang
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2oo.py
+++ b/translate/convert/test_po2oo.py
@@ -159,9 +159,9 @@ class TestPO2OOCommand(test_convert.TestConvertCommand, TestPO2OO):
     """Tests running actual po2oo commands on files"""
     convertmodule = po2oo
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "--source-language=LANG")
         options = self.help_check(options, "--language=LANG")
         options = self.help_check(options, "-T, --keeptimestamp")

--- a/translate/convert/test_po2oo.py
+++ b/translate/convert/test_po2oo.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import os
 import warnings
 
-from pytest import mark
+from pytest import mark, skip
 
 from translate.convert import oo2po, po2oo, test_convert
 from translate.misc import wStringIO
@@ -49,6 +49,8 @@ class TestPO2OO(object):
 
     def test_convertoo(self):
         """checks that the convertoo function is working"""
+        if os.name == 'nt':
+            skip("test or storage broken on Windows")
         oobase = r'svx	source\dialog\numpages.src	0	string	RID_SVXPAGE_NUM_OPTIONS	STR_BULLET			0	%s	%s				20050924 09:13:58' + '\r\n'
         posource = '''#: numpages.src#RID_SVXPAGE_NUM_OPTIONS.STR_BULLET.string.text\nmsgid "Simple String"\nmsgstr "Dimpled Ring"\n'''
         ootemplate = oobase % ('en-US', 'Simple String')

--- a/translate/convert/test_po2php.py
+++ b/translate/convert/test_po2php.py
@@ -304,9 +304,9 @@ class TestPO2PhpCommand(test_convert.TestConvertCommand, TestPO2Php):
     convertmodule = po2php
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2prop.py
+++ b/translate/convert/test_po2prop.py
@@ -468,9 +468,9 @@ class TestPO2PropCommand(test_convert.TestConvertCommand, TestPO2Prop):
     convertmodule = po2prop
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--fuzzy")
         options = self.help_check(options, "--threshold=PERCENT")

--- a/translate/convert/test_po2resx.py
+++ b/translate/convert/test_po2resx.py
@@ -450,7 +450,7 @@ class TestPO2TSCommand(test_convert.TestConvertCommand, TestPO2RESX):
     """ Tests running actual po2ts commands on files """
     convertmodule = po2resx
 
-    def test_help(self):
+    def test_help(self, capsys):
         """ Tests getting help """
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")

--- a/translate/convert/test_po2sub.py
+++ b/translate/convert/test_po2sub.py
@@ -69,9 +69,9 @@ class TestPO2SubCommand(test_convert.TestConvertCommand, TestPO2Sub):
     convertmodule = po2sub
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2tiki.py
+++ b/translate/convert/test_po2tiki.py
@@ -64,6 +64,6 @@ class TestPo2TikiCommand(test_convert.TestConvertCommand, TestPo2Tiki):
     convertmodule = po2tiki
     defaultoptions = {}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)

--- a/translate/convert/test_po2tmx.py
+++ b/translate/convert/test_po2tmx.py
@@ -192,9 +192,9 @@ class TestPO2TMXCommand(test_convert.TestConvertCommand, TestPO2TMX):
     """Tests running actual po2tmx commands on files"""
     convertmodule = po2tmx
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-l LANG, --language=LANG")
         options = self.help_check(options, "--source-language=LANG")
         options = self.help_check(options, "--comments", last=True)

--- a/translate/convert/test_po2ts.py
+++ b/translate/convert/test_po2ts.py
@@ -97,8 +97,8 @@ class TestPO2TSCommand(test_convert.TestConvertCommand, TestPO2TS):
     """Tests running actual po2ts commands on files"""
     convertmodule = po2ts
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-c CONTEXT, --context=CONTEXT")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE", last=True)

--- a/translate/convert/test_po2txt.py
+++ b/translate/convert/test_po2txt.py
@@ -177,9 +177,9 @@ class TestPO2TxtCommand(test_convert.TestConvertCommand, TestPO2Txt):
     convertmodule = po2txt
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2yaml.py
+++ b/translate/convert/test_po2yaml.py
@@ -189,9 +189,9 @@ class TestPO2YAMLCommand(test_convert.TestConvertCommand, TestPO2YAML):
     convertmodule = po2yaml
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_pot2po.py
+++ b/translate/convert/test_pot2po.py
@@ -782,9 +782,9 @@ class TestPOT2POCommand(test_convert.TestConvertCommand, TestPOT2PO):
     """Tests running actual pot2po commands on files"""
     convertmodule = pot2po
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--tm")

--- a/translate/convert/test_prop2po.py
+++ b/translate/convert/test_prop2po.py
@@ -338,9 +338,9 @@ class TestProp2POCommand(test_convert.TestConvertCommand, TestProp2PO):
     convertmodule = prop2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--personality=TYPE")

--- a/translate/convert/test_resx2po.py
+++ b/translate/convert/test_resx2po.py
@@ -177,9 +177,9 @@ class TestRESX2POCommand(test_convert.TestConvertCommand, TestRESX2PO):
     convertmodule = resx2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """ Tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")

--- a/translate/convert/test_tiki2po.py
+++ b/translate/convert/test_tiki2po.py
@@ -65,7 +65,7 @@ class TestTiki2PoCommand(test_convert.TestConvertCommand, TestTiki2Po):
     convertmodule = tiki2po
     defaultoptions = {}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "--include-unused")

--- a/translate/convert/test_ts2po.py
+++ b/translate/convert/test_ts2po.py
@@ -112,8 +112,8 @@ class TestTS2POCommand(test_convert.TestConvertCommand, TestTS2PO):
     """Tests running actual ts2po commands on files"""
     convertmodule = ts2po
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")
         options = self.help_check(options, "-P, --pot", last=True)

--- a/translate/convert/test_txt2po.py
+++ b/translate/convert/test_txt2po.py
@@ -225,9 +225,9 @@ class TestTxt2POCommand(test_convert.TestConvertCommand, TestTxt2PO):
     convertmodule = txt2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates")
         options = self.help_check(options, "--encoding")

--- a/translate/convert/test_xliff2po.py
+++ b/translate/convert/test_xliff2po.py
@@ -248,9 +248,9 @@ class TestXLIFF2POCommand(test_convert.TestConvertCommand, TestXLIFF2PO):
             assert len(pofile.units) == 1
             return pofile.units[0]
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")
 

--- a/translate/convert/test_yaml2po.py
+++ b/translate/convert/test_yaml2po.py
@@ -122,8 +122,8 @@ class TestYAML2POCommand(test_convert.TestConvertCommand, TestYAML2PO):
     convertmodule = yaml2po
     defaultoptions = {"progress": "none"}
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")

--- a/translate/misc/test_optrecurse.py
+++ b/translate/misc/test_optrecurse.py
@@ -1,5 +1,5 @@
 import os
-from tempfile import TemporaryFile
+from tempfile import NamedTemporaryFile
 
 from translate.misc import optrecurse
 
@@ -21,10 +21,14 @@ class TestRecursiveOptionParser:
     def test_outputfile_receives_bytes(self, capsys):
         parser = optrecurse.RecursiveOptionParser({"txt": ("po", None)})
 
-        temp_file = TemporaryFile()
-        with TemporaryFile() as tempfile:
+        temp_file = NamedTemporaryFile(delete=False)
+        temp_file.close()
+        try:
             out = parser.openoutputfile(None, temp_file.name)
             out.write(b'binary suff')
+            out.close()
+        finally:
+            os.unlink(temp_file.name)
 
         out = parser.openoutputfile(None, None)  # To sys.stdout
         out.write(b'binary suff')

--- a/translate/storage/oo.py
+++ b/translate/storage/oo.py
@@ -86,7 +86,7 @@ def makekey(ookey, long_keys):
     project, sourcefile, resourcetype, groupid, localid, platform = ookey
     sourcefile = sourcefile.replace('\\', '/')
     if long_keys:
-        sourcebase = os.path.join(project, sourcefile)
+        sourcebase = '/'.join((project, sourcefile))
     else:
         sourceparts = sourcefile.split('/')
         sourcebase = "".join(sourceparts[-1:])

--- a/translate/storage/statsdb.py
+++ b/translate/storage/statsdb.py
@@ -740,3 +740,9 @@ class StatsCache(object):
             stats["targetwordcount"].append(targetcount)
 
         return stats
+
+    def close(self):
+        for threads in self._caches.values():
+            for cache in threads.values():
+                cache.con.close()
+        self._caches = {}

--- a/translate/storage/test_statsdb.py
+++ b/translate/storage/test_statsdb.py
@@ -106,11 +106,13 @@ class TestStatsDb:
         cache.filestats(f.filename, checker)
         state = cache.recacheunit(f.filename, checker, f.units[1])
         assert state == ['translated', 'total']
+        cache.close()
 
     def test_unitstats(self):
         f, cache = self.setup_file_and_db(jtoolkit_extract)
         u = cache.unitstats(f.filename)
         assert u['sourcewordcount'] == [3, 8, 11, 2, 9, 3]
+        cache.close()
 
     def test_filestats(self):
         f, cache = self.setup_file_and_db(jtoolkit_extract)
@@ -119,6 +121,7 @@ class TestStatsDb:
         assert s['fuzzy'] == [1, 4]
         assert s['untranslated'] == [6]
         assert s['total'] == [1, 2, 3, 4, 5, 6]
+        cache.close()
 
     def make_file_and_return_id(self, cache, filename):
         cache.cur.execute("""
@@ -130,13 +133,17 @@ class TestStatsDb:
         f, cache = self.setup_file_and_db(jtoolkit_extract)
         cache.filestats(f.filename, checks.UnitChecker())
         assert self.make_file_and_return_id(cache, f.filename) is not None
+        cache.close()
 
     def test_if_cached_after_unitstats(self):
         f, cache = self.setup_file_and_db(jtoolkit_extract)
         cache.unitstats(f.filename, checks.UnitChecker())
         assert self.make_file_and_return_id(cache, f.filename) is not None
+        cache.close()
 
     def test_singletonness(self):
         f1, cache1 = self.setup_file_and_db(jtoolkit_extract)
         f2, cache2 = self.setup_file_and_db(fr_terminology_extract)
         assert cache1 == cache2
+        cache1.close()
+        cache2.close()

--- a/translate/storage/test_zip.py
+++ b/translate/storage/test_zip.py
@@ -19,6 +19,7 @@ class TestZIPFile(object):
 
     def teardown_method(self, method):
         """removes the attributes set up by setup_method"""
+        self.zip.close()
         self.cleardir(self.testzip)
 
     def cleardir(self, dirname):

--- a/translate/storage/test_zip.py
+++ b/translate/storage/test_zip.py
@@ -52,8 +52,11 @@ class TestZIPFile(object):
         self.touchfiles(None, files, last=True)
 
         d = zip.ZIPFile(self.testzip)
-        filenames = [name for dir, name in d.getfiles()]
-        assert filenames == files
+        try:
+            filenames = [name for dir, name in d.getfiles()]
+            assert filenames == files
+        finally:
+            d.close()
 
     def test_structure(self):
         """Tests a small directory structure."""
@@ -63,8 +66,11 @@ class TestZIPFile(object):
         self.touchfiles(os.path.join(self.testzip, "bla"), files, last=True)
 
         d = zip.ZIPFile(self.testzip)
-        filenames = [name for dir, name in d.getfiles()]
-        assert filenames == files * 2
+        try:
+            filenames = [name for dir, name in d.getfiles()]
+            assert filenames == files * 2
+        finally:
+            d.close()
 
     def test_getunits(self):
         """Tests basic functionality."""
@@ -73,6 +79,9 @@ class TestZIPFile(object):
         self.touchfiles(self.testzip, files, posource, last=True)
 
         d = zip.ZIPFile(self.testzip)
-        for unit in d.getunits():
-            assert unit.target == "blabla"
-        assert len(d.getunits()) == 3
+        try:
+            for unit in d.getunits():
+                assert unit.target == "blabla"
+            assert len(d.getunits()) == 3
+        finally:
+            d.close()

--- a/translate/storage/utx.py
+++ b/translate/storage/utx.py
@@ -183,7 +183,7 @@ class UtxFile(base.TranslationStore):
         self._header = {
             "version": "1.00",
             "source_language": "en",
-            "date_created": time.strftime("%FT%TZ%z",
+            "date_created": time.strftime("%Y-%m-%dT%H:%M:%SZ%z",
                                           time.localtime(time.time()))
         }
         if inputfile is not None:

--- a/translate/storage/versioncontrol/test_helper.py
+++ b/translate/storage/versioncontrol/test_helper.py
@@ -42,5 +42,5 @@ class HelperTest(object):
             dirs = os.path.dirname(name)
             if dirs:
                 os.path.makedirs(os.path.join(self.co_path, dirs))
-            with open(os.path.join(self.co_path, dirs, name), 'w') as fh:
+            with open(os.path.join(self.co_path, dirs, name), 'wb') as fh:
                 fh.write(content)

--- a/translate/storage/versioncontrol/test_helper.py
+++ b/translate/storage/versioncontrol/test_helper.py
@@ -2,13 +2,20 @@
 
 import os
 import shutil
+import stat
+
+
+def remove_readonly(func, path, _):
+    "Clear the readonly bit and reattempt the removal"
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
 
 
 class HelperTest(object):
 
     def remove_dirs(self, path):
         if os.path.exists(path):
-            shutil.rmtree(path)
+            shutil.rmtree(path, onerror=remove_readonly)
 
     def get_test_path(self, method):
         return os.path.realpath("%s_%s" % (self.__class__.__name__, method.__name__))

--- a/translate/storage/versioncontrol/test_svn.py
+++ b/translate/storage/versioncontrol/test_svn.py
@@ -28,6 +28,8 @@ class TestSVN(HelperTest):
         file_path = os.path.join(self.co_path, "test1.txt")
         o.add(os.path.join(file_path))
         o = get_versioned_object(file_path)
-        assert os.path.samefile(o.location_abs, file_path)
+
+        # The samefile is available on Unix only, compare path only
+        assert os.path.abspath(o.location_abs) == os.path.abspath(file_path)
 
         assert o.getcleanfile().decode('utf-8') == "First file\n"

--- a/translate/storage/versioncontrol/test_svn.py
+++ b/translate/storage/versioncontrol/test_svn.py
@@ -22,8 +22,8 @@ class TestSVN(HelperTest):
     def test_add(self):
         o = get_versioned_object(self.co_path)
         self.create_files({
-            "test1.txt": "First file\n",
-            "test2.txt": "Second file\n",
+            "test1.txt": b"First file\n",
+            "test2.txt": b"Second file\n",
         })
         file_path = os.path.join(self.co_path, "test1.txt")
         o.add(os.path.join(file_path))

--- a/translate/storage/zip.py
+++ b/translate/storage/zip.py
@@ -37,6 +37,7 @@ class ZIPFile(directory.Directory):
     def __init__(self, filename=None):
         self.filename = filename
         self.filedata = []
+        self.archive = None
 
     def unit_iter(self):
         """Iterator over all the units in all the files in this zip file."""
@@ -55,3 +56,8 @@ class ZIPFile(directory.Directory):
         for completename in self.archive.namelist():
             dir, name = path.split(completename)
             self.filedata.append((dir, name))
+
+    def close(self):
+        if self.archive is not None:
+            self.archive.close()
+            self.archive = None

--- a/translate/storage/zip.py
+++ b/translate/storage/zip.py
@@ -24,7 +24,6 @@
 
 # TODO: consider also providing directories as we currently provide files
 
-from os import path
 from zipfile import ZipFile
 
 from translate.misc import wStringIO
@@ -42,7 +41,7 @@ class ZIPFile(directory.Directory):
     def unit_iter(self):
         """Iterator over all the units in all the files in this zip file."""
         for dirname, filename in self.file_iter():
-            strfile = wStringIO.StringIO(self.archive.read(path.join(dirname, filename)))
+            strfile = wStringIO.StringIO(self.archive.read('/'.join((dirname, filename))))
             strfile.filename = filename
             store = factory.getobject(strfile)
             # TODO: don't regenerate all the storage objects
@@ -54,7 +53,11 @@ class ZIPFile(directory.Directory):
         self.filedata = []
         self.archive = ZipFile(self.filename)
         for completename in self.archive.namelist():
-            dir, name = path.split(completename)
+            if '/' in completename:
+                dir, name = completename.rsplit('/', 1)
+            else:
+                dir = ''
+                name = completename
             self.filedata.append((dir, name))
 
     def close(self):

--- a/translate/tools/test_podebug.py
+++ b/translate/tools/test_podebug.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 import six
 
 from translate.storage import base, po, xliff
@@ -208,9 +210,9 @@ msgstr "Test msgstr 3"
         for debug in debugs:
             for po_doc in po_docs:
                 postore = po.pofile(po_doc.encode('utf-8'))
-                postore.filename = "fullpath/to/fakefile.po"
+                postore.filename = os.path.join('fullpath', 'to', 'fakefile.po')
                 po_out = debug.convertstore(postore)
                 in_unit = postore.units[0]
                 out_unit = po_out.units[0]
                 assert in_unit.source == out_unit.source
-                assert out_unit.target == results.pop(0)
+                assert out_unit.target == results.pop(0).replace('/', os.sep)

--- a/translate/tools/test_pretranslate.py
+++ b/translate/tools/test_pretranslate.py
@@ -305,9 +305,9 @@ class TestPretranslateCommand(test_convert.TestConvertCommand, TestPretranslate)
     """Tests running actual pretranslate commands on files"""
     convertmodule = pretranslate
 
-    def test_help(self):
+    def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self)
+        options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--tm")
         options = self.help_check(options, "-s MIN_SIMILARITY, --similarity=MIN_SIMILARITY")


### PR DESCRIPTION
This is followup to https://github.com/translate/translate/pull/3569 with fixes for the Windows build to make tests pass.

The build now succeeds, see https://ci.appveyor.com/project/nijel/translate/build/1.0.18

I've fixed all failures with exception to oo format, where I was not really sure whether it's test or storage error. Additionally this format doesn't seem to have any upstream docs anymore and is probably dead, so I didn't want to spend much time on that...

To make it usable, registration on AppVeyoyr site is needed and enabling build for this repository. Unfortunately seems to be bound to individual user rather than project there.