### PR TITLE
mo: Fix parsing context

### DIFF
--- a/translate/storage/mo.py
+++ b/translate/storage/mo.py
@@ -283,5 +283,5 @@ class mofile(poheader.poheader, base.TranslationStore):
             newunit = mounit(source)
             newunit.target = target
             if context is not None:
-                newunit.msgctxt.append(context)
+                newunit.msgctxt.append(context.decode(self.encoding))
             self.addunit(newunit)

--- a/translate/storage/test_mo.py
+++ b/translate/storage/test_mo.py
@@ -137,6 +137,10 @@ class TestMOFile(test_base.TestTranslationStore):
         store.addunit(unit)
         assert b'context' in store.__bytes__()
 
+        newstore = self.StoreClass.parsestring(store.__bytes__())
+        assert len(newstore.units) == 1
+        assert newstore.units[0].getcontext(), 'context'
+
     def test_output(self):
         for posource in posources:
             print("PO source file")


### PR DESCRIPTION
It was mistakenly kept as bytes, making later string join on that crash.