### PR TITLE
JSON: Fix exception handling in Python 3

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -215,7 +215,7 @@ class JsonFile(base.TranslationStore):
         try:
             self._file = json.loads(input, object_pairs_hook=OrderedDict)
         except ValueError as e:
-            raise base.ParseError(e.message)
+            raise base.ParseError(e)
 
         for k, data, item, notes in self._extract_translatables(self._file,
                                                                 stop=self._filter):

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 from io import BytesIO
+from pytest import raises
 from translate.misc.multistring import multistring
-from translate.storage import jsonl10n, test_monolingual
+from translate.storage import base, jsonl10n, test_monolingual
 
 
 JSON_I18NEXT = b"""{
@@ -46,6 +47,11 @@ class TestJSONResourceStore(test_monolingual.TestMonolingualStore):
         store.serialize(out)
 
         assert out.getvalue() == b'{\n    "key": "value"\n}\n'
+
+    def test_error(self):
+        store = self.StoreClass()
+        with raises(base.ParseError):
+            store.parse('{"key": "value"')
 
     def test_filter(self):
         store = self.StoreClass(filter=['key'])


### PR DESCRIPTION
There is no message attribute on exception in Python 3.