### PR TITLE
Fix + enhance web2py <-> po translation

### DIFF
--- a/translate/convert/test_po2web2py.py
+++ b/translate/convert/test_po2web2py.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+from translate.convert import po2web2py
+from translate.misc import wStringIO
+from translate.storage import po
+
+import six
+import pytest
+
+
+class TestPO2WEB2PY(object):
+
+    def po2web2py(self, po_source):
+        """helper that converts po source to web2py source without requiring files"""
+        input_file = wStringIO.StringIO(po_source)
+        input_po = po.pofile(input_file)
+        convertor = po2web2py.po2pydict()
+        output_web2py = convertor.convertstore(input_po, False)
+        return output_web2py.read()
+
+    def test_basic(self):
+        """test a basic po to web2py conversion"""
+        input_po = '''#: .text
+msgid "A simple string"
+msgstr "Du texte simple"
+'''
+        expected_web2py = '''# -*- coding: utf-8 -*-
+{
+'A simple string': 'Du texte simple',
+}
+'''
+        web2py_out = self.po2web2py(input_po)
+        assert web2py_out == expected_web2py
+
+    @pytest.mark.skipif(six.PY2, reason='Skipping unicode tests on PY2')
+    def test_unicode(self):
+        """test a po to web2py conversion with unicode"""
+        input_po = '''#: .text
+msgid "Foobar"
+msgstr "Fúbär"
+'''
+        expected_web2py = '''# -*- coding: utf-8 -*-
+{
+'Foobar': 'Fúbär',
+}
+'''
+        web2py_out = self.po2web2py(input_po)
+        assert web2py_out == expected_web2py
+
+    def test_ordering_serialize(self):
+        """test alphabetic ordering in po to web2py conversion"""
+        input_po = '''
+#: .foo
+msgid "foo"
+msgstr "oof"
+
+#: .bar
+msgid "bar"
+msgstr "rab"
+
+#: .baz
+msgid "baz"
+msgstr "zab"
+'''
+        expected_web2py = '''# -*- coding: utf-8 -*-
+{
+'bar': 'rab',
+'baz': 'zab',
+'foo': 'oof',
+}
+'''
+        web2py_out = self.po2web2py(input_po)
+        assert web2py_out == expected_web2py

--- a/translate/convert/test_web2py2po.py
+++ b/translate/convert/test_web2py2po.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+import sys
+
+from translate.convert import web2py2po
+from translate.storage import po
+from translate.storage.test_base import first_translatable, headerless_len
+
+import six
+import pytest
+
+
+class TestWEB2PY2PO(object):
+
+    def web2py2po(self, web2py_source):
+        """helper that converts po source to web2py source without requiring files"""
+        input_web2py = eval(web2py_source)
+        new_pofile = po.pofile()
+        convertor = web2py2po.web2py2po(new_pofile)
+        output_po = convertor.convertstore(input_web2py)
+        return output_po
+
+    def singleelement(self, storage):
+        """checks that the pofile contains a single non-header element, and returns it"""
+        assert headerless_len(storage.units) == 1
+        return first_translatable(storage)
+
+    def test_basic(self):
+        """test a basic web2py to po conversion"""
+        input_web2py = '''# -*- coding: utf-8 -*-
+{
+'A simple string': 'Du texte simple',
+}
+'''
+
+        po_out = self.web2py2po(input_web2py)
+        pounit = self.singleelement(po_out)
+        assert pounit.source == "A simple string"
+        assert pounit.target == "Du texte simple"
+
+    @pytest.mark.skipif(six.PY2, reason='Skipping unicode tests on PY2')
+    def test_unicode(self):
+        """test a web2py to po conversion with unicode"""
+        input_web2py = '''# -*- coding: utf-8 -*-
+{
+'Foobar': 'Fúbär',
+}
+'''
+
+        po_out = self.web2py2po(input_web2py)
+        pounit = self.singleelement(po_out)
+        assert pounit.source == "Foobar"
+        assert pounit.target == "Fúbär"

--- a/translate/convert/web2py2po.py
+++ b/translate/convert/web2py2po.py
@@ -26,11 +26,14 @@ for examples and usage instructions.
 
 from translate.storage import po
 
+import six
+
 
 class web2py2po(object):
 
-    def __init__(self, pofile=None):
+    def __init__(self, pofile=None, duplicatestyle="msgctxt"):
         self.mypofile = pofile
+        self.duplicatestyle = duplicatestyle
 
     def convertunit(self, source_str, target_str):
         pounit = po.pounit(encoding="UTF-8")
@@ -40,25 +43,26 @@ class web2py2po(object):
         return pounit
 
     def convertstore(self, mydict):
-
         targetheader = self.mypofile.header()
         targetheader.addnote("extracted from web2py", "developer")
 
         for source_str in mydict.keys():
             target_str = mydict[source_str]
+            if six.PY2:
+                target_str = target_str.decode('utf-8')
+                source_str = source_str.decode('utf-8')
             if target_str == source_str:
                 # a convention with new (untranslated) web2py files
-                target_str = u''
-            elif target_str.startswith(u'*** '):
-                # an older convention
                 target_str = u''
             pounit = self.convertunit(source_str, target_str)
             self.mypofile.addunit(pounit)
 
+        self.mypofile.removeduplicates(self.duplicatestyle)
+
         return self.mypofile
 
 
-def convertpy(inputfile, outputfile, encoding="UTF-8"):
+def convertpy(inputfile, outputfile, encoding="UTF-8", duplicatestyle="msgctxt"):
 
     new_pofile = po.pofile()
     convertor = web2py2po(new_pofile)

--- a/translate/convert/web2py2po.py
+++ b/translate/convert/web2py2po.py
@@ -37,6 +37,7 @@ class web2py2po(object):
 
     def convertunit(self, source_str, target_str):
         pounit = po.pounit(encoding="UTF-8")
+        pounit.settypecomment('python-format')
         pounit.source = source_str
         if target_str:
             pounit.target = target_str


### PR DESCRIPTION
This commit includes numerous updates and bug fixes that allow for the use of the web2py <-> po converter commands:
- Fixes runtime for the converters to properly function (previously throwing errors)
- Includes Unicode support
- Utilizes the standard function calls to add po unit data
- Alphabetically sorts entries in the new web2py file
- Doesn't write the file if contents will be empty
- Fixes whitespace and other formatting
- Adds test for po2web2py

Fixes #3254.