### PR TITLE
Add macOS and Python 3.7 classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,6 +166,7 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License (GPL)",
     "Operating System :: OS Independent",
     "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS :: MacOS X",
     "Operating System :: Unix",
     "Programming Language :: Python",
     "Programming Language :: Python :: 2.7",
@@ -173,6 +174,7 @@ classifiers = [
     "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Localization",
 ]


### PR DESCRIPTION
Since we're providing support for Python 3.7 and testing against it, we might as well add it as a PyPi classifier.  (Same for macOS, since Windows and Unix are defined.)