### PR TITLE
RESX: Consistent formatting with Visual Studio

### DIFF
--- a/translate/convert/test_po2resx.py
+++ b/translate/convert/test_po2resx.py
@@ -26,48 +26,48 @@ from translate.misc import wStringIO
 
 
 class TestPO2RESX(object):
-    XMLskeleton = '''<?xml version='1.0' encoding='UTF-8'?>
+    XMLskeleton = '''<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -81,8 +81,7 @@ class TestPO2RESX(object):
     <value>2.0</value>
   </resheader>
   %s
-</root>
-'''
+</root>'''
 
     def po2resx(self, resxsource, po_source):
         """ Helper that merges po translations to .resx source without requiring files """
@@ -215,22 +214,22 @@ msgid ""
 msgstr "Drie"
 '''
         resx_template = self.XMLskeleton % '''<data name="ResourceKey" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="ResourceKey2" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="ResourceKey3" xml:space="preserve">
-    <value/>
+    <value />
   </data>'''
         expected_output = self.XMLskeleton % '''<data name="ResourceKey" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="ResourceKey2" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="ResourceKey3" xml:space="preserve">
-    <value/>
+    <value />
   </data>'''
         resx_file = self.po2resx(resx_template, po_source)
         assert resx_file == expected_output

--- a/translate/storage/resx.py
+++ b/translate/storage/resx.py
@@ -243,5 +243,11 @@ class RESXFile(lisa.LISAfile):
         return unit
 
     def serialize(self, out=None):
-        reindent(self.document.getroot(), indent="  ", max_level=4)
-        super(RESXFile, self).serialize(out)
+        root = self.document.getroot()
+        reindent(root, indent="  ", max_level=4)
+        # Use same header as Visual Studio
+        out.write(b'<?xml version="1.0" encoding="utf-8"?>\n')
+        content = etree.tostring(root, pretty_print=False, xml_declaration=False,
+                                 encoding='utf-8')
+        # Additional space on empty tags same as Visual Studio
+        out.write(content.replace(b'/>', b' />'))

--- a/translate/storage/test_resx.py
+++ b/translate/storage/test_resx.py
@@ -27,48 +27,48 @@ class TestRESXUnit(test_monolingual.TestMonolingualUnit):
 
 
 class TestRESXUnitFromParsedString(TestRESXUnit):
-    resxsource = XMLskeleton = '''<?xml version='1.0' encoding='UTF-8'?>
+    resxsource = XMLskeleton = '''<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -85,8 +85,7 @@ class TestRESXUnitFromParsedString(TestRESXUnit):
     <value>Test String</value>
   </data>
   %s
-</root>
-'''
+</root>'''
 
     def setup_method(self, method):
         self.store = resx.RESXFile.parsestring(self.resxsource % '')


### PR DESCRIPTION
Make formatting consistent with Visual Studio output:

- use double quotes in XML declaration
- remove trailing end line
- add space before empty tags closing

Addresses https://github.com/WeblateOrg/weblate/issues/2807