### PR TITLE
Add python 3.7 to testing matrix and fix failing tests with pytest 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,35 +9,18 @@ python:
   - 3.6
 env:
   matrix:
-    - USECPO=0 MINVERSION=1 META=
     - USECPO=0 MINVERSION= META=
-    - USECPO=0 MINVERSION= META=1
     #- USECPO=2
 matrix:
-  exclude:
-    - python: 3.3
+  include:
+    # Obtain Python 3.7 from xenial as per https://github.com/travis-ci/travis-ci/issues/9815
+    - python: 3.7
+      dist: xenial
+      sudo: true
+    # Do additional variations with Python 2.7 only
+    - python: 2.7
       env: USECPO=0 MINVERSION=1 META=
-    - python: 3.3
-      env: USECPO=0 MINVERSION=1 META=1
-    - python: 3.3
-      env: USECPO=0 MINVERSION= META=1
-    - python: 3.4
-      env: USECPO=0 MINVERSION=1 META=
-    - python: 3.4
-      env: USECPO=0 MINVERSION=1 META=1
-    - python: 3.4
-      env: USECPO=0 MINVERSION= META=1
-    - python: 3.5
-      env: USECPO=0 MINVERSION=1 META=
-    - python: 3.5
-      env: USECPO=0 MINVERSION=1 META=1
-    - python: 3.5
-      env: USECPO=0 MINVERSION= META=1
-    - python: 3.6
-      env: USECPO=0 MINVERSION=1 META=
-    - python: 3.6
-      env: USECPO=0 MINVERSION=1 META=1
-    - python: 3.6
+    - python: 2.7
       env: USECPO=0 MINVERSION= META=1
 install:
   - pip install coveralls

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@
 isort>=4.2.3
 pycodestyle==2.4.0
 pydocstyle==2.1.1
-pytest==3.8.2
+pytest==3.10.1
 pytest-cov
 pytest-xdist
 Sphinx==1.8.1

--- a/translate/misc/test_deprecation.py
+++ b/translate/misc/test_deprecation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from pytest import deprecated_call, raises
+from pytest import deprecated_call, raises, mark
 
 from translate.misc.deprecation import deprecated
 
@@ -18,5 +18,6 @@ class TestDeprecation(object):
     def test_deprecated_decorator(self):
         deprecated_call(self.deprecated_helper)
 
-        with raises(AssertionError):
-            deprecated_call(self.active_helper)
+    @mark.filterwarnings("error")
+    def test_no_deprecated_decorator(self):
+        self.active_helper()


### PR DESCRIPTION
Python 3.7 is now out and so it's time to add that to the test matrix. Some jiggling is required to express the test matrix in a sensible fashion to get Python 3.7.

There's also a new version of pytest out, and with either pytest 3.9 or 3.10, the way the `deprecated` decorator was tested broke; a second commit to fix that.