### PR TITLE
Python formatting fix

### DIFF
--- a/translate/storage/placeables/general.py
+++ b/translate/storage/placeables/general.py
@@ -115,7 +115,7 @@ class PythonFormattingPlaceable(Ph):
     regex = re.compile(r"""(?x)
                        %                     # Start of formatting specifier
                        (%|                   # No argument converted %% creates a %
-                       (\([a-z_]+\)){0,1}    # Mapping key value (optional)
+                       (\([^)]+\)){0,1}      # Mapping key value (optional)
                        [\-\+0\s\#]{0,1}      # Conversion flags (optional)
                        (\d+|\*){0,1}         # Minimum field width (optional)
                        (\.(\d+|\*)){0,1}     # Precision (optional)

--- a/translate/storage/placeables/test_general.py
+++ b/translate/storage/placeables/test_general.py
@@ -143,4 +143,28 @@ def test_placeable_brace():
     assert bp.parse(u'There were {{number1}} cows and {number2} sheep')[3] == bp([u'{number2}'])
 
 
-# TODO: PythonFormattingPlaceable, JavaMessageFormatPlaceable, UrlPlaceable, XMLTagPlaceable
+def test_python_placeable():
+    pfp = general.PythonFormattingPlaceable
+    # No conversion
+    assert pfp.parse(u'100%% correct')[1] == pfp([u'%%'])
+
+    # Mapping keys
+    assert pfp.parse(u'There were %(number)d cows')[1] == pfp([u'%(number)d'])
+    assert pfp.parse(u'There were %(cows.number)d cows')[1] == pfp([u'%(cows.number)d'])
+    assert pfp.parse(u'There were %(number of cows)d cows')[1] == pfp([u'%(number of cows)d'])
+
+    # Conversion flags
+    assert pfp.parse(u'There were %(number)03d cows')[1] == pfp([u'%(number)03d'])
+    assert pfp.parse(u'There were %(number) 3d cows')[1] == pfp([u'%(number) 3d'])
+
+    # Minimum field width
+    assert pfp.parse(u'There were %(number)*d cows')[1] == pfp([u'%(number)*d'])
+
+    # Precision
+    assert pfp.parse(u'There were %(number)3.1d cows')[1] == pfp([u'%(number)3.1d'])
+
+    # Length modifier
+    assert pfp.parse(u'There were %(number)Ld cows')[1] == pfp([u'%(number)Ld'])
+
+
+# TODO: JavaMessageFormatPlaceable, UrlPlaceable, XMLTagPlaceable


### PR DESCRIPTION
Mapping keys for Python can be any string, currently podebug is rewriting values such as:

```
msgid "Camp story - %(object.name)s"
msgstr "Ƈȧḿƥ şŧǿřẏ - %(ǿƀĵḗƈŧ.ƞȧḿḗ)ş"
```

This PR should allow any character inside the parentheses. I've also added some tests which should hopefully cover most of the common PythonFormattingPlaceable cases.

Closes #3705 