### PR TITLE
resx: Properly indent new entries

### DIFF
--- a/translate/convert/test_po2resx.py
+++ b/translate/convert/test_po2resx.py
@@ -446,8 +446,8 @@ msgstr "Bézier-kurwe"
         assert resx_file == expected_output
 
 
-class TestPO2TSCommand(test_convert.TestConvertCommand, TestPO2RESX):
-    """ Tests running actual po2ts commands on files """
+class TestPO2RESXCommand(test_convert.TestConvertCommand, TestPO2RESX):
+    """ Tests running actual po2resx commands on files """
     convertmodule = po2resx
 
     def test_help(self, capsys):

--- a/translate/storage/test_resx.py
+++ b/translate/storage/test_resx.py
@@ -27,48 +27,48 @@ class TestRESXUnit(test_monolingual.TestMonolingualUnit):
 
 
 class TestRESXUnitFromParsedString(TestRESXUnit):
-    resxsource = XMLskeleton = '''<?xml version="1.0" encoding="utf-8"?>
+    resxsource = XMLskeleton = '''<?xml version='1.0' encoding='UTF-8'?>
 <root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
+              <xsd:attribute name="name" use="required" type="xsd:string"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+              <xsd:attribute ref="xml:space"/>
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -85,11 +85,12 @@ class TestRESXUnitFromParsedString(TestRESXUnit):
      <value>Test String</value>
   </data>
   %s
-</root>'''
+</root>
+'''
 
     def setup_method(self, method):
-        store = resx.RESXFile.parsestring(self.resxsource)
-        self.unit = store.units[0]
+        self.store = resx.RESXFile.parsestring(self.resxsource % '')
+        self.unit = self.store.units[0]
 
 
 class TestRESXfile(test_monolingual.TestMonolingualStore):

--- a/translate/storage/test_resx.py
+++ b/translate/storage/test_resx.py
@@ -92,6 +92,34 @@ class TestRESXUnitFromParsedString(TestRESXUnit):
         self.store = resx.RESXFile.parsestring(self.resxsource % '')
         self.unit = self.store.units[0]
 
+    def _assert_store(self, expected_resx):
+        output_file = wStringIO.StringIO()
+        self.store.serialize(output_file)
+        actual_resx = output_file.getvalue().decode("utf-8")
+        assert actual_resx == expected_resx
+
+    def test_newunit(self):
+        new_unit = resx.RESXUnit("New translated value")
+        new_unit.setid("test")
+        self.store.addunit(new_unit)
+
+        expected_resx = self.resxsource % '''<data name="test" xml:space="preserve">
+    <value>New translated value</value>
+  </data>'''
+        self._assert_store(expected_resx)
+
+    def test_newunit_comment(self):
+        new_unit = resx.RESXUnit("New translated value")
+        new_unit.setid("test")
+        new_unit.addnote("this unit didn't exist before")
+        self.store.addunit(new_unit)
+
+        expected_resx = self.resxsource % '''<data name="test" xml:space="preserve">
+    <value>New translated value</value>
+    <comment>this unit didn't exist before</comment>
+  </data>'''
+        self._assert_store(expected_resx)
+
 
 class TestRESXfile(test_monolingual.TestMonolingualStore):
     StoreClass = resx.RESXFile


### PR DESCRIPTION
Yet another change to make ResX play nicer with VCS.

Before this, adding new units to a file (ie. when a source resx has the entry, but the target resx does not) would put the new `<data>` entry where the closing `</root>` was (not indented at all), and the new `</root>` indented as if it was `<data>`.
```diff
--- a/Resources.de.resx
+++ b/Resources.de.resx
@@ -126,4 +126,7 @@
   <data name="ExistingEntry" xml:space="preserve">
     <value>Bestehender Eintrag</value>
   </data>
-</root>
+<data name="NewEntry" xml:space="preserve">
+    <value>Neuer Eintrag</value>
+  </data>
+  </root>
```
After the change, only the newly added `<data>` is part of the diff (as it should be), leaving the surrounding tags alone.
```diff
--- a/Resources.de.resx
+++ b/Resources.de.resx
@@ -126,4 +126,7 @@
   <data name="ExistingEntry" xml:space="preserve">
     <value>Bestehender Eintrag</value>
   </data>
+  <data name="NewEntry" xml:space="preserve">
+    <value>Neuer Eintrag</value>
+  </data>
 </root>
```
Visual Studio would obviously fix those, but this only leads to unnecessary back and forth bloating diffs and making reviews of actual changes a little harder.

That should take care of the most common issues causing conflicts for us, but I'm pretty sure there are other corner-cases that do not behave corretly (in part due to how lxml handles pretty-printing and the format attempts to fix those issues by setting `tail`/`text` on the elements by hand); but it's a little hard to fix an issue that isn't known to me, so there might be follow-up PRs addressing similar formatting issues.