### PR TITLE
Avoid using lxml 4.3.1

### DIFF
--- a/requirements/recommended.txt
+++ b/requirements/recommended.txt
@@ -5,7 +5,7 @@
 ###############
 
 # lxml - for XML processing (XLIFF, TMX, TBX, ts, Android)
-lxml>=3.5
+lxml>=3.5,!=4.3.1
 
 # Faster matching in e.g. pot2po
 python-Levenshtein>=0.12


### PR DESCRIPTION
It seems to be causing random segfaults on both Travis CI and AppVeyor.

Fixes #3873