### PR TITLE
Remove Python 3.3 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required  # For now these builds are faster
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6


### PR DESCRIPTION
- current lxml no longer supports it making installation fail
- 3.3 has reached end of life on 2017-09-29