### PR TITLE
pypo: raise erorr on invalid file content

### DIFF
--- a/translate/storage/poparser.py
+++ b/translate/storage/poparser.py
@@ -53,6 +53,7 @@ class ParseState(object):
         # and for decoding all further strings.
         self._input_iterator = input_iterator
         self.next_line = ''
+        self.lineno = 0
         self.eof = False
         self.encoding = encoding
         self.read_line()
@@ -70,8 +71,10 @@ class ParseState(object):
             return current
         try:
             self.next_line = next(self._input_iterator)
+            self.lineno += 1
             while not self.eof and self.next_line.isspace():
                 self.next_line = next(self._input_iterator)
+                self.lineno += 1
         except StopIteration:
             self.next_line = u''
             self.eof = True
@@ -372,4 +375,5 @@ def parse_units(parse_state, store):
         unit.infer_state()
         store.addunit(unit)
         unit = parse_unit(parse_state)
-    return parse_state.eof
+    if not parse_state.eof:
+        raise ValueError('Syntax error on line {}'.format(parse_state.lineno))

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -514,3 +514,23 @@ msgstr ""
         pofile = self.poparse(posource_extra.encode('utf-8'))
         assert len(pofile.units) == 1
         assert bytes(pofile).decode('utf-8') == posource
+
+    def test_incomplete(self):
+        """checks that empty file raises error"""
+        posource = b'''msgid ""
+msgstr ""
+"Project-Id-Version: YaST (@memory@)\\n"
+
+EXTRA
+'''
+        with raises(ValueError):
+            pofile = self.poparse(posource)
+
+    def test_invalid(self):
+        """checks that empty file raises error"""
+        posource = b'''README
+
+This is just a random text file.
+'''
+        with raises(ValueError):
+            pofile = self.poparse(posource)


### PR DESCRIPTION
The pypo parser happily parsed any file as containing no unit - it just
stopped on first line and did not report any error. Now the ValueError
is raised in case it can not parse the whole file.