### PR TITLE
Android: Fix XML enttites handling

### DIFF
--- a/translate/misc/xml_helpers.py
+++ b/translate/misc/xml_helpers.py
@@ -141,6 +141,8 @@ def reindent(elem, level=0, indent="  ", max_level=4, skip=None, toplevel=True):
     Each nested tag is identified by indent string, up to
     max_level depth, possibly skipping tags listed in skip.
     """
+    if elem.tag is etree.Entity:
+        return
     i = "\n" + (indent * level)
     if skip and elem.tag in skip:
         next_level = level
@@ -149,13 +151,15 @@ def reindent(elem, level=0, indent="  ", max_level=4, skip=None, toplevel=True):
         next_level = level + 1
         extra_i = i + indent
     if len(elem) and level < max_level:
-        if (not elem.text or not elem.text.strip()) and getXMLspace(elem) != 'preserve':
+        if ((not elem.text or not elem.text.strip())
+                and getXMLspace(elem) != 'preserve'
+                and elem[0].tag is not etree.Entity):
             elem.text = extra_i
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
         for child in elem:
             reindent(child, next_level, indent, max_level, skip, False)
-        if not child.tail or not child.tail.strip():
+        if (not child.tail or not child.tail.strip()) and child.tag is not etree.Entity:
             child.tail = i
     if toplevel:
         if not elem.tail or not elem.tail.strip():

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -472,3 +472,20 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
         otherstore.parse(other)
         store.addunit(otherstore.units[0], True)
         assert bytes(store) == expected
+
+    def test_entity(self):
+        content = b'''<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE resources [
+<!ENTITY appName "Linphone">
+]>
+<resources>
+    <string name="app_name">&appName;</string>
+    <string name="app_core">&appName; Core</string>
+</resources>'''
+        store = self.StoreClass()
+        store.parse(content)
+        assert store.units[0].source == "&appName;"
+        store.units[0].target = "&appName;"
+        assert store.units[1].source == "&appName; Core"
+        store.units[1].target = "&appName; Core"
+        assert bytes(store) == content


### PR DESCRIPTION
Properly parse, indent and store XML entities.

Fixes #3907