### PR TITLE
fix import OS X strings file

### DIFF
--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -262,6 +262,16 @@ key=value
         assert propunit.name == u'I am a "key"'
         assert propunit.source == u'I am a "value"'
 
+    def test_mac_multiline_strings(self):
+        """test can read multiline items used in Mac OS X strings files"""
+        propsource = (r'''"I am a \"key\"" = "I am a \"value\" ''' +
+                      '\n nextline";').encode('utf-16')
+        propfile = self.propparse(propsource, personality="strings")
+        assert len(propfile.units) == 1
+        propunit = propfile.units[0]
+        assert propunit.name == u'I am a "key"'
+        assert propunit.source == u"I am a \"value\" nextline"
+
     def test_mac_strings_unicode(self):
         """Ensure we can handle Unicode"""
         propsource = u'''"I am a “key”" = "I am a “value”";'''.encode('utf-16')
@@ -307,7 +317,7 @@ key=value
         propsource = (u'/* Foo\n'
                       u'Bar\n'
                       u'Baz */\n'
-                      u'"key" = "value"').encode('utf-16')
+                      u'"key" = "value";').encode('utf-16')
         propfile = self.propparse(propsource, personality="strings")
         assert len(propfile.units) == 1
         propunit = propfile.units[0]


### PR DESCRIPTION
This fixes: https://github.com/translate/translate/issues/3824

There is a bug when reading multiline OS X strings.

In the file: storage/properties.py , the stringsfile and stringsutf8file classes derive from the properties class.

It looks like .properties files can have multiline strings but using a backslashes \ (or that is what I understood looking at the code), but OS X string files do not require that. Instead, to check for the end of the string the last character, that should be a ';'.

Could not make the tests in the master branch pass, and did not understand how to create a new test to raise the issue (in an initial commit) and then commit the fix. So, I know that this is not a good enough PR, but if you try to import the OS X strings file that I attach, you will find it fails.

[os_x_strings_sample.zip](https://github.com/translate/translate/files/2364438/os_x_strings_sample.zip)

After applying this modification, the OS X strings file is imported as expected.