### PR TITLE
pypo: Fix serializing long msgidcomments

### DIFF
--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -664,6 +664,9 @@ class pounit(pocommon.pounit):
                     #Before we used to strip. Necessary in some cases?
                     combinedcomment.append(comment)
                 partcomments = self.quote("_:%s" % "".join(combinedcomment))
+                # Strip heading empty line for multiline string, it was already added above
+                if partcomments[0] == '""':
+                    partcomments = partcomments[1:]
             # comments first, no blank leader line needed
             partstr += "\n".join(partcomments)
             partstr = quote.rstripeol(partstr)
@@ -671,7 +674,12 @@ class pounit(pocommon.pounit):
             partstr += '""'
         partstr += '\n'
         # add the rest
+        previous = None
         for partline in partlines[partstartline:]:
+            # Avoid duplicate empty lines
+            if previous == '""' and partline == '""':
+                continue
+            previous = partline
             partstr += partline + '\n'
         return partstr
 

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -461,3 +461,36 @@ msgstr "FcoeClient"
         assert pofile.units[0].source == ''
         assert pofile.units[1].source == 'FcoeClient'
         assert bytes(pofile) == posource[3:]
+
+    def test_long_msgidcomments(self):
+        posource = """#: networkstatus/connectionmanager.cpp:148
+msgid ""
+"_: Message shown when a network connection failed.  The placeholder contains "
+"the concrete description of the operation eg 'while performing this "
+"operation\\n"
+""
+"A network connection failed %1.  Do you want to place the application in "
+"offline mode?"
+msgstr ""
+"Připojení k síti se nezdařilo: %1. Chcete aplikaci přepnout do režimu "
+"offline?"
+"""
+        pofile = self.poparse(posource.encode('utf-8'))
+        assert len(pofile.units) == 1
+        assert bytes(pofile).decode('utf-8') == posource
+        posource_extra = """#: networkstatus/connectionmanager.cpp:148
+msgid ""
+""
+"_: Message shown when a network connection failed.  The placeholder contains "
+"the concrete description of the operation eg 'while performing this "
+"operation\\n"
+""
+"A network connection failed %1.  Do you want to place the application in "
+"offline mode?"
+msgstr ""
+"Připojení k síti se nezdařilo: %1. Chcete aplikaci přepnout do režimu "
+"offline?"
+"""
+        pofile = self.poparse(posource_extra.encode('utf-8'))
+        assert len(pofile.units) == 1
+        assert bytes(pofile).decode('utf-8') == posource


### PR DESCRIPTION
This repeatedly added blank lines to the output, see https://github.com/WeblateOrg/weblate/issues/2954