### PR TITLE
XML indentation for Android, Resx and Xliff

### DIFF
--- a/translate/misc/test_xml_helpers.py
+++ b/translate/misc/test_xml_helpers.py
@@ -1,0 +1,35 @@
+from lxml import etree
+
+from translate.misc.xml_helpers import reindent
+
+
+class TestReindent:
+    def _xmlfromstring(self, xmlstring):
+        return etree.fromstring(xmlstring)
+
+    def _xmltostring(self, xml):
+        return etree.tostring(xml, pretty_print=True, xml_declaration=True, encoding='utf-8')
+
+    def test_indent_four_spaces(self):
+        """Test that using 4 spaces for indent yields a consistent result."""
+        xmlsource = self._xmlfromstring('<root><str key="test">Test</str></root>')
+        reindent(xmlsource, indent="    ")
+        actual = self._xmltostring(xmlsource)
+        expected = b'''<?xml version='1.0' encoding='utf-8'?>
+<root>
+    <str key="test">Test</str>
+</root>
+'''
+        assert actual == expected
+
+    def test_indent_tab(self):
+        """Test that using a tab for indent yields a consistent result."""
+        xmlsource = self._xmlfromstring('<root><str key="test">Test</str></root>')
+        reindent(xmlsource, indent="\t")
+        actual = self._xmltostring(xmlsource)
+        expected = b'''<?xml version='1.0' encoding='utf-8'?>
+<root>
+\t<str key="test">Test</str>
+</root>
+'''
+        assert actual == expected

--- a/translate/misc/xml_helpers.py
+++ b/translate/misc/xml_helpers.py
@@ -133,3 +133,33 @@ def normalize_xml_space(node, xml_space, remove_start=False):
 
     for child in node:
         normalize_xml_space(child, remove_start)
+
+
+def reindent(elem, level=0, indent="  ", max_level=4, skip=None):
+    """Adjust indentation to match specification.
+
+    Each nested tag is identified by indent string, up to
+    max_level depth, possibly skipping tags listed in skip.
+    """
+    i = "\n" + (indent * level)
+    if skip and elem.tag in skip:
+        next_level = level
+        extra_i = i
+    else:
+        next_level = level + 1
+        extra_i = i + indent
+    if len(elem) and level < max_level:
+        if (not elem.text or not elem.text.strip()) and getXMLspace(elem) != 'preserve':
+            elem.text = extra_i
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+        for child in elem:
+            reindent(child, next_level, indent, max_level)
+        if not child.tail or not child.tail.strip():
+            child.tail = i
+    if level:
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+    else:
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = ''

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -47,171 +47,171 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
 
     def test_escape_message_with_newline(self):
         string = 'message\nwith newline'
-        xml = '<string name="teststring">message\n\\nwith newline</string>\n\n'
+        xml = '<string name="teststring">message\n\\nwith newline</string>\n'
         self.__check_escape(string, xml)
 
     def test_escape_quotes_with_newline(self):
         string = '\'message\'\nwith newline'
-        xml = '<string name="teststring">\\\'message\\\'\n\\nwith newline</string>\n\n'
+        xml = '<string name="teststring">\\\'message\\\'\n\\nwith newline</string>\n'
         self.__check_escape(string, xml)
 
     def test_escape_message_with_newline_in_xml(self):
         string = 'message\n\nwith newline in xml\n'
         xml = ('<string name="teststring">message\n\\n\n\\nwith newline in xml\n\\n'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_twitter(self):
         string = '@twitterescape'
-        xml = '<string name="teststring">\\@twitterescape</string>\n\n'
+        xml = '<string name="teststring">\\@twitterescape</string>\n'
         self.__check_escape(string, xml)
 
     def test_escape_quote(self):
         string = 'quote \'escape\''
-        xml = '<string name="teststring">quote \\\'escape\\\'</string>\n\n'
+        xml = '<string name="teststring">quote \\\'escape\\\'</string>\n'
         self.__check_escape(string, xml)
 
     def test_escape_question(self):
         string = 'question?'
-        xml = '<string name="teststring">question\\?</string>\n\n'
+        xml = '<string name="teststring">question\\?</string>\n'
         self.__check_escape(string, xml)
 
     def test_escape_double_space(self):
         string = 'double  space'
-        xml = '<string name="teststring">"double  space"</string>\n\n'
+        xml = '<string name="teststring">"double  space"</string>\n'
         self.__check_escape(string, xml)
 
     def test_escape_leading_space(self):
         string = ' leading space'
-        xml = '<string name="teststring">" leading space"</string>\n\n'
+        xml = '<string name="teststring">" leading space"</string>\n'
         self.__check_escape(string, xml)
 
     def test_escape_tailing_space(self):
         string = 'tailing space '
-        xml = '<string name="teststring">"tailing space "</string>\n\n'
+        xml = '<string name="teststring">"tailing space "</string>\n'
         self.__check_escape(string, xml)
 
     def test_escape_xml_entities(self):
         string = '>xml&entities'
-        xml = '<string name="teststring">&gt;xml&amp;entities</string>\n\n'
+        xml = '<string name="teststring">&gt;xml&amp;entities</string>\n'
         self.__check_escape(string, xml)
 
     def test_escape_html_code(self):
         string = 'some <b>html code</b> here'
         xml = ('<string name="teststring">some <b>html code</b> here'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_html_code_quote(self):
         string = 'some <b>html code</b> \'here\''
         xml = ('<string name="teststring">some <b>html code</b> \\\'here\\\''
-               '</string>\n\n')
+               '</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_html_code_quote_newline(self):
         string = 'some \n<b>html code</b> \'here\''
         xml = ('<string name="teststring">some \n\\n<b>html code</b> \\\'here\\\''
-               '</string>\n\n')
+               '</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_arrows(self):
         string = '<<< arrow'
-        xml = '<string name="teststring">&lt;&lt;&lt; arrow</string>\n\n'
+        xml = '<string name="teststring">&lt;&lt;&lt; arrow</string>\n'
         self.__check_escape(string, xml)
 
     def test_escape_link(self):
         string = '<a href="http://example.net">link</a>'
         xml = ('<string name="teststring">\n'
                '  <a href="http://example.net">link</a>\n'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_link_and_text(self):
         string = '<a href="http://example.net">link</a> and text'
         xml = ('<string name="teststring"><a href="http://example.net">link'
-               '</a> and text</string>\n\n')
+               '</a> and text</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_blank_string(self):
         string = ''
-        xml = '<string name="teststring"></string>\n\n'
+        xml = '<string name="teststring"></string>\n'
         self.__check_escape(string, xml)
 
     def test_plural_escape_message_with_newline(self):
         mString = multistring(['one message\nwith newline', 'other message\nwith newline'])
         xml = ('<plurals name="teststring">\n'
-               '    <item quantity="one">one message\n\\nwith newline</item>\n'
-               '    <item quantity="other">other message\n\\nwith newline</item>\n'
-               '</plurals>\n\n')
+               '    <item quantity="one">one message\n\\nwith newline</item>'
+               '<item quantity="other">other message\n\\nwith newline</item>'
+               '</plurals>\n')
         self.__check_escape(mString, xml, 'en')
 
     def test_plural_invalid_lang(self):
         mString = multistring(['one message', 'other message'])
         xml = ('<plurals name="teststring">\n'
-               '    <item quantity="one">one message</item>\n'
-               '    <item quantity="other">other message</item>\n'
-               '</plurals>\n\n')
+               '    <item quantity="one">one message</item>'
+               '<item quantity="other">other message</item>'
+               '</plurals>\n')
         self.__check_escape(mString, xml, 'invalid')
 
     def test_escape_html_quote(self):
         string = 'start \'here\' <b>html code \'to escape\'</b> also \'here\''
         xml = ('<string name="teststring">start \\\'here\\\' <b>html code \\\'to escape\\\'</b> also \\\'here\\\''
-               '</string>\n\n')
+               '</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_html_leading_space(self):
         string = ' <b>html code \'to escape\'</b> some \'here\''
         xml = ('<string name="teststring"> <b>html code \\\'to escape\\\'</b> some \\\'here\\\''
-               '</string>\n\n')
+               '</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_html_trailing_space(self):
         string = '<b>html code \'to escape\'</b> some \'here\' '
         xml = ('<string name="teststring"><b>html code \\\'to escape\\\'</b> some \\\'here\\\' '
-               '</string>\n\n')
+               '</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_html_with_ampersand(self):
         string = '<b>html code \'to escape\'</b> some \'here\' with &amp; char'
         xml = ('<string name="teststring"><b>html code \\\'to escape\\\'</b> some \\\'here\\\' with &amp; char'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_html_double_space(self):
         string = '<b>html code \'to  escape\'</b> some \'here\''
         xml = ('<string name="teststring"><b>"html code \\\'to  escape\\\'"</b> some \\\'here\\\''
-               '</string>\n\n')
+               '</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_html_deep_double_space(self):
         string = '<b>html code \'to  <i>escape</i>\'</b> some \'here\''
         xml = ('<string name="teststring"><b>"html code \\\'to  "<i>escape</i>\\\'</b> some \\\'here\\\''
-               '</string>\n\n')
+               '</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_complex_xml(self):
         string = '<g:test xmlns:g="ttt" g:somevalue="aaaa  &quot;  aaa">value</g:test> &amp; outer &gt; <br/>text'
         xml = ('<string name="teststring">'
                '<g:test xmlns:g="ttt" g:somevalue="aaaa  &quot;  aaa">value</g:test> &amp; outer &gt; <br/>text'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_escape(string, xml)
 
     ############################ Check string parse ###########################
 
     def test_parse_message_with_newline(self):
         string = 'message\nwith newline'
-        xml = '<string name="teststring">message\\nwith newline</string>\n\n'
+        xml = '<string name="teststring">message\\nwith newline</string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_message_with_newline_in_xml(self):
         string = 'message \nwith\n newline\n in xml'
         xml = ('<string name="teststring">message\n\\nwith\\n\nnewline\\n\nin xml'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_parse(string, xml)
 
     def test_parse_twitter(self):
         string = '@twitterescape'
-        xml = '<string name="teststring">\\@twitterescape</string>\n\n'
+        xml = '<string name="teststring">\\@twitterescape</string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_question(self):
@@ -221,86 +221,86 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
 
     def test_parse_quote(self):
         string = 'quote \'escape\''
-        xml = '<string name="teststring">quote \\\'escape\\\'</string>\n\n'
+        xml = '<string name="teststring">quote \\\'escape\\\'</string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_double_space(self):
         string = 'double  space'
-        xml = '<string name="teststring">"double  space"</string>\n\n'
+        xml = '<string name="teststring">"double  space"</string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_leading_space(self):
         string = ' leading space'
-        xml = '<string name="teststring">" leading space"</string>\n\n'
+        xml = '<string name="teststring">" leading space"</string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_xml_entities(self):
         string = '>xml&entities'
-        xml = '<string name="teststring">&gt;xml&amp;entities</string>\n\n'
+        xml = '<string name="teststring">&gt;xml&amp;entities</string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_html_code(self):
         string = 'some <b>html code</b> here'
         xml = ('<string name="teststring">some <b>html code</b> here'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_parse(string, xml)
 
     def test_parse_arrows(self):
         string = '<<< arrow'
-        xml = '<string name="teststring">&lt;&lt;&lt; arrow</string>\n\n'
+        xml = '<string name="teststring">&lt;&lt;&lt; arrow</string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_link(self):
         string = '<a href="http://example.net">link</a>'
         xml = ('<string name="teststring"><a href="http://example.net">link'
-               '</a></string>\n\n')
+               '</a></string>\n')
         self.__check_parse(string, xml)
 
     def test_parse_link_and_text(self):
         string = '<a href="http://example.net">link</a> and text'
         xml = ('<string name="teststring"><a href="http://example.net">link'
-               '</a> and text</string>\n\n')
+               '</a> and text</string>\n')
         self.__check_parse(string, xml)
 
     def test_parse_blank_string(self):
         string = ''
-        xml = '<string name="teststring"></string>\n\n'
+        xml = '<string name="teststring"></string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_trailing_space(self):
         string = 'test'
-        xml = '<string name="teststring">test </string>\n\n'
+        xml = '<string name="teststring">test </string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_trailing_spaces(self):
         string = 'test'
-        xml = '<string name="teststring">test    </string>\n\n'
+        xml = '<string name="teststring">test    </string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_leading_spaces(self):
         string = 'test'
-        xml = '<string name="teststring">    test</string>\n\n'
+        xml = '<string name="teststring">    test</string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_trailing_newline(self):
         string = 'test'
-        xml = '<string name="teststring">test\n</string>\n\n'
+        xml = '<string name="teststring">test\n</string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_many_quotes(self):
         string = 'test'
-        xml = '<string name="teststring">""""""""""test"""""""</string>\n\n'
+        xml = '<string name="teststring">""""""""""test"""""""</string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_blank_string_again(self):
         string = ''
-        xml = '<string name="teststring"/>\n\n'
+        xml = '<string name="teststring"/>\n'
         self.__check_parse(string, xml)
 
     def test_parse_double_quotes_string(self):
         """Check that double quotes got removed."""
         string = 'double quoted text'
-        xml = '<string name="teststring">"double quoted text"</string>\n\n'
+        xml = '<string name="teststring">"double quoted text"</string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_newline_in_string(self):
@@ -309,76 +309,76 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
         At least it seems to be what Android does.
         """
         string = 'newline\nin string'
-        xml = '<string name="teststring">newline\\nin string</string>\n\n'
+        xml = '<string name="teststring">newline\\nin string</string>\n'
         self.__check_parse(string, xml)
 
     def test_parse_not_translatable_string(self):
         string = 'string'
         xml = ('<string name="teststring" translatable="false">string'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_parse(string, xml)
 
     def test_plural_parse_message_with_newline(self):
         mString = multistring(['one message\nwith newline', 'other message\nwith newline'])
         xml = ('<plurals name="teststring">\n'
                '    <item quantity="one">one message\\nwith newline</item>\n'
-               '    <item quantity="other">other message\\nwith newline</item>\n\n'
-               '</plurals>\n\n')
+               '    <item quantity="other">other message\\nwith newline</item>\n'
+               '</plurals>\n')
         self.__check_parse(mString, xml)
 
     def test_parse_html_quote(self):
         string = 'start \'here\' <b>html code \'to escape\'</b> also \'here\''
         xml = ('<string name="teststring">start \\\'here\\\' <b>html code \\\'to escape\\\'</b> also \\\'here\\\''
-               '</string>\n\n')
+               '</string>\n')
         self.__check_parse(string, xml)
 
     def test_parse_html_leading_space(self):
         string = ' <b>html code \'to escape\'</b> some \'here\''
         xml = ('<string name="teststring"> <b>html code \\\'to escape\\\'</b> some \\\'here\\\''
-               '</string>\n\n')
+               '</string>\n')
         self.__check_parse(string, xml)
 
     def test_parse_html_leading_space_quoted(self):
         string = ' <b>html code \'to escape\'</b> some \'here\''
         xml = ('<string name="teststring">" "<b>"html code \'to escape\'"</b>" some \'here\'"'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_parse(string, xml)
 
     def test_parse_html_trailing_space(self):
         string = '<b>html code \'to escape\'</b> some \'here\' '
         xml = ('<string name="teststring"><b>html code \\\'to escape\\\'</b> some \\\'here\\\' '
-               '</string>\n\n')
+               '</string>\n')
         self.__check_parse(string, xml)
 
     def test_parse_html_trailing_space_quoted(self):
         string = '<b>html code \'to escape\'</b> some \'here\' '
         xml = ('<string name="teststring"><b>"html code \'to escape\'"</b>" some \'here\' "'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_parse(string, xml)
 
     def test_parse_html_with_ampersand(self):
         string = '<b>html code \'to escape\'</b> some \'here\' with &amp; char'
         xml = ('<string name="teststring"><b>html code \\\'to escape\\\'</b> some \\\'here\\\' with &amp; char'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_parse(string, xml)
 
     def test_parse_html_double_space_quoted(self):
         string = '<b>html code \'to  escape\'</b> some \'here\''
         xml = ('<string name="teststring"><b>"html code \'to  escape\'"</b>" some \'here\'"'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_parse(string, xml)
 
     def test_parse_html_deep_double_space_quoted(self):
         string = '<b>html code \'to  <i>  escape</i>\'</b> some \'here\''
         xml = ('<string name="teststring"><b>"html code \'to  "<i>"  escape"</i>\\\'</b> some \\\'here\\\''
-               '</string>\n\n')
+               '</string>\n')
         self.__check_parse(string, xml)
 
     def test_parse_complex_xml(self):
         string = '<g:test xmlns:g="ttt" g:somevalue="aaaa  &quot;  aaa">value</g:test> outer &amp; text'
         xml = ('<string name="teststring">'
                '<g:test xmlns:g="ttt" g:somevalue="aaaa  &quot;  aaa">value</g:test> outer &amp; text'
-               '</string>\n\n')
+               '</string>\n')
         self.__check_parse(string, xml)
 
 

--- a/translate/storage/test_resx.py
+++ b/translate/storage/test_resx.py
@@ -82,7 +82,7 @@ class TestRESXUnitFromParsedString(TestRESXUnit):
     <value>2.0</value>
   </resheader>
   <data name="key" xml:space="preserve">
-     <value>Test String</value>
+    <value>Test String</value>
   </data>
   %s
 </root>

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -479,3 +479,34 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert newxfile.getfilenode("file0") is not None
         assert newxfile.getfilenode("file1") is not None
         assert not newxfile.getfilenode("foo")
+
+    def test_indent(self):
+        xlfsource = b'''<?xml version='1.0' encoding='UTF-8'?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.1" version="1.1">
+  <file original="doc.txt" source-language="en-US">
+    <body>
+      <trans-unit id="1" xml:space="preserve">
+        <source>File</source>
+        <target/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+'''
+        xlfsourcenote = b'''<?xml version='1.0' encoding='UTF-8'?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.1" version="1.1">
+  <file original="doc.txt" source-language="en-US">
+    <body>
+      <trans-unit id="1" xml:space="preserve">
+        <source>File</source>
+        <target/>
+        <note>Test note</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+'''
+        xfile = xliff.xlifffile.parsestring(xlfsource)
+        assert bytes(xfile) == xlfsource
+        xfile.units[0].addnote('Test note')
+        assert bytes(xfile) == xlfsourcenote

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -38,6 +38,7 @@ from lxml import etree
 from translate.lang import data
 from translate.misc.deprecation import deprecated
 from translate.misc.multistring import multistring
+from translate.misc.xml_helpers import reindent
 from translate.storage import base, lisa
 from translate.storage.placeables import general
 from translate.storage.workflow import StateEnum as state
@@ -174,11 +175,8 @@ class tsunit(lisa.LISAunit):
             for string in strings:
                 numerus = etree.SubElement(targetnode, self.namespaced("numerusform"))
                 numerus.text = data.forceunicode(string) or u""
-                # manual, nasty pretty printing. See bug 1420.
-                numerus.tail = u"\n        "
         else:
             targetnode.text = data.forceunicode(target) or u""
-            targetnode.tail = u"\n    "
 
     # Deprecated on 2.3.1
     @deprecated("Use `target` property instead")
@@ -509,6 +507,7 @@ class tsfile(lisa.LISAfile):
     def serialize(self, out):
         """Write the XML document to a file."""
         root = self.document.getroot()
+        reindent(root, indent="    ", skip=['TS'])
         doctype = self.document.docinfo.doctype
         # Iterate over empty tags without children and force empty text
         # This will prevent self-closing tags in pretty_print mode

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -27,7 +27,7 @@ from lxml import etree
 
 from translate.misc.deprecation import deprecated
 from translate.misc.multistring import multistring
-from translate.misc.xml_helpers import getXMLspace, setXMLlang, setXMLspace
+from translate.misc.xml_helpers import getXMLspace, setXMLlang, setXMLspace, reindent
 from translate.storage import base, lisa
 from translate.storage.placeables.lisa import strelem_to_xml, xml_to_strelem
 from translate.storage.workflow import StateEnum as state
@@ -872,6 +872,7 @@ class xlifffile(lisa.LISAfile):
 
     def serialize(self, out):
         self.removedefaultfile()
+        reindent(self.document.getroot(), indent="  ", max_level=4)
         super(xlifffile, self).serialize(out)
 
     @classmethod


### PR DESCRIPTION
This introduces generic XML formatting code based on #3670 and uses that in Android, Resx (what simplifies it's code) and Xliff (what fixes #3424).