### PR TITLE
Change empty file handling

### DIFF
--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -774,11 +774,10 @@ class TranslationStore(object):
     def parsestring(cls, storestring):
         """Convert the string representation back to an object."""
         newstore = cls()
-        if storestring:
-            if isinstance(storestring, six.text_type):
-                # parse() is expecting bytes
-                storestring = storestring.encode(cls.default_encoding)
-            newstore.parse(storestring)
+        if isinstance(storestring, six.text_type):
+            # parse() is expecting bytes
+            storestring = storestring.encode(cls.default_encoding)
+        newstore.parse(storestring)
         return newstore
 
     def fallback_detection(self, text):
@@ -895,9 +894,10 @@ class TranslationStore(object):
         if mode == 1 or "r" in mode:
             storestring = storefile.read()
             storefile.close()
+            newstore = cls.parsestring(storestring)
         else:
             storestring = ""
-        newstore = cls.parsestring(storestring)
+            newstore = cls()
         newstore.fileobj = storefile
         newstore._assignname()
         return newstore

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -634,7 +634,7 @@ class propfile(base.TranslationStore):
         text, encoding = self.detect_encoding(
             propsrc, default_encodings=[self.personality.default_encoding,
                                         'utf-8', 'utf-16'])
-        if not text:
+        if not text and propsrc:
             raise IOError("Cannot detect encoding for %s." % (self.filename or
                                                               "given string"))
         self.encoding = encoding


### PR DESCRIPTION
I'm not sure with this change, but to me it looks weird that *all* formats accept empty files through `parsefile` or `parsestring` even when those are not syntactically valid (eg. XML or JSON based formats).

The code in question was introduced in https://github.com/translate/translate/commit/9141370e95ac5ced702aa1b503d1cfbb96051c6a where it was ported from some formats.