### PR TITLE
resx: remove unused variable

### DIFF
--- a/translate/storage/resx.py
+++ b/translate/storage/resx.py
@@ -73,11 +73,6 @@ class RESXUnit(lisa.LISAunit):
         self._rich_target = None
         if self.target == target:
             return
-        strings = []
-        if isinstance(target, list):
-            strings = target
-        else:
-            strings = [target]
         targetnode = self._gettargetnode()
         targetnode.clear()
         targetnode.text = data.forceunicode(target) or u""


### PR DESCRIPTION
`strings` is only written to, but never read anywhere. Seemed to be in there since ResX was first committed, but has no effect whatsoever. Unless I missed some pythonic side-effect that isn't obvious.