### PR TITLE
Properties: Avoid creating comment only units

### DIFF
--- a/translate/convert/test_prop2po.py
+++ b/translate/convert/test_prop2po.py
@@ -205,7 +205,7 @@ do=translate me
         unit = self.singleelement(pofile)
         assert unit.source == "\nvalue\n"
 
-    def test_unassociated_comments(self):
+    def test_header_comments(self):
         """check that we can handle comments not directly associated with a property"""
         propsource = '''# Header comment\n\n# Comment\n\nprop=value\n'''
         pofile = self.prop2po(propsource)
@@ -219,7 +219,7 @@ do=translate me
         pofile = self.prop2po(propsource)
         unit = self.singleelement(pofile)
         assert unit.source == "value"
-        assert unit.getnotes("developer") == "# 1st Unassociated comment\n# 2nd Connected comment"
+        assert unit.getnotes("developer") == "# 1st Unassociated comment\n\n# 2nd Connected comment"
 
     def test_x_header(self):
         """Test that we correctly create the custom header entries

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -654,6 +654,7 @@ class propfile(base.TranslationStore):
         newunit = propunit("", self.personality.name)
         inmultilinevalue = False
         inmultilinecomment = False
+        was_header = False
 
         for line in propsrc.split(u"\n"):
             # handle multiline value if we're in one
@@ -685,9 +686,16 @@ class propfile(base.TranslationStore):
                     inmultilinecomment = False
             elif not line.strip():
                 # this is a blank line...
-                if str(newunit).strip():
+                # avoid adding comment only units
+                if newunit.name:
                     self.addunit(newunit)
                     newunit = propunit("", self.personality.name)
+                elif not was_header and str(newunit).strip():
+                    self.addunit(newunit)
+                    newunit = propunit("", self.personality.name)
+                    was_header = True
+                elif newunit.comments:
+                    newunit.comments.append("")
             else:
                 newunit.delimiter, delimiter_pos = self.personality.find_delimiter(line)
                 if delimiter_pos == -1:

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -458,3 +458,30 @@ key=value
         assert propunit.name == u'key'
         assert propunit.value == u''
         assert bytes(propfile) == propsource
+
+    def test_multi_comments(self):
+        propsource = """# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+
+# This contains the translations of the module in the default language
+# (generally English).
+
+job.log.begin=Starting job of type [{0}]
+""".encode('utf-8')
+        propfile = self.propparse(propsource, personality="java-utf8")
+        assert len(propfile.units) == 2
+        propunit = propfile.units[0]
+        assert propunit.name == u''
+        assert propunit.value == u''
+        assert propunit.getnotes() == """# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version."""
+        propunit = propfile.units[1]
+        assert propunit.name == u'job.log.begin'
+        assert propunit.value == u'Starting job of type [{0}]'
+        print(bytes(propfile))
+        print(propsource)
+        assert bytes(propfile) == propsource


### PR DESCRIPTION
The units with comment only are problematic as they can not be
identified - the getid returns just empty string for all of them. This
makes it hard to process them. Concatenating such comments makes it also
behave consistent with other storages.

Fixes #3928