### PR TITLE
PHP: Improve handling of unit name

### DIFF
--- a/translate/storage/php.py
+++ b/translate/storage/php.py
@@ -413,33 +413,35 @@ class phpfile(base.TranslationStore):
                     )
             elif isinstance(item, Assignment):
                 if isinstance(item.node, ArrayOffset):
+                    name = lexer.extract_name('EQUALS', *item.lexpositions)
                     if isinstance(item.expr, six.string_types):
                         self.create_and_add_unit(
-                            lexer.extract_name('EQUALS', *item.lexpositions),
+                            name,
                             item.expr,
                             lexer.extract_quote(),
                             lexer.extract_comments(item.lexpositions[1]),
                         )
                     elif isinstance(item.expr, BinaryOp) and item.expr.op == '.':
                         self.create_and_add_unit(
-                            lexer.extract_name('EQUALS', *item.lexpositions),
+                            name,
                             concatenate(item.expr),
                             lexer.extract_quote(),
                             lexer.extract_comments(item.lexpositions[1]),
                         )
                 elif isinstance(item.node, Variable):
+                    name = lexer.extract_name('EQUALS', *item.lexpositions)
                     if isinstance(item.expr, Array):
-                        handle_array(item.node.name, item.expr.nodes, lexer)
+                        handle_array(name, item.expr.nodes, lexer)
                     elif isinstance(item.expr, six.string_types):
                         self.create_and_add_unit(
-                            item.node.name,
+                            name,
                             item.expr,
                             lexer.extract_quote(),
                             lexer.extract_comments(item.lexpositions[1]),
                         )
                     elif isinstance(item.expr, BinaryOp) and item.expr.op == '.':
                         self.create_and_add_unit(
-                            item.node.name,
+                            name,
                             concatenate(item.expr),
                             lexer.extract_quote(),
                             lexer.extract_comments(item.lexpositions[1]),

--- a/translate/storage/test_php.py
+++ b/translate/storage/test_php.py
@@ -960,3 +960,12 @@ using nowdoc syntax.'''
         assert phpfile.units[1].name == "$arr->1234"
         assert phpfile.units[2].source == 'Third'
         assert phpfile.units[2].name == "$arr->'1245'"
+
+    def test_double_var(self):
+        """checks that a double $ is handled correctly"""
+        phpsource = """$$lang['mediaselect'] = 'Bestand selectie';"""
+        phpfile = self.phpparse(phpsource)
+        assert len(phpfile.units) == 1
+        phpunit = phpfile.units[0]
+        assert phpunit.name == "$$lang['mediaselect']"
+        assert phpunit.source == "Bestand selectie"


### PR DESCRIPTION
Consistently use lexer to extract name as is used in the original file
instead of relying on parser to return the exact way.