### PR TITLE
Fix osx tests by adding gettext to path

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install brew dependencies
       run: |
         brew install gettext
-        brew link gettext --force
+        echo "::add-path::/usr/local/opt/gettext/bin"
     - name: Update pip
       run: pip install --upgrade pip wheel
     - name: Install pip dependencies


### PR DESCRIPTION
Something has changed in the brew and link --force no longer works for
gettext. Adding it to PATH should adddress this.