### PR TITLE
Setup: Import setuptools before py2exe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ import re
 import sys
 from distutils.sysconfig import get_python_lib
 from os.path import dirname, isfile, join
+from setuptools import setup
 
 try:
     from sphinx.setup_command import BuildDoc
@@ -487,7 +488,6 @@ def standardsetup(name, version, custompackages=[], customdatafiles=[]):
 
 
 def dosetup(name, version, packages, datafiles, scripts, ext_modules=[]):
-    from setuptools import setup
     description, long_description = __doc__.split("\n", 1)
     kwargs = {}
     if py2exe:


### PR DESCRIPTION
Fixes #3958

This time without tests and other changes, see https://github.com/translate/translate/pull/3959 and https://github.com/translate/translate/issues/3958