### PR TITLE
properties: Fix saving utf-16 java files

### DIFF
--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -255,7 +255,7 @@ class Dialect(object):
         """Encode the string"""
         # FIXME: dialects are a bad idea, not possible for subclasses
         # to override key methods
-        if encoding != "utf-8":
+        if encoding not in ("utf-8", "utf-16"):
             return quote.javapropertiesencode(string or u"")
         return quote.java_utf8_properties_encode(string or u"")
 
@@ -348,6 +348,17 @@ class DialectJava(Dialect):
 class DialectJavaUtf8(DialectJava):
     name = "java-utf8"
     default_encoding = "utf-8"
+    delimiters = [u"=", u":", u" "]
+
+    @classmethod
+    def encode(cls, string, encoding=None):
+        return quote.java_utf8_properties_encode(string or u"")
+
+
+@register_dialect
+class DialectJavaUtf16(DialectJava):
+    name = "java-utf16"
+    default_encoding = "utf-16"
     delimiters = [u"=", u":", u" "]
 
     @classmethod
@@ -725,6 +736,16 @@ class javautf8file(propfile):
     def __init__(self, *args, **kwargs):
         kwargs['personality'] = "java-utf8"
         kwargs['encoding'] = "utf-8"
+        super(javautf8file, self).__init__(*args, **kwargs)
+
+
+class javautf16file(propfile):
+    Name = "Java Properties (UTF-16)"
+    Extensions = ['properties']
+
+    def __init__(self, *args, **kwargs):
+        kwargs['personality'] = "java-utf16"
+        kwargs['encoding'] = "utf-16"
         super(javautf8file, self).__init__(*args, **kwargs)
 
 

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -262,6 +262,17 @@ key=value
         assert propunit.name == u'I am a "key"'
         assert propunit.source == u'I am a "value"'
 
+    def test_utf_16_save(self):
+        """test saving of utf-16 java properties files"""
+        propsource = u'''key=zkouška\n'''.encode('utf-16')
+        propfile = self.propparse(propsource, personality="java-utf16")
+        assert propfile.encoding == 'utf-16'
+        assert len(propfile.units) == 1
+        propunit = propfile.units[0]
+        assert propunit.name == u'key'
+        assert propunit.source == u'zkouška'
+        assert bytes(propfile) == propsource
+
     def test_mac_multiline_strings(self):
         """test can read multiline items used in Mac OS X strings files"""
         propsource = (r'''"I am a \"key\"" = "I am a \"value\" ''' +


### PR DESCRIPTION
Without this the files in utf-16 encoding get saved with escaped unicode chars, see https://github.com/WeblateOrg/weblate/issues/3099