### PR TITLE
pypo: Avoid stripping empty lines from comments

### DIFF
--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -379,12 +379,12 @@ class pounit(pocommon.pounit):
         :param origin: programmer, developer, source code, translator or None
         """
         if origin is None:
-            comments = u"".join([comment[2:] for comment in self.othercomments])
-            comments += u"".join([comment[3:] for comment in self.automaticcomments])
+            comments = u"".join([comment[2:] or "\n" for comment in self.othercomments])
+            comments += u"".join([comment[3:] or "\n" for comment in self.automaticcomments])
         elif origin == "translator":
-            comments = u"".join([comment[2:] for comment in self.othercomments])
+            comments = u"".join([comment[2:] or "\n" for comment in self.othercomments])
         elif origin in ["programmer", "developer", "source code"]:
-            comments = u"".join([comment[3:] for comment in self.automaticcomments])
+            comments = u"".join([comment[3:] or "\n" for comment in self.automaticcomments])
         else:
             raise ValueError("Comment type not valid")
         # Let's drop the last newline

--- a/translate/storage/test_poheader.py
+++ b/translate/storage/test_poheader.py
@@ -261,6 +261,29 @@ msgstr ""
     assert "# Khaled Hosny <khaledhosny@domain.org>, 2006, 2007, 2008, %s." % time.strftime("%Y") in bytes(pofile).decode('utf-8')
 
 
+def test_updatecontributor_header():
+    """Test preserving empty lines in comments"""
+    # The replace introduces trailing whitespace
+    posource = r'''# Japanese translation of ibus.
+# Copyright (C) 2015-2019 Takao Fujiwara <takao.fujiwara1@gmail.com>
+# This file is distributed under the same license as the ibus package.
+#
+# Translators:
+# Takao Fujiwara <takao.fujiwara1@gmail.com>, 2012
+msgid ""
+msgstr ""
+"MIME-Version: 1.0"
+'''.replace("#\n", "# \n")
+    pofile = poparse(posource)
+
+    # Add contributor
+    pofile.updatecontributor("Grasvreter")
+
+    # Manually build expected output
+    expected = posource.replace("msgid", "# Grasvreter, %s.\nmsgid" % time.strftime("%Y"))
+    assert bytes(pofile).decode('utf-8') == expected
+
+
 def test_language():
     """Test that we can get a language from the relevant headers."""
     posource = r'''msgid ""


### PR DESCRIPTION
The empty line inside comments are usually intentional, so avoid dropping them
on round trip.

Issue was brought up by @fujiwarat at https://github.com/WeblateOrg/weblate/issues/3376