### PR TITLE
Msgfmt to use the same byte order as pocompile

### DIFF
--- a/translate/storage/test_mo.py
+++ b/translate/storage/test_mo.py
@@ -151,7 +151,7 @@ class TestMOFile(test_base.TestTranslationStore):
             with open(PO_FILE, 'wb') as out_file:
                 out_file.write(posource)
 
-            subprocess.call(['msgfmt', PO_FILE, '-o', MO_MSGFMT])
+            subprocess.call(['msgfmt', PO_FILE, '-o', MO_MSGFMT, '--endianness', sys.byteorder])
             subprocess.call(['pocompile', '--errorlevel=traceback', PO_FILE, MO_POCOMPILE])
 
             store = factory.getobject(BytesIO(posource))


### PR DESCRIPTION
Fixes testing on s390 and others.