### PR TITLE
prop2po: Remove not needed join

### DIFF
--- a/translate/convert/prop2po.py
+++ b/translate/convert/prop2po.py
@@ -222,7 +222,7 @@ class prop2po(object):
             for comment in propunit.comments:
                 if "DONT_TRANSLATE" in comment:
                     return "discard"
-            pounit.addnote(u"".join(propunit.getnotes()).rstrip(), commenttype)
+            pounit.addnote(propunit.getnotes().rstrip(), commenttype)
         # TODO: handle multiline msgid
         if propunit.isblank():
             return None


### PR DESCRIPTION
The getnotes() returns string, there is no reason in joining it
char by char.