### PR TITLE
Android: Fix setting plural with markup

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -298,7 +298,7 @@ class AndroidResourceUnit(base.TranslationUnit):
             if self._store is not None:
                 cloned_doc = copy.deepcopy(self._store.document)
                 cloned_root = cloned_doc.getroot()
-                for child in cloned_root.xpath('//string'):
+                for child in cloned_root.xpath('*'):
                     cloned_root.remove(child)
                 template = etree.tostring(cloned_doc, encoding='unicode')
             else:

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -511,3 +511,22 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         store.parse(content)
         assert bytes(store) == content
+
+    def test_edit_plural_markup(self):
+        content = '''<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="teststring">
+        <item quantity="one"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> den</item>
+        <item quantity="few"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dny</item>
+        <item quantity="other"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu</item>
+    </plurals>
+</resources>'''.encode('utf-8')
+        store = self.StoreClass()
+        store.targetlanguage = 'cs'
+        store.parse(content)
+        store.units[0].target = multistring([
+            '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> den',
+            '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dny',
+            '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu',
+        ])
+        assert bytes(store) == content


### PR DESCRIPTION
Generating template from the file failed to remove plurals and other elements leading to generating messed up output as can be seen here: https://github.com/Etar-Group/Etar-Calendar/pull/580/commits/75c18f1e3223b3c1d7b520e88635f58abb4f24e1