### PR TITLE
Misc: Remove has_key implementation

### DIFF
--- a/translate/misc/dictutils.py
+++ b/translate/misc/dictutils.py
@@ -74,9 +74,6 @@ class cidict(dict):
                 return 1
         return 0
 
-    def has_key(self, key):
-        return self.__contains__(key)
-
     def get(self, key, default=None):
         if key in self:
             return self[key]


### PR DESCRIPTION
It was deprecated in dict years ago and translate-toolkit doesn't use it
(see #3451), so there is no good reason to implement it.