### PR TITLE
po <-> web2py: don't copy "@markmin" string

### DIFF
--- a/translate/convert/po2web2py.py
+++ b/translate/convert/po2web2py.py
@@ -47,7 +47,7 @@ class po2pydict(object):
             if unit.istranslated() or (includefuzzy and unit.isfuzzy()):
                 mydict[unit.source] = unit.target
             else:
-                mydict[unit.source] = unit.source
+                mydict[unit.source] = unit.source.replace('@markmin\x01', '')
 
         str_obj.write(u'# -*- coding: utf-8 -*-\n')
         str_obj.write(u'{\n')

--- a/translate/convert/test_po2web2py.py
+++ b/translate/convert/test_po2web2py.py
@@ -71,3 +71,17 @@ msgstr "zab"
 '''
         web2py_out = self.po2web2py(input_po)
         assert web2py_out == expected_web2py
+
+    def test_markmin(self):
+        """test removal of @markmin in po to web2py conversion"""
+        input_po = '''
+msgid "@markmin\x01Hello **world**!"
+msgstr ""
+'''
+        expected_web2py = '''# -*- coding: utf-8 -*-
+{
+'@markmin\\x01Hello **world**!': 'Hello **world**!',
+}
+'''
+        web2py_out = self.po2web2py(input_po)
+        assert web2py_out == expected_web2py

--- a/translate/convert/test_web2py2po.py
+++ b/translate/convert/test_web2py2po.py
@@ -50,3 +50,16 @@ class TestWEB2PY2PO(object):
         pounit = self.singleelement(po_out)
         assert pounit.source == "Foobar"
         assert pounit.target == "Fúbär"
+
+    def test_markmin(self):
+        """test removal of @markmin in po to web2py conversion"""
+        input_web2py = '''# -*- coding: utf-8 -*-
+{
+'@markmin\\x01Hello **world**!': 'Hello **world**!',
+}
+'''
+
+        po_out = self.web2py2po(input_web2py)
+        pounit = self.singleelement(po_out)
+        assert pounit.source == "@markmin\x01Hello **world**!"
+        assert pounit.target == ""

--- a/translate/convert/web2py2po.py
+++ b/translate/convert/web2py2po.py
@@ -52,7 +52,7 @@ class web2py2po(object):
             if six.PY2:
                 target_str = target_str.decode('utf-8')
                 source_str = source_str.decode('utf-8')
-            if target_str == source_str:
+            if target_str == source_str.replace('@markmin\x01', ''):
                 # a convention with new (untranslated) web2py files
                 target_str = u''
             pounit = self.convertunit(source_str, target_str)


### PR DESCRIPTION
web2py includes `@markmin\x01` in the unit's source string when the string uses web2py's markmin formatting.  However, it does not copy over to the translation.  This PR updates the converter to reflect this same behavior, allowing a smoother experience.