### PR TITLE
aresource: Fix setting target and removing markup

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -331,6 +331,9 @@ class AndroidResourceUnit(base.TranslationUnit):
                 for x in newstring.iterchildren():
                     xmltarget.append(x)
         else:
+            # Remove possible old elements
+            for x in xmltarget.iterchildren():
+                xmltarget.remove(x)
             # Handle text only
             xmltarget.text = self.escape(target)
 

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -547,3 +547,16 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
         second.addunit(store.units[1], True)
         store = self.StoreClass()
         assert bytes(second) == content
+
+    def test_markup_remove(self):
+        template = '''<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="privacy_policy"><u>Datenschutzerklärung</u></string>
+</resources>'''
+        content = template.encode('utf-8')
+        newcontent = template.replace('<u>', '').replace('</u>', '').encode('utf-8')
+        store = self.StoreClass()
+        store.parse(content)
+        assert bytes(store) == content
+        store.units[0].target = "Datenschutzerklärung"
+        assert bytes(store) == newcontent


### PR DESCRIPTION
When new target is plain text, the any possible child elements were
kept leaving some mess in the string.