### PR TITLE
Joomla fixes

### DIFF
--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -259,6 +259,10 @@ class Dialect(object):
             return quote.javapropertiesencode(string or u"")
         return quote.java_utf8_properties_encode(string or u"")
 
+    @staticmethod
+    def decode(string):
+        return quote.propertiesdecode(string)
+
     @classmethod
     def find_delimiter(cls, line):
         """Find the type and position of the delimiter in a property line.
@@ -433,9 +437,15 @@ class DialectJoomla(Dialect):
     def value_strip(cls, value):
         """Strip unneeded characters from the value"""
         newvalue = value.strip()
+        if not newvalue:
+            return newvalue
         if newvalue[0] == '"' and newvalue[-1] == '"':
             newvalue = newvalue[1:-1]
         return newvalue.replace('"_QQ_"', '"')
+
+    @classmethod
+    def decode(cls, string):
+        return cls.value_strip(string)
 
     @classmethod
     def encode(cls, string, encoding=None):
@@ -471,7 +481,7 @@ class propunit(base.TranslationUnit):
 
     @property
     def source(self):
-        return quote.propertiesdecode(self.value)
+        return self.personality.decode(self.value)
 
     @source.setter
     def source(self, source):
@@ -486,7 +496,7 @@ class propunit(base.TranslationUnit):
 
     @property
     def target(self):
-        return re.sub(u"\\\\ ", u" ", quote.propertiesdecode(self.translation))
+        return re.sub(u"\\\\ ", u" ", self.personality.decode(self.translation))
 
     @target.setter
     def target(self, target):

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -27,7 +27,7 @@ def test_find_delimiter_pos_multiple():
 def test_find_delimiter_pos_none():
     """Find delimiters when there isn't one"""
     assert properties.DialectJava.find_delimiter(u"key") == (None, -1)
-    assert properties.DialectJava.find_delimiter(u"key\=\:\ ") == (None, -1)
+    assert properties.DialectJava.find_delimiter(u"key\\=\\:\\ ") == (None, -1)
 
 
 def test_find_delimiter_pos_whitespace():
@@ -42,10 +42,10 @@ def test_find_delimiter_pos_whitespace():
 
 def test_find_delimiter_pos_escapes():
     """Find delimiters when potential earlier delimiters are escaped"""
-    assert properties.DialectJava.find_delimiter(u"key\:=value") == ('=', 5)
-    assert properties.DialectJava.find_delimiter(u"key\=: value") == (':', 5)
-    assert properties.DialectJava.find_delimiter(u"key\   value") == (' ', 5)
-    assert properties.DialectJava.find_delimiter(u"key\ key\ key\: = value") == ('=', 16)
+    assert properties.DialectJava.find_delimiter(u"key\\:=value") == ('=', 5)
+    assert properties.DialectJava.find_delimiter(u"key\\=: value") == (':', 5)
+    assert properties.DialectJava.find_delimiter(u"key\\   value") == (' ', 5)
+    assert properties.DialectJava.find_delimiter(u"key\\ key\\ key\\: = value") == ('=', 16)
 
 
 def test_is_line_continuation():
@@ -60,9 +60,9 @@ def test_is_line_continuation():
 def test_key_strip():
     assert properties._key_strip(u"key") == "key"
     assert properties._key_strip(u" key") == "key"
-    assert properties._key_strip(u"\ key") == "\ key"
+    assert properties._key_strip(u"\\ key") == "\\ key"
     assert properties._key_strip(u"key ") == "key"
-    assert properties._key_strip(u"key\ ") == "key\ "
+    assert properties._key_strip(u"key\\ ") == "key\\ "
 
 
 def test_is_comment_one_line():
@@ -159,8 +159,8 @@ class TestProp(test_monolingual.TestMonolingualStore):
         whitespaces = (
             ('key = value', 'key', 'value'),      # Standard for baseline
             (' key =  value', 'key', 'value'),    # Extra \s before key and value
-            ('\ key\ = value', '\ key\ ', 'value'),  # extra space at start and end of key
-            ('key = \ value ', 'key', ' value '),  # extra space at start end end of value
+            ('\\ key\\ = value', '\\ key\\ ', 'value'),  # extra space at start and end of key
+            ('key = \\ value ', 'key', ' value '),  # extra space at start end end of value
         )
         for propsource, key, value in whitespaces:
             propfile = self.propparse(propsource)
@@ -221,12 +221,12 @@ key=value
 
     def test_fullspec_escaped_key(self):
         """Escaped delimeters can be in the key"""
-        prop_source = u"\:\="
+        prop_source = u"\\:\\="
         prop_store = self.propparse(prop_source)
         assert len(prop_store.units) == 1
         unit = prop_store.units[0]
         print(unit)
-        assert unit.name == u"\:\="
+        assert unit.name == u"\\:\\="
 
     def test_fullspec_line_continuation(self):
         """Whitespace delimiter and pre whitespace in line continuation are dropped"""

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -398,6 +398,19 @@ key=value
         assert bom not in result[3:]
         assert b'None' not in result[3:]
 
+    def test_joomla_set_target(self):
+        """test various items used in Joomla files"""
+        propsource = '''COM_EXAMPLE_FOO="This is a test"\n'''.encode('utf-8')
+        proptarget = '''COM_EXAMPLE_FOO="This is another test"\n'''.encode('utf-8')
+        propfile = self.propparse(propsource, personality="joomla")
+        assert len(propfile.units) == 1
+        propunit = propfile.units[0]
+        assert propunit.name == u'COM_EXAMPLE_FOO'
+        assert propunit.source == u'This is a test'
+        assert bytes(propfile) == propsource
+        propunit.target = 'This is another test'
+        assert bytes(propfile) == proptarget
+
     def test_joomla(self):
         """test various items used in Joomla files"""
         propsource = '''; comment\nVALUE="I am a "_QQ_"value"_QQ_""\n'''.encode('utf-8')


### PR DESCRIPTION
- generic fix of missing `\` escaping in properties test
- fixed storing changed value in Joomla, see https://github.com/WeblateOrg/weblate/issues/1716