### PR TITLE
Android: Fix indentation of markup in translation

### DIFF
--- a/translate/misc/xml_helpers.py
+++ b/translate/misc/xml_helpers.py
@@ -135,7 +135,7 @@ def normalize_xml_space(node, xml_space, remove_start=False):
         normalize_xml_space(child, remove_start)
 
 
-def reindent(elem, level=0, indent="  ", max_level=4, skip=None, toplevel=True):
+def reindent(elem, level=0, indent="  ", max_level=4, skip=None, toplevel=True, leaves=None):
     """Adjust indentation to match specification.
 
     Each nested tag is identified by indent string, up to
@@ -151,16 +151,19 @@ def reindent(elem, level=0, indent="  ", max_level=4, skip=None, toplevel=True):
         next_level = level + 1
         extra_i = i + indent
     if len(elem) and level < max_level:
+        is_leave = leaves and elem.tag in leaves
         if ((not elem.text or not elem.text.strip())
                 and getXMLspace(elem) != 'preserve'
-                and elem[0].tag is not etree.Entity):
+                and elem[0].tag is not etree.Entity
+                and not is_leave):
             elem.text = extra_i
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
-        for child in elem:
-            reindent(child, next_level, indent, max_level, skip, False)
-        if (not child.tail or not child.tail.strip()) and child.tag is not etree.Entity:
-            child.tail = i
+        if not is_leave:
+            for child in elem:
+                reindent(child, next_level, indent, max_level, skip, False, leaves)
+            if (not child.tail or not child.tail.strip()) and child.tag is not etree.Entity:
+                child.tail = i
     if toplevel:
         if not elem.tail or not elem.tail.strip():
             elem.tail = ''

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -465,7 +465,7 @@ class AndroidResourceFile(lisa.LISAfile):
     def serialize(self, out=None):
         """Converts to a string containing the file's XML"""
         out.write(b'<?xml version="1.0" encoding="utf-8"?>\n')
-        reindent(self.document.getroot(), indent="    ", max_level=3)
+        reindent(self.document.getroot(), indent="    ", leaves=('string', 'item'))
         self.document.write(out, pretty_print=False, xml_declaration=False,
                             encoding='utf-8')
 

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -499,3 +499,15 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
         assert store.units[1].source == "&appName; Core"
         store.units[1].target = "&appName; Core"
         assert bytes(store) == content
+
+    def test_indent(self):
+        content = '''<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE resources [
+<!ENTITY url_privacy_policy "http://example.com/">
+]>
+<resources>
+    <string name="privacy_policy"><u><a href="&url_privacy_policy;">Datenschutzerklärung</a></u></string>
+</resources>'''.encode('utf-8')
+        store = self.StoreClass()
+        store.parse(content)
+        assert bytes(store) == content


### PR DESCRIPTION
The whitespace can have meaning there even if xml:whitespace is not set.