### PR TITLE
Android: Remove not needed code

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -341,10 +341,7 @@ class AndroidResourceUnit(base.TranslationUnit):
                 self.setid(old_id)
 
             locale = self.gettargetlanguage().replace('_', '-').split('-')[0]
-            lang_tags = data.plural_tags.get(locale, data.plural_tags['en'])
-
-            # Get plural tags in the right order.
-            plural_tags = [tag for tag in ['zero', 'one', 'two', 'few', 'many', 'other'] if tag in lang_tags]
+            plural_tags = data.plural_tags.get(locale, data.plural_tags['en'])
 
             # Get string list to handle, wrapping non multistring/list targets into a list.
             if isinstance(target, multistring):


### PR DESCRIPTION
The plurals are already properly sorted in the data module, there is no
need to sort them again.