### PR TITLE
pypo: Fix parsing of files with mixed newlines

### DIFF
--- a/translate/storage/test_po.py
+++ b/translate/storage/test_po.py
@@ -835,7 +835,7 @@ msgstr "b"
         assert header_dict[u"Last-Translator"] == u"Tránslátór"
 
     def test_final_slash(self):
-        """Test that \ as last character is correcly interpreted (bug 960)."""
+        """Test that \\ as last character is correcly interpreted (bug 960)."""
         posource = r'''
 msgid ""
 msgstr ""

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -387,3 +387,15 @@ msgstr[1] "toetse"
         pofile = self.poparse(posource)
         assert len(pofile.units) == 1
         assert pofile.units[0].source == 'test me'
+
+    def test_mixed_newlines(self):
+        """checks that mixed newlines are properly parsed"""
+        posource = b'''#Comment
+#: foo.c:124\r bar.c:124\r
+msgid "test me"
+msgstr ""
+'''
+        pofile = self.poparse(posource)
+        assert len(pofile.units) == 1
+        assert pofile.units[0].source == 'test me'
+        assert bytes(pofile) == posource


### PR DESCRIPTION
In case \r is included in comment text and whole file is having \n
newlines, the univerzal newlines approach breaks lines on wrong
locations, while gettext handles this just fine.

This addresses regression introduced by https://github.com/translate/translate/pull/3760, see https://github.com/WeblateOrg/weblate/issues/1986#issuecomment-386704921