### PR TITLE
CSV: Make default dialect more flexible

### DIFF
--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -34,7 +34,7 @@ from translate.storage import base
 
 class DefaultDialect(csv.excel):
     skipinitialspace = True
-    quoting = csv.QUOTE_NONNUMERIC
+    quoting = csv.QUOTE_ALL
     escapechar = '\\'
 
 

--- a/translate/storage/test_csvl10n.py
+++ b/translate/storage/test_csvl10n.py
@@ -44,6 +44,19 @@ class TestCSV(test_base.TestTranslationStore):
         assert store.units[0].target == 'zkouška sirén'
         assert bytes(store) == content
 
+    def test_default(self):
+        content = '''ID,English
+GENERAL@2|Notes,"cable, motor, switch"
+*****END CALL*****|Ask,-'''
+        store = self.parse_store(content)
+        assert len(store.units) == 3
+        assert store.units[0].location == 'ID'
+        assert store.units[0].source == 'English'
+        assert store.units[1].location == 'GENERAL@2|Notes'
+        assert store.units[1].source == 'cable, motor, switch'
+        assert store.units[2].location == '*****END CALL*****|Ask'
+        assert store.units[2].source == '-'
+
     @mark.xfail(reason="Bug #3356")
     def test_context_is_parsed(self):
         """Tests that units with the same source are different based on context."""


### PR DESCRIPTION
Changed default quoting to csv.QUOTE_ALL from csv.QUOTE_NONNUMERIC. The
problem with csv.QUOTE_NONNUMERIC is that it tries to convert all non
quoted stringst to float leading to exceptions when parsing the files
without quoted strings:

ValueError("could not convert string to float: 'ID'")

The root cause is that sniffer is not able to detect a delimiter, but
this seems to be fixed in Python 3.7.