### PR TITLE
Catkeys: merge header and fingerprint

### DIFF
--- a/docs/formats/catkeys.rst
+++ b/docs/formats/catkeys.rst
@@ -9,6 +9,34 @@ Haiku catkeys
 Localisation for the `Haiku <http://www.haiku-os.org/>`_ operating system is
 done with a file format called catkeys.  It is a bilingual file format.
 
+The is a tab separated value (TSV) file, where each line represents a
+translatable unit. A line consists of four elements:
+
++------------+---------------------------------------------------------------+
+| Column     | Description                                                   |
++============+===============================================================+
+| source     | The source text (in English)                                  |
++------------+---------------------------------------------------------------+
+| context    | The context of where the source text is used.                 |
++------------+---------------------------------------------------------------+
+| remarks    | An additional remark by the developer, that gives a hint to   |
+|            | the translator. Within the context of this toolkit, this is   |
+|            | stored as the note of the unit.                               |
++------------+---------------------------------------------------------------+
+| target     | The target text                                               |
++------------+---------------------------------------------------------------+
+
+The first line of the file is the header file, with four tab separated values:
+
+* The version (currently: 1)
+* The name of the language in lower case (for example: catalan)
+* The signature (for example: x-vnd.Haiku-StyledEdit)
+* A checksum (32 bit unsigned integer)
+
+The checksum is calculated by an algorithm that hashes the source, context and
+remark values of all units. The target text is not relevant for the checksum
+algorithm.
+
 .. _catkeys#links:
 
 Links

--- a/translate/convert/pot2po.py
+++ b/translate/convert/pot2po.py
@@ -123,9 +123,11 @@ def _store_pre_merge(input_store, output_store, template_store, **kwargs):
     if isinstance(input_store, poheader.poheader):
         _do_poheaders(input_store, output_store, template_store)
     elif isinstance(input_store, catkeys.CatkeysFile):
-        #FIXME: shouldn't we be merging template_store.header instead?
         #FIXME: also this should be a format specific hook
-        output_store.header = input_store.header
+        if template_store is not None:
+            output_store.header = template_store.header
+        else:
+            output_store.header = input_store.header
 
     # Dispatch to format specific functions
     store_pre_merge_hook = "_store_pre_merge_%s" % input_store.__class__.__name__

--- a/translate/storage/catkeys.py
+++ b/translate/storage/catkeys.py
@@ -113,7 +113,11 @@ class CatkeysHeader(object):
         if not header:
             self._header_dict = self._create_default_header()
         elif isinstance(header, dict):
-            self._header_dict = header
+            for key in FIELDNAMES_HEADER:
+                value = header.get(key, "")
+                if value is None:
+                    value = ""
+                self._header_dict[key] = value
 
     def _create_default_header(self):
         """Create a default catkeys header"""
@@ -127,6 +131,12 @@ class CatkeysHeader(object):
         #XXX assumption about the current structure of the languages dict in data
         self._header_dict['language'] = data.languages[newlang][0].lower()
     targetlanguage = property(None, settargetlanguage)
+
+    def setchecksum(self, checksum):
+        """Set the checksum for the file"""
+        if not checksum:
+            return
+        self._header_dict['checksum'] = str(checksum)
 
 
 @six.python_2_unicode_compatible
@@ -149,8 +159,13 @@ class CatkeysUnit(base.TranslationUnit):
         :param newdict: a new dictionary with catkeys line elements
         :type newdict: Dict
         """
-        # TODO First check that the values are OK
-        self._dict = newdict
+        # Process the input values
+        self._dict = {}
+        for key in FIELDNAMES:
+            value = newdict.get(key, "")
+            if value is None:
+                value = ""
+            self._dict[key] = value
     dict = property(getdict, setdict)
 
     def _get_source_or_target(self, key):
@@ -198,11 +213,14 @@ class CatkeysUnit(base.TranslationUnit):
 
     def getnotes(self, origin=None):
         if not origin or origin in ["programmer", "developer", "source code"]:
-            return self._dict["comment"]
+            return self._dict.get("comment", "")
         return u""
 
     def getcontext(self):
-        return self._dict["context"]
+        return self._dict.get("context", "")
+
+    def setcontext(self, context):
+        self._dict["context"] = context
 
     def getid(self):
         context = self.getcontext()
@@ -283,8 +301,48 @@ class CatkeysFile(base.TranslationStore):
     def serialize(self, out):
         output = csv.StringIO()
         writer = csv.DictWriter(output, FIELDNAMES, dialect="catkeys")
+        # Calculate/update fingerprint
+        self.header.setchecksum(self._compute_fingerprint())
         # No real headers, the first line contains metadata
         writer.writerow(dict(zip(FIELDNAMES, [self.header._header_dict[key] for key in FIELDNAMES_HEADER])))
         for unit in self.units:
             writer.writerow(unit.dict)
         out.write(output.getvalue().encode(self.encoding))
+
+    def _compute_fingerprint(self):
+        """
+        Compute the current hash key in the header for the current state of the store.
+        """
+
+        def hashfun(string, startValue):
+            """
+            This function is on CatKey::HashFun(). In this implementation C integer overflow is emulated.
+            https://github.com/haiku/haiku/blob/b65adbdfbc322bb7d86d74049389c688e9962f15/src/kits/locale/HashMapCatalog.cpp#L93
+            """
+            h = startValue
+            array = string.encode('utf-8')
+
+            for byte in six.iterbytes(array):
+                if byte > 127:
+                    byte -= 256
+                h = 5 * h + byte
+                h &= 0xFFFFFFFF
+
+            # Add 1
+            h = 5 * h + 1
+            h &= 0xFFFFFFFF
+
+            return h
+
+        fingerprint = 0
+        for unit in self.units:
+            stringhash = hashfun(unit.source, 0)
+            stringhash &= 0xFFFFFFFF
+            stringhash = hashfun(unit.getcontext(), stringhash)
+            stringhash &= 0xFFFFFFFF
+            stringhash = hashfun(unit.getnotes(), stringhash)
+            stringhash &= 0xFFFFFFFF
+            fingerprint += stringhash
+            fingerprint &= 0xFFFFFFFF
+
+        return fingerprint

--- a/translate/storage/test_catkeys.py
+++ b/translate/storage/test_catkeys.py
@@ -8,9 +8,9 @@ class TestCatkeysUnit(test_base.TestTranslationUnit):
     UnitClass = catkeys.CatkeysUnit
 
     def test_difficult_escapes(self):
-        r"""Wordfast files need to perform magic with escapes.
+        r"""Catkeys files need to perform magic with escapes.
 
-           Wordfast does not accept line breaks in its TM (even though they would be
+           Catkeys does not accept line breaks in its TM (even though they would be
            valid in CSV) thus we turn \\n into \n and reimplement the base class test but
            eliminate a few of the actual tests.
         """
@@ -43,3 +43,25 @@ class TestCatkeysUnit(test_base.TestTranslationUnit):
 
 class TestCatkeysFile(test_base.TestTranslationStore):
     StoreClass = catkeys.CatkeysFile
+
+    def test_checksum(self):
+        """Tests that the checksum for a file is properly calculated."""
+        # The following test is based on: https://github.com/haiku/haiku/blob/d30c60446a40ba4aa1418a548c82e6aaf72b409a/data/catalogs/add-ons/disk_systems/fat/tr.catkeys
+        store = self.StoreClass()
+        unit1 = store.addsourceunit(u"Auto (default)")
+        unit1.setcontext(u"FAT_Initialize_Parameter")
+        unit2 = store.addsourceunit(u"FAT bits:")
+        unit2.setcontext(u"FAT_Initialize_Parameter")
+        unit3 = store.addsourceunit(u"Name:")
+        unit3.setcontext(u"FAT_Initialize_Parameter")
+        assert store._compute_fingerprint() == 2766737426
+
+        # setting translations should not change the fingerprint
+        unit1.target = u"Otomatik (öntanımlı)"
+        unit2.target = u"FAT bitleri:"
+        unit3.target = u"Ad:"
+        assert store._compute_fingerprint() == 2766737426
+
+        # changing a source string should change the fingerprint
+        unit1.source = u"Auto(no longer default)"
+        assert store._compute_fingerprint() != 2766737426


### PR DESCRIPTION
The catkeys format now has support for fingerprint calculation.
This means that if the tools change the contents of the file (like
remove or change strings), the header will now be correct and the file
will be parseable on Haiku.

When merging with pot2po, it will use the template header to determine
the language of the output format.