### PR TITLE
aresource: Fix setting rich content with comments

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -298,7 +298,7 @@ class AndroidResourceUnit(base.TranslationUnit):
             if self._store is not None:
                 cloned_doc = copy.deepcopy(self._store.document)
                 cloned_root = cloned_doc.getroot()
-                for child in cloned_root.xpath('*'):
+                for child in cloned_root.iterchildren():
                     cloned_root.remove(child)
                 template = etree.tostring(cloned_doc, encoding='unicode')
             else:

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -560,3 +560,17 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
         assert bytes(store) == content
         store.units[0].target = "Datenschutzerklärung"
         assert bytes(store) == newcontent
+
+    def test_markup_set(self):
+        template = '''<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--Multimedia tab-->
+    <string name="id">Multimedia tab</string>
+</resources>'''
+        content = template.encode('utf-8')
+        newcontent = template.replace('>Multimedia tab<', '>Other <b>tab</b><').encode('utf-8')
+        store = self.StoreClass()
+        store.parse(content)
+        assert bytes(store) == content
+        store.units[0].target = "Other <b>tab</b>"
+        assert bytes(store) == newcontent


### PR DESCRIPTION
We need to remove all children before using (not only elements, but also comments).