### PR TITLE
yaml: Fixed adding units to empty document

### DIFF
--- a/translate/storage/test_yaml.py
+++ b/translate/storage/test_yaml.py
@@ -280,6 +280,19 @@ foo: "Hello \n World."
   value: teststring2
 '''
 
+    def test_add_to_mepty(self):
+        store = self.StoreClass()
+        store.parse('')
+        unit = self.StoreClass.UnitClass("teststring")
+        unit.setid('key')
+        store.addunit(unit)
+        unit = self.StoreClass.UnitClass("teststring2")
+        unit.setid('key->value')
+        store.addunit(unit)
+        assert bytes(store).decode('utf-8') == '''key:
+  value: teststring2
+'''
+
     @pytest.mark.skipif(ruamel.yaml.version_info < (0, 16, 6), reason='Empty keys serialization broken in ruamel.yaml<0.16.6')
     def test_empty_key(self):
         yaml_souce = b''''': Jedna

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -125,6 +125,10 @@ class YAMLFile(base.TranslationStore):
                 target[path[0]] = value
             return target
 
+        # Always start with valid root even if original file was empty
+        if self._original is None:
+            self._original = self.get_root_node()
+
         units = self.preprocess(self._original)
         for unit in self.unit_iter():
             nested_set(units, unit.getid().split('->'), unit.target)


### PR DESCRIPTION
When the parsed document is empty, the parser returns just None and further processing fails. This change ensures there is always valid root.