### PR TITLE
Gettext: Strip UTF-8 BOM from input

### DIFF
--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -59,6 +59,10 @@ def splitlines(text):
     should safely cover weird newlines used in comments or filenames, while
     properly parsing po files with any newlines.
     """
+    # Strip UTF-8 BOM if present. This file would not be accepted
+    # by gettext, but some editors might create it, so better handle it.
+    if text[:3] == b'\xEF\xBB\xBF':
+        text = text[3:]
     # Find first newline
     newline = b'\n'
     msgid_pos = max(0, text.find(b'msgid'))

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -419,3 +419,18 @@ msgstr "FcoeClient"
         assert pofile.units[1].source == 'FcoeClient'
         print(repr(bytes(pofile)))
         assert bytes(pofile) == posource
+
+    def test_bom(self):
+        """checks that BOM is parsed"""
+        posource = '''msgid ""
+msgstr ""
+"Project-Id-Version: YaST (@memory@)\\n"
+
+msgid "FcoeClient"
+msgstr "FcoeClient"
+'''.encode('utf-8-sig')
+        pofile = self.poparse(posource)
+        assert len(pofile.units) == 2
+        assert pofile.units[0].source == ''
+        assert pofile.units[1].source == 'FcoeClient'
+        assert bytes(pofile) == posource[3:]


### PR DESCRIPTION
Such file is not conforming with how Gettext tools behave, but
apparently some editors create such files.

Fixes #1640