### PR TITLE
json: allow usage of BOM in JSON files

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -214,7 +214,10 @@ class JsonFile(base.TranslationStore):
             input.close()
             input = src
         if isinstance(input, bytes):
-            input = input.decode('utf-8')
+            # The JSON files should be UTF-8, but implementations
+            # that parse JSON texts MAY ignore the presence of a byte order mark
+            # rather than treating it as an error, see RFC7159
+            input, self.encoding = self.detect_encoding(input)
         try:
             self._file = json.loads(input, object_pairs_hook=OrderedDict)
         except ValueError as e:

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -97,6 +97,15 @@ class TestJSONResourceStore(test_monolingual.TestMonolingualStore):
 }
 '''
 
+    def test_bom(self):
+        content = "{}\n".encode("utf-8-sig")
+        store = self.StoreClass()
+        store.parse(content)
+        assert len(store.units) == 0
+        out = BytesIO()
+        store.serialize(out)
+        assert out.getvalue() == content
+
 
 class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):
     StoreClass = jsonl10n.JsonNestedFile


### PR DESCRIPTION
Such files are violating RFC, but it suggests that parses should be able
to skip this, see https://tools.ietf.org/html/rfc7159#section-8.1