### PR TITLE
YAML: Switch to ruamel.yaml

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -8,5 +8,5 @@ iniparse==0.4 ;python_version < '3.0'      # INI (ini2po)
 vobject==0.9.6.1       # iCal (ical2po)
 aeidon==1.2.1 ;python_version > '3.0'      # Subtitles (sub2po)
 l20n==4.0.0a1        # l20n (l20n2po)
-PyYAML==3.13         # yaml
+ruamel.yaml==0.15.87 # yaml
 phply==1.2.5         # PHP

--- a/translate/convert/test_yaml2po.py
+++ b/translate/convert/test_yaml2po.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+import pytest
+
 from translate.convert import yaml2po, test_convert
 from translate.misc import wStringIO
 
@@ -93,6 +95,7 @@ eggs: spam
         assert target_store.units[4].source == "spam"
         assert target_store.units[4].target == ""
 
+    @pytest.mark.xfail(reason="This is invalid YAML document")
     def test_no_duplicates(self):
         """Check converting drops duplicates."""
         input_string = '''

--- a/translate/storage/test_yaml.py
+++ b/translate/storage/test_yaml.py
@@ -29,6 +29,13 @@ class TestYAMLResourceStore(test_monolingual.TestMonolingualStore):
         store.serialize(out)
         assert out.getvalue() == b'key: value\n'
 
+    def test_empty(self):
+        store = self.StoreClass()
+        store.parse('{}')
+        out = BytesIO()
+        store.serialize(out)
+        assert out.getvalue() == b'{}\n'
+
     def test_edit(self):
         store = self.StoreClass()
         store.parse('key: value')
@@ -433,3 +440,10 @@ class TestRubyYAMLResourceStore(test_monolingual.TestMonolingualStore):
         out = BytesIO()
         store.serialize(out)
         assert out.getvalue() == data.encode('ascii')
+
+    def test_empty(self):
+        store = self.StoreClass()
+        store.parse('{}')
+        out = BytesIO()
+        store.serialize(out)
+        assert out.getvalue() == b'{}\n'

--- a/translate/storage/test_yaml.py
+++ b/translate/storage/test_yaml.py
@@ -88,7 +88,7 @@ foo: bar
         assert store.units[0].source == 'Oficina'
         out = BytesIO()
         store.serialize(out)
-        assert out.getvalue() == b''''yes': Oficina
+        assert out.getvalue() == b'''yes: Oficina
 '''
 
     def test_nested(self):
@@ -414,7 +414,7 @@ class TestRubyYAMLResourceStore(test_monolingual.TestMonolingualStore):
     def test_invalid_key(self):
         store = yaml.YAMLFile()
         with pytest.raises(base.ParseError):
-            store.parse('yes: string')
+            store.parse('1: string')
 
     def test_invalid_value(self):
         store = yaml.YAMLFile()

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -200,7 +200,7 @@ class RubyYAMLFile(YAMLFile):
 
     def _parse_dict(self, data, prev):
         # Does this look like a plural?
-        if all((x in cldr_plural_categories for x in data.keys())):
+        if data and all((x in cldr_plural_categories for x in data.keys())):
             # Ensure we have correct plurals ordering.
             values = [data[item] for item in cldr_plural_categories if item in data]
             yield (prev, multistring(values))


### PR DESCRIPTION
- This allows us to remove majority of custom code around preserving
  order of keys
- It supports YAML 1.2 which supports yes/no as keys (see #3695)