### PR TITLE
pypo: Fix handing typecomments with non word chars

### DIFF
--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -553,15 +553,21 @@ class pounit(pocommon.pounit):
         # Before, the equivalent of the following was the final return statement:
         # return len(self.source.strip()) == 0
 
-    def hastypecomment(self, typecomment):
+    def _extracttypecomment(self):
+        for tc in self.typecomments:
+            for flag in tc.split(","):
+                value = flag.strip()
+                if not value or value == '#':
+                    continue
+                yield value
+
+    def hastypecomment(self, typecomment, parsed=None):
         """Check whether the given type comment is present"""
         if not self.typecomments:
             return False
-        for tc in self.typecomments:
-            # check for word boundaries properly by using a regular expression
-            if re.search("\\b%s\\b" % typecomment, tc):
-                return True
-        return False
+        if not parsed:
+            parsed = self._extracttypecomment()
+        return typecomment in parsed
 
     def hasmarkedcomment(self, commentmarker):
         """Check whether the given comment marker is present.
@@ -578,8 +584,8 @@ class pounit(pocommon.pounit):
 
     def settypecomment(self, typecomment, present=True):
         """Alters whether a given typecomment is present"""
-        if self.hastypecomment(typecomment) != present:
-            typecomments = re.findall(r"\b[-\w]+\b", "\n".join(self.typecomments))
+        typecomments = list(self._extracttypecomment())
+        if self.hastypecomment(typecomment, typecomments) != present:
             if present:
                 typecomments.append(typecomment)
             else:

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -262,6 +262,26 @@ class TestPYPOFile(test_po.TestPOFile):
         assert pofile.units[0].sourcecomments == ["#: source comment\n"]
         assert pofile.units[0].typecomments == ["#, fuzzy\n"]
 
+    def test_typecomments(self):
+        """test typecomments handling"""
+        posource = """#: 00-8C-41-10-00-00-31-10-12-05-42-44-00-2E
+#, max-length:10
+msgctxt "0"
+msgid "Aurora"
+msgstr ""
+"""
+        pofile = self.poparse(posource)
+        print(pofile)
+        assert len(pofile.units) == 1
+        assert bytes(pofile).decode('utf-8') == posource
+        unit = pofile.units[0]
+        assert unit.typecomments == ["#, max-length:10\n"]
+        assert unit.hastypecomment("max-length:10") is True
+        unit.target = "Aurora"
+        unit.markfuzzy()
+        assert unit.typecomments == ["#, fuzzy, max-length:10\n"]
+        assert unit.hastypecomment("max-length:10") is True
+
     def test_unassociated_comments(self):
         """tests behaviour of unassociated comments."""
         oldsource = '# old lonesome comment\n\nmsgid "one"\nmsgstr "een"\n'


### PR DESCRIPTION
Addresses situation when typecomments contain more complex things than just those few defined by gettext.