### PR TITLE
Android: Fix question mark escaping

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -238,6 +238,7 @@ class AndroidResourceUnit(base.TranslationUnit):
         text = text.replace('\n', '\n\\n')
         text = text.replace('\t', '\\t')
         text = text.replace('\'', '\\\'')
+        text = text.replace('?', '\\?')
         text = text.replace('"', '\\"')
 
         # @ needs to be escaped at start

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -71,6 +71,11 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
         xml = '<string name="teststring">quote \\\'escape\\\'</string>\n\n'
         self.__check_escape(string, xml)
 
+    def test_escape_question(self):
+        string = 'question?'
+        xml = '<string name="teststring">question\\?</string>\n\n'
+        self.__check_escape(string, xml)
+
     def test_escape_double_space(self):
         string = 'double  space'
         xml = '<string name="teststring">"double  space"</string>\n\n'


### PR DESCRIPTION
This is complement to 60762a01565262e2463db60e7c38b42f3189646e which did
only handle parsing.

Fixes https://github.com/WeblateOrg/weblate/issues/2291