### PR TITLE
Gettext: Improve finding out newline format for a file

### DIFF
--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -54,15 +54,20 @@ def splitlines(text):
     Can not use univerzal newlines as they match any newline like
     character inside text and that breaks on files with unix newlines
     and LF chars inside comments.
+
+    The code looks for first msgid and looks for newline used after it. This
+    should safely cover weird newlines used in comments or filenames, while
+    properly parsing po files with any newlines.
     """
     # Find first newline
     newline = b'\n'
-    for i, ch in enumerate(text):
+    msgid_pos = max(0, text.find(b'msgid'))
+    for i, ch in enumerate(text[msgid_pos:]):
         # Iteration over bytes yields numbers in Python 3
         if ch in ('\n', 10):
             break
         if ch in ('\r', 13):
-            if text[i + 1] in ('\n', 10):
+            if text[msgid_pos + i + 1] in ('\n', 10):
                 newline = b'\r\n'
             else:
                 newline = b'\r'

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -399,3 +399,23 @@ msgstr ""
         assert len(pofile.units) == 1
         assert pofile.units[0].source == 'test me'
         assert bytes(pofile) == posource
+
+    def test_mixed_newlines_header(self):
+        """checks that mixed newlines are properly parsed"""
+        posource = b'''# Polish message file for YaST2 (@memory@).\r
+# Copyright (C) 2005 SUSE Linux Products GmbH.\r
+msgid ""
+msgstr ""
+"Project-Id-Version: YaST (@memory@)\\n"
+
+#. Rich text title for FcoeClient in proposals
+#: src/clients/fcoe-client_proposal.rb:82
+msgid "FcoeClient"
+msgstr "FcoeClient"
+'''
+        pofile = self.poparse(posource)
+        assert len(pofile.units) == 2
+        assert pofile.units[0].source == ''
+        assert pofile.units[1].source == 'FcoeClient'
+        print(repr(bytes(pofile)))
+        assert bytes(pofile) == posource


### PR DESCRIPTION
Run detection starting at "msgid" string. This should be better way to
detect actual newlines used to detect the strings.

See https://github.com/WeblateOrg/weblate/issues/2519