### PR TITLE
Storage: consistent API for removenotes

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -408,7 +408,7 @@ class AndroidResourceUnit(base.TranslationUnit):
         else:
             return super(AndroidResourceUnit, self).getnotes(origin)
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         if ((self.xmlelement is not None) and (self.xmlelement.getparent is not None)):
             prevSibling = self.xmlelement.getprevious()
             while ((prevSibling is not None) and (prevSibling.tag is etree.Comment)):

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -355,7 +355,7 @@ class TranslationUnit(object):
         else:
             self.notes = text
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         """Remove all the translator's notes."""
         self.notes = u''
 

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -520,7 +520,7 @@ class pounit(pocommon.pounit):
             else:
                 gpo.po_message_set_comments(self._gpo_message, newnotes)
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         gpo.po_message_set_comments(self._gpo_message, b"")
 
     def copy(self):

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -115,7 +115,7 @@ class csvunit(base.TranslationUnit):
             else:
                 self.translator_comments = text
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         self.translator_comments = u''
 
     def isfuzzy(self):

--- a/translate/storage/fpo.py
+++ b/translate/storage/fpo.py
@@ -172,7 +172,7 @@ class pounit(pocommon.pounit):
         else:
             self.othercomments = newcomments
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         """Remove all the translator's notes (other comments)"""
         self.othercomments = []
 

--- a/translate/storage/omegat.py
+++ b/translate/storage/omegat.py
@@ -115,7 +115,7 @@ class OmegaTUnit(base.TranslationUnit):
         else:
             self._set_field('comment', text)
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         self._set_field('comment', u'')
 
     @property

--- a/translate/storage/php.py
+++ b/translate/storage/php.py
@@ -303,7 +303,7 @@ class phpunit(base.TranslationUnit):
         else:
             return super(phpunit, self).getnotes(origin)
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         self._comments = []
 
     def isblank(self):

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -593,7 +593,7 @@ class propunit(base.TranslationUnit):
         else:
             return super(propunit, self).getnotes(origin)
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         self.comments = []
 
     def isblank(self):

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -418,7 +418,7 @@ class pounit(pocommon.pounit):
         else:
             self.othercomments = newcomments
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         """Remove all the translator's notes (other comments)"""
         self.othercomments = []
 

--- a/translate/storage/qph.py
+++ b/translate/storage/qph.py
@@ -65,7 +65,7 @@ class QphUnit(lisa.LISAunit):
     def addnote(self, text, origin=None, position="append"):
         """Add a note specifically in a "definition" tag"""
         current_notes = self.getnotes(origin)
-        self.removenotes()
+        self.removenotes(origin)
         note = etree.SubElement(self.xmlelement, self.namespaced("definition"))
         note.text = "\n".join(filter(None, [current_notes, text.strip()]))
 
@@ -77,7 +77,7 @@ class QphUnit(lisa.LISAunit):
             comment = notenode.text
         return comment
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         """Remove all the translator notes."""
         note = self.xmlelement.find(self.namespaced("definition"))
         if note is not None:

--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -114,7 +114,7 @@ class rcunit(base.TranslationUnit):
     def getnotes(self, origin=None):
         return '\n'.join(self.comments)
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         self.comments = []
 
     def isblank(self):

--- a/translate/storage/tbx.py
+++ b/translate/storage/tbx.py
@@ -51,7 +51,7 @@ class tbxunit(lisa.LISAunit):
         # The id attribute is optional
         return self.xmlelement.get("id") or self.source
 
-    def removenotes(self, origin="translator"):
+    def removenotes(self, origin=None):
         """Remove all the translator notes."""
         notes = self.xmlelement.iterdescendants(self.namespaced("note"))
         for note in notes:

--- a/translate/storage/tmx.py
+++ b/translate/storage/tmx.py
@@ -81,7 +81,7 @@ class tmxunit(lisa.LISAunit):
     def getnotes(self, origin=None):
         return '\n'.join(self._getnotelist(origin=origin))
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         """Remove all the translator notes."""
         notes = self.xmlelement.iterdescendants(self.namespaced("note"))
         for note in notes:

--- a/translate/storage/utx.py
+++ b/translate/storage/utx.py
@@ -140,7 +140,7 @@ class UtxUnit(base.TranslationUnit):
         else:
             self._set_field('comment', text)
 
-    def removenotes(self):
+    def removenotes(self, origin=None):
         self._set_field('comment', u'')
 
     @property

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -357,7 +357,7 @@ class xliffunit(lisa.LISAunit):
     def getnotes(self, origin=None):
         return '\n'.join(self._getnotelist(origin=origin))
 
-    def removenotes(self, origin="translator"):
+    def removenotes(self, origin=None):
         """Remove all the translator notes."""
         notes = self.xmlelement.iterdescendants(self.namespaced("note"))
         for note in notes:


### PR DESCRIPTION
Similarly like with addnote and getnotes, this now accepts origin on all
storages, even when most of them do ignore it.