### PR TITLE
CSV: Avoid hardcoding escape char

### DIFF
--- a/translate/convert/test_csv2po.py
+++ b/translate/convert/test_csv2po.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from translate.convert import csv2po, test_convert
 from translate.misc import wStringIO
 from translate.storage import csvl10n, po
@@ -122,6 +125,14 @@ msgstr ""
         assert pounit._extract_msgidcomments() == 'KDE comment'
         assert pounit.source == "Source"
         assert pounit.target == "Target"
+
+    def test_newlines(self):
+        """Tests that things keep working with empty entries"""
+        minicsv = '"source","target"\r\n"yellow pencil","żółty\\nołówek"'
+        pofile = self.csv2po(minicsv)
+        assert pofile.findunit("yellow pencil") is not None
+        assert pofile.findunit("yellow pencil").target == "żółty\\nołówek"
+        assert headerless_len(pofile.units) == 1
 
 
 class TestCSV2POCommand(test_convert.TestConvertCommand, TestCSV2PO):

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -301,12 +301,10 @@ class csvfile(base.TranslationStore):
 
         try:
             self.dialect = sniffer.sniff(sample)
-            if not self.dialect.escapechar:
-                self.dialect.escapechar = '\\'
-                if self.dialect.quoting == csv.QUOTE_MINIMAL:
-                    #HACKISH: most probably a default, not real detection
-                    self.dialect.quoting = csv.QUOTE_ALL
-                    self.dialect.doublequote = True
+            if self.dialect.quoting == csv.QUOTE_MINIMAL:
+                #HACKISH: most probably a default, not real detection
+                self.dialect.quoting = csv.QUOTE_ALL
+                self.dialect.doublequote = True
         except csv.Error:
             self.dialect = 'default'
 

--- a/translate/storage/test_csvl10n.py
+++ b/translate/storage/test_csvl10n.py
@@ -73,3 +73,11 @@ GENERAL@2|Notes,"cable, motor, switch"
         assert unit2.source == "Ogre"
         assert unit2.target == "Ogros"
         assert unit1.getid() != unit2.getid()
+
+    def test_newline(self):
+        content = b'"location";"source";"target"\r\n"foo.c:1";"te\\nst";"ot\\nher"\r\n'
+        store = self.parse_store(content)
+        assert len(store.units) == 1
+        assert store.units[0].source == 'te\\nst'
+        assert store.units[0].target == 'ot\\nher'
+        assert bytes(store) == content


### PR DESCRIPTION
Really rely on sniffer here, otherwise we might strip too much (the
escape char in CSV is meant only for quotes, otherwise the parser just
strips the escape char).

Fixes #3246