### PR TITLE
ci: fixed pip upgrade on Windows

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Update pip
-      run: pip install --upgrade pip wheel
+      run: pip install --user --upgrade pip wheel
     - name: Install pip dependencies
       run: pip install -r requirements/dev.txt
     - name: Install


### PR DESCRIPTION
It seems that updating system package is not allowed.