### PR TITLE
TMX: Avoid mentioning po2tmx in creation tool

### DIFF
--- a/translate/convert/test_po2tmx.py
+++ b/translate/convert/test_po2tmx.py
@@ -46,7 +46,7 @@ msgstr "Toepassings"
         assert tmx.translate("Applications") == "Toepassings"
         assert tmx.translate("bla") is None
         xmltext = bytes(tmx).decode('utf-8')
-        assert xmltext.index('creationtool="Translate Toolkit - po2tmx"')
+        assert xmltext.index('creationtool="Translate Toolkit"')
         assert xmltext.index('adminlang')
         assert xmltext.index('creationtoolversion')
         assert xmltext.index('datatype')

--- a/translate/filters/test_pofilter.py
+++ b/translate/filters/test_pofilter.py
@@ -258,7 +258,7 @@ class TestTMXFilter(BaseTestFilter):
     """Test class for TMX-specific tests."""
     filetext = '''<!DOCTYPE tmx SYSTEM "tmx14.dtd">
 <tmx version="1.4">
-  <header creationtool="Translate Toolkit - po2tmx"
+  <header creationtool="Translate Toolkit"
           creationtoolversion="1.1.1rc1" segtype="sentence" o-tmf="UTF-8"
           adminlang="en" srclang="en" datatype="PlainText"/>
   <body>

--- a/translate/storage/test_tmx.py
+++ b/translate/storage/test_tmx.py
@@ -11,7 +11,7 @@ class TestTMXUnitFromParsedString(TestTMXUnit):
 <!DOCTYPE tmx
   SYSTEM 'tmx14.dtd'>
 <tmx version="1.4">
-        <header adminlang="en" creationtool="Translate Toolkit - po2tmx" creationtoolversion="1.0beta" datatype="PlainText" o-tmf="UTF-8" segtype="sentence" srclang="en"/>
+        <header adminlang="en" creationtool="Translate Toolkit" creationtoolversion="1.0beta" datatype="PlainText" o-tmf="UTF-8" segtype="sentence" srclang="en"/>
         <body>
                 <tu>
                         <tuv xml:lang="en">

--- a/translate/storage/tmx.py
+++ b/translate/storage/tmx.py
@@ -135,7 +135,7 @@ class tmxfile(lisa.LISAfile):
 
     def addheader(self):
         headernode = next(self.document.getroot().iterchildren(self.namespaced("header")))
-        headernode.set("creationtool", "Translate Toolkit - po2tmx")
+        headernode.set("creationtool", "Translate Toolkit")
         headernode.set("creationtoolversion", __version__.sver)
         headernode.set("segtype", "sentence")
         headernode.set("o-tmf", "UTF-8")


### PR DESCRIPTION
The file can be created by anything using Translate Toolkit, so
mentioning po2tmx might be confusing and makes people think there is
some po file existing for the data.