### PR TITLE
Android: Workaround broken plural handling

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -375,6 +375,13 @@ class AndroidResourceUnit(base.TranslationUnit):
 
             self.xmlelement.text = "\n    "
 
+            # Include "other" as copy of "many" if "other" is not present. This avoids crashes
+            # of Android builts with broken plurals handling.
+            if "other" not in plural_tags and "many" in plural_tags:
+                # Create copy here to avoid modifications to laguage.data
+                plural_tags = plural_tags + ["other"]
+                plural_strings.append(plural_strings[-1])
+
             for plural_tag, plural_string in zip(plural_tags, plural_strings):
                 item = etree.Element("item")
                 item.set("quantity", plural_tag)

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -574,3 +574,23 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
         assert bytes(store) == content
         store.units[0].target = "Other <b>tab</b>"
         assert bytes(store) == newcontent
+
+    def test_edit_plural_others(self):
+        content = '''<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="teststring">
+        <item quantity="one"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> den</item>
+        <item quantity="few"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dny</item>
+        <item quantity="many"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu</item>
+        <item quantity="other"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu</item>
+    </plurals>
+</resources>'''.encode('utf-8')
+        store = self.StoreClass()
+        store.targetlanguage = 'ru'
+        store.parse(content)
+        store.units[0].target = multistring([
+            '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> den',
+            '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dny',
+            '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu',
+        ])
+        assert bytes(store) == content


### PR DESCRIPTION
In some Android builds, the plurals which do not have "others" are not handled
properly and cause application to crash (android.content.res.Resources$NotFoundException).
Adding "others" as a copy of "many" should address this.