### PR TITLE
INI: Fix ini for Python 3

### DIFF
--- a/translate/convert/ini2po.py
+++ b/translate/convert/ini2po.py
@@ -23,6 +23,8 @@ See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/command
 for examples and usage instructions.
 """
 
+import sys
+
 from translate.convert import convert
 from translate.storage import ini, po
 
@@ -38,10 +40,8 @@ class ini2po(object):
                  blank_msgstr=False, duplicate_style="msgctxt",
                  dialect="default"):
         """Initialize the converter."""
-        import sys
-        if sys.version_info[0] == 3:
-            print("Translate Toolkit doesn't yet support converting from INI in "
-                  "Python 3.")
+        if ini.INIConfig is None:
+            print("Missing iniparse library!")
             sys.exit()
 
         self.blank_msgstr = blank_msgstr

--- a/translate/convert/po2ini.py
+++ b/translate/convert/po2ini.py
@@ -23,6 +23,8 @@ See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/command
 for examples and usage instructions.
 """
 
+import sys
+
 from translate.convert import convert
 from translate.storage import ini, po
 
@@ -39,10 +41,8 @@ class po2ini(object):
                  include_fuzzy=False, output_threshold=None,
                  dialect="default"):
         """Initialize the converter."""
-        import sys
-        if sys.version_info[0] == 3:
-            print("Translate Toolkit doesn't yet support converting to INI in "
-                  "Python 3.")
+        if ini.INIConfig is None:
+            print("Missing iniparse library!")
             sys.exit()
 
         if template_file is None:


### PR DESCRIPTION
There is no official support in iniparse upstream, but for example
Debian ships patched iniparse version to work with Python 3.