### PR TITLE
Misc: Fix indentation of toplevel tags

### DIFF
--- a/translate/misc/xml_helpers.py
+++ b/translate/misc/xml_helpers.py
@@ -135,7 +135,7 @@ def normalize_xml_space(node, xml_space, remove_start=False):
         normalize_xml_space(child, remove_start)
 
 
-def reindent(elem, level=0, indent="  ", max_level=4, skip=None):
+def reindent(elem, level=0, indent="  ", max_level=4, skip=None, toplevel=True):
     """Adjust indentation to match specification.
 
     Each nested tag is identified by indent string, up to
@@ -154,12 +154,12 @@ def reindent(elem, level=0, indent="  ", max_level=4, skip=None):
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
         for child in elem:
-            reindent(child, next_level, indent, max_level)
+            reindent(child, next_level, indent, max_level, skip, False)
         if not child.tail or not child.tail.strip():
             child.tail = i
-    if level:
-        if not elem.tail or not elem.tail.strip():
-            elem.tail = i
-    else:
+    if toplevel:
         if not elem.tail or not elem.tail.strip():
             elem.tail = ''
+    else:
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i

--- a/translate/storage/test_ts2.py
+++ b/translate/storage/test_ts2.py
@@ -64,6 +64,27 @@ The other line&apos;s translation may have quotes, too (&quot;&apos;&quot;,
 </TS>
 """
 
+TS_CONTEXT = """<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="cs">
+<defaultcodec>UTF-8</defaultcodec>
+<context>
+    <name></name>
+    <message>
+        <source>Hello, world!</source>
+        <translation>Ahoj svete!</translation>
+    </message>
+</context>
+<context>
+    <name>Second</name>
+    <message>
+        <source>Obsolete</source>
+        <translation type="obsolete">Thanks</translation>
+    </message>
+</context>
+</TS>
+"""
+
 xliffparsers = []
 for attrname in dir(xliff):
     attr = getattr(xliff, attrname)
@@ -293,3 +314,7 @@ class TestTSfile(test_base.TestTranslationStore):
         assert newunit.getcontext() == ""
         newunit.setcontext("Some context")
         assert newunit.getcontext() == "Some context"
+
+    def test_roundtrip_context(self):
+        tsfile = ts.tsfile.parsestring(TS_CONTEXT)
+        assert bytes(tsfile).decode('utf-8') == TS_CONTEXT


### PR DESCRIPTION
The toplevel tags were wrongly indented in some cases.