### PR TITLE
YAML: Consistent handling of int and bool

### DIFF
--- a/translate/storage/test_yaml.py
+++ b/translate/storage/test_yaml.py
@@ -144,7 +144,6 @@ eggs: spam
 eggs: spam
 '''
 
-    @pytest.mark.xfail(reason="Not Implemented")
     def test_boolean(self):
         store = self.StoreClass()
         store.parse('''
@@ -155,7 +154,20 @@ foo: True
         assert store.units[0].source == 'True'
         out = BytesIO()
         store.serialize(out)
-        assert out.getvalue() == b'''foo: True
+        assert out.getvalue() == b'''foo: 'True'
+'''
+
+    def test_integer(self):
+        store = self.StoreClass()
+        store.parse('''
+foo: 1
+''')
+        assert len(store.units) == 1
+        assert store.units[0].getid() == 'foo'
+        assert store.units[0].source == '1'
+        out = BytesIO()
+        store.serialize(out)
+        assert out.getvalue() == b'''foo: '1'
 '''
 
     def test_no_quote_strings(self):

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -179,7 +179,7 @@ class YAMLFile(base.TranslationStore):
         else:
             if isinstance(data, six.string_types):
                 yield (prev, data)
-            elif isinstance(data, bool):
+            elif isinstance(data, (bool, int)):
                 yield (prev, str(data))
             elif isinstance(data, list):
                 for k, v in enumerate(data):


### PR DESCRIPTION
We convert both to string on loading and store them as string.

Fixes #3619