### PR TITLE
Trados: list all public memebers

### DIFF
--- a/translate/storage/trados.py
+++ b/translate/storage/trados.py
@@ -53,6 +53,12 @@ except ImportError:
 from translate.misc.deprecation import deprecated
 from translate.storage import base
 
+__all__ = (
+    'TRADOS_TIMEFORMAT', 'RTF_ESCAPES',
+    'escape', 'unescape',
+    'TradosTxtDate', 'TradosUnit', 'TradosTxtTmFile',
+)
+
 
 TRADOS_TIMEFORMAT = "%d%m%Y, %H:%M:%S"
 """Time format used by Trados .txt"""


### PR DESCRIPTION
Needed to hide TradosSoup from Sphinx autodoc module as it makes no
sense to include Soup documentation (especially as it fails to build
using Sphinx).