### PR TITLE
[html2po] multiple bug fixes, parsing makeover

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -11,6 +11,7 @@ Alphabetical Order of Contributors
 ----------------------------------
 
 Alexander Dupuy: poterminology, quality checks
+Anders Kaplan: improvements to html2po
 Caio Begotti: documentation
 Clytie Siddall: testing and bugreporting
 Dan Schafer (Mozilla): improvements to html2po

--- a/docs/commands/html2po.rst
+++ b/docs/commands/html2po.rst
@@ -76,28 +76,31 @@ Examples
   html2po -P site pot
 
 This will find all HTML files (.htm, .html, .xhtml) in *site*, convert them to
-POT files and place them in *pot*::
+POT files and place them in *pot*.
 
-  po2html -t site xh site-xh
+You can create and update PO files for different languages using the
+:doc:`pot2po` command.
 
-All the PO translations in *xh* will be converted to html using html files in
-*site* as templates and outputting new translated HTML files in *site-xh*
+::
+
+  po2html -t site -i xh -o site-xh
+
+All the PO translations in *xh* will be converted to HTML using HTML files in
+*site* as templates and outputting new translated HTML files in *site-xh*.
+
+
+.. _html2po#notes:
+
+Notes
+=====
+
+The :doc:`HTML format description </formats/html>` gives more details on the 
+format of the localisable HTML content and the capabilities of this converter.
+
 
 .. _html2po#bugs:
 
 Bugs
 ====
 
-We don't hide enough of some of the tags, e.g. <a> tags have too much exposed,
-we should expose only what needs to be translated and allow the changing on
-position of the tag within the translation block.  Similarly there is some
-markup that could be excluded e.g. <b> tags that appear at the start and end of
-a msgid, i.e. they don't need placement from the translator.
-
-If the HTML is indented you get very odd msgid's
-
 Some items end up in the msgid's that should not be translated
-
-It might be worth investigating
-http://opensource.bureau-cornavin.com/html2pot-po2html/index.html which uses
-XSLT to transform XHTML to Gettext PO

--- a/docs/formats/html.rst
+++ b/docs/formats/html.rst
@@ -7,22 +7,37 @@ HTML
 The Translate Toolkit is able to process HTML files using the :doc:`html2po
 </commands/html2po>` converter.
 
-The HTML support is basic, so please be aware of that.
 
 .. _html#conformance:
 
 Conformance
 ===========
 
-* Can identify almost all tags and attributes that are localisable.
-* Does not convert HTML entities (e.g. ``&copy;``) to normal strings
-* It does not handle inline elements well and will drop them, so complicated
-  HTML might not make it through the filter
+* Can identify almost all HTML elements and attributes that are localisable.
+
+* The localisable and localised text in the PO/POT files is fragments of HTML. 
+  Therefore, reserved characters must be represented by HTML entities:
+  
+  - Content from HTML elements uses the HTML entities ``&amp;`` (&), ``&lt;``
+    (<), and ``&gt;`` (>).
+
+  - Content from HTML attributes uses the HTML entities ``&quot;`` (") or
+    ``&apos;`` (').
+
+* Leading and trailing tags are removed from the localisable text,
+  but only in matching pairs. 
+
+* Can cope with embedded PHP, as long as the documents remain valid HTML. If 
+  you place PHP code inside HTML attributes, you need to make sure that the PHP
+  doesn't contain special characters that interfere with the HTML.
+
 
 .. _html#references:
 
 References
 ==========
 
-* Using character entities:
-  http://www.w3.org/International/questions/qa-escapes
+* `Reserved characters
+  <https://developer.mozilla.org/en-US/docs/Glossary/Entity>`__
+* `Using character entities
+  <http://www.w3.org/International/questions/qa-escapes>`__

--- a/translate/convert/test_html2po.py
+++ b/translate/convert/test_html2po.py
@@ -504,6 +504,7 @@ ghi ?>'''
         pofile = self.html2po(htmlsource)
         self.compareunit(pofile, 1, 'EPS färg')
 
+
 class TestHTML2POCommand(test_convert.TestConvertCommand, TestHTML2PO):
     """Tests running actual html2po commands on files"""
     convertmodule = html2po

--- a/translate/convert/test_html2po.py
+++ b/translate/convert/test_html2po.py
@@ -58,11 +58,11 @@ class TestHTML2PO:
         self.check_null('<html><head></head><body><p>' + php + '</p></body></html>')
 
     def test_extract_lang_attribute_from_html_tag(self):
-        """Test that the lang attribute is extracted from the html tag"""
+        """Test that the lang attribute is extracted from the html tag, issue #3884"""
         markup = '''<!DOCTYPE html>
 <html lang="en">
     <head>
-        <title>translate lang attribute #3884</title>
+        <title>translate lang attribute</title>
     </head>
     <body>
     </body>
@@ -71,7 +71,7 @@ class TestHTML2PO:
         pofile = self.html2po(markup)
         self.countunits(pofile, 2)
         self.compareunit(pofile, 1, "en")
-        self.compareunit(pofile, 2, "translate lang attribute #3884")
+        self.compareunit(pofile, 2, "translate lang attribute")
 
     def test_do_not_extract_lang_attribute_from_tags_other_than_html(self):
         """Test that the lang attribute is extracted from the html tag"""

--- a/translate/convert/test_html2po.py
+++ b/translate/convert/test_html2po.py
@@ -55,7 +55,7 @@ class TestHTML2PO:
         if the results are as expected"""
         self.check_single('<html><head></head><body><p><a href="' + php + '/site.html">Body text</a></p></body></html>', "Body text")
         self.check_single('<html><head></head><body><p>More things in <a href="' + php + '/site.html">Body text</a></p></body></html>', 'More things in <a href="' + php + '/site.html">Body text</a>')
-        self.check_null('<html><head></head><body><p>' + php + '</p></body></html>')
+        self.check_single('<html><head></head><body><p>' + php + '</p></body></html>', php)
 
     def test_extract_lang_attribute_from_html_tag(self):
         """Test that the lang attribute is extracted from the html tag, issue #3884"""
@@ -455,6 +455,10 @@ years has helped to bridge the digital divide to a limited extent.</p> \r
         # Contains HTML tag characters (< and >)
         self.check_phpsnippet('''<?=($a < $b ? $foo : ($b > c ? $bar : $cat))?>''')
 
+        # Make sure basically any symbol can be handled
+        # NOTE quotation mark removed since it violates the HTML format when placed in an attribute
+        self.check_phpsnippet('''<? asdfghjkl qwertyuiop 1234567890!@#$%^&*()-=_+[]\\{}|;':,./<>? ?>''')
+
     def test_multiple_php(self):
         """Test multiple PHP snippets in a string to make sure they get restored properly"""
         php1 = '''<?=$phpvariable?>'''
@@ -462,7 +466,7 @@ years has helped to bridge the digital divide to a limited extent.</p> \r
         php3 = '''<? asdfghjklqwertyuiop1234567890!@#$%^&*()-=_+[]\\{}|;':",./<>? ?>'''
 
         # Put 3 different strings into an html string
-        innertext = '<a href="' + php1 + '/site.html">Body text</a> and some ' + php2 + ' more text ' + php2 + php3 + ' even more text'
+        innertext = '<a href="' + php1 + '/site.html">Body text</a> and some ' + php2 + ' more text ' + php2 + php3
         htmlsource = '<html><head></head><body><p>' + innertext + '</p></body></html>'
         self.check_single(htmlsource, innertext)
 
@@ -474,8 +478,8 @@ def
 ghi ?>'''
 
         # Scatter the php strings throughout the file, and show what the translation should be
-        innertext = '<a href="' + php1 + '/site.html">Body text</a> and some ' + php1 + ' more text ' + php1 + php1 + ' even more text'
-        innertrans = '<a href="' + php1 + '/site.html">Texte de corps</a> et encore de ' + php1 + ' plus de texte ' + php1 + php1 + ' encore plus de texte'
+        innertext = '<a href="' + php1 + '/site.html">Body text</a> and some ' + php1 + ' more text ' + php1 + php1
+        innertrans = '<a href="' + php1 + '/site.html">Texte de corps</a> et encore de ' + php1 + ' plus de texte ' + php1 + php1
 
         htmlsource = '<html><head></head><body><p>' + innertext + '</p></body></html>'  # Current html file
         transsource = '<html><head></head><body><p>' + innertrans + '</p></body></html>'  # Expected translation

--- a/translate/convert/test_html2po.py
+++ b/translate/convert/test_html2po.py
@@ -57,13 +57,25 @@ class TestHTML2PO:
         self.check_single('<html><head></head><body><p>More things in <a href="' + php + '/site.html">Body text</a></p></body></html>', 'More things in <a href="' + php + '/site.html">Body text</a>')
         self.check_null('<html><head></head><body><p>' + php + '</p></body></html>')
 
-    def test_htmllang(self):
-        """test to ensure that we no longer use the lang attribure"""
-        markup = '''<html lang="en"><head><title>My title</title></head><body></body></html>'''
+    def test_extract_lang_attribute_from_html_tag(self):
+        """Test that the lang attribute is extracted from the html tag"""
+        markup = '''<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>translate lang attribute #3884</title>
+    </head>
+    <body>
+    </body>
+</html>
+'''
         pofile = self.html2po(markup)
-        self.countunits(pofile, 1)
-        # Check that the first item is the <title> not <head>
-        self.compareunit(pofile, 1, "My title")
+        self.countunits(pofile, 2)
+        self.compareunit(pofile, 1, "en")
+        self.compareunit(pofile, 2, "translate lang attribute #3884")
+
+    def test_do_not_extract_lang_attribute_from_tags_other_than_html(self):
+        """Test that the lang attribute is extracted from the html tag"""
+        self.check_single("<p><span lang=\"fr\">Français</span></p>", "Français")
 
     def test_title(self):
         """test that we can extract the <title> tag"""
@@ -89,6 +101,9 @@ title</title>
     def test_tag_p(self):
         """test that we can extract the <p> tag"""
         self.check_single("<html><head></head><body><p>A paragraph.</p></body></html>", "A paragraph.")
+
+    def test_tag_p_with_br(self):
+        """test that we can extract the <p> tag with an embedded <br> element"""
         markup = "<p>First line.<br>Second line.</p>"
         pofile = self.html2po(markup)
         self.compareunit(pofile, 1, "First line.<br>Second line.")
@@ -108,9 +123,16 @@ with indentation, and it consists of at least one sentence.
 </html>
 '''
         self.check_single(htmltext, "A paragraph is a section in a piece of writing, usually highlighting a particular point or topic. It always begins on a new line and usually with indentation, and it consists of at least one sentence.")
+
+    def test_tag_p_with_linebreak_and_embedded_br(self):
+        """Test newlines within the <p> tag when there is an embedded <br> element."""
         markup = "<p>First\nline.<br>Second\nline.</p>"
         pofile = self.html2po(markup)
         self.compareunit(pofile, 1, "First line.<br>Second line.")
+
+    def test_uppercase_html(self):
+        """Should ignore the casing of the html tags."""
+        self.check_single("<HTML><HEAD></HEAD><BODY><P>A paragraph.</P></BODY></HTML>", "A paragraph.")
 
     def test_tag_div(self):
         """test that we can extract the <div> tag"""
@@ -157,6 +179,10 @@ newlines.</p></body></html>
 '''
         self.check_single(htmltext, 'A paragraph with <a href="http://translate.org.za/">hyperlink</a> and newlines.')
 
+    def test_sequence_of_anchor_elements(self):
+        """test that we can extract a sequence of anchor elements without mixing up start/end tags, issue #3768"""
+        self.check_single('<p><a href="http://example.com">This is a link</a> but this is not. <a href="http://example.com">However this is too</a></p>', '<a href="http://example.com">This is a link</a> but this is not. <a href="http://example.com">However this is too</a>')
+
     def test_tag_img(self):
         """Test that we can extract the alt attribute from the <img> tag."""
         self.check_single('''<html><head></head><body><img src="picture.png" alt="A picture"></body></html>''', "A picture")
@@ -165,6 +191,10 @@ newlines.</p></body></html>
         """Test that we can extract the alt attribute from the <img> tag."""
         htmlsource = '''<html><head></head><body><img src="images/topbar.jpg" width="750" height="80"></body></html>'''
         self.check_null(htmlsource)
+
+    def test_tag_img_inside_a(self):
+        """Test that we can extract the alt attribute from the <img> tag when the img is embedded in a link."""
+        self.check_single('''<html><head></head><body><p><a href="#"><img src="picture.png" alt="A picture" /></a></p></body></html>''', "A picture")
 
     def test_tag_table_summary(self):
         """Test that we can extract the summary attribute."""
@@ -245,7 +275,7 @@ newlines.</p></body></html>
         self.check_single("<html><head></head><body><p>You are a <span>Spanish</span> sentence.</p></body></html>", "You are a <span>Spanish</span> sentence.")
 
     def test_ul(self):
-        """Test to see if the list item <li> is exracted"""
+        """Test to see if the list item <li> is extracted"""
         markup = "<html><head></head><body><ul><li>Unordered One</li><li>Unordered Two</li></ul><ol><li>Ordered One</li><li>Ordered Two</li></ol></body></html>"
         pofile = self.html2po(markup)
         self.countunits(pofile, 4)
@@ -253,6 +283,33 @@ newlines.</p></body></html>
         self.compareunit(pofile, 2, "Unordered Two")
         self.compareunit(pofile, 3, "Ordered One")
         self.compareunit(pofile, 4, "Ordered Two")
+
+    def test_nested_lists(self):
+        """Nested lists should be extracted correctly"""
+        markup = '''<!DOCTYPE html><html><head><title>Nested lists</title></head><body>
+<ul>
+    <li>Vegetables</li>
+    <li>Fruit
+        <ul>
+            <li>Bananas</li>
+            <li>Apples</li>
+            <li>Pears</li>
+        </ul>
+        yeah, that should be enough
+    </li>
+    <li>Meat</li>
+</ul>
+</body></html>'''
+        pofile = self.html2po(markup)
+        self.countunits(pofile, 8)
+        self.compareunit(pofile, 1, "Nested lists")
+        self.compareunit(pofile, 2, "Vegetables")
+        self.compareunit(pofile, 3, "Fruit")
+        self.compareunit(pofile, 4, "Bananas")
+        self.compareunit(pofile, 5, "Apples")
+        self.compareunit(pofile, 6, "Pears")
+        self.compareunit(pofile, 7, "yeah, that should be enough")
+        self.compareunit(pofile, 8, "Meat")
 
     def test_duplicates(self):
         """check that we use the default style of msgctxt to disambiguate duplicate messages"""
@@ -270,7 +327,6 @@ newlines.</p></body></html>
         self.check_single('''<td valign="middle" width="96%"><font class="headingwhite">South
                   Africa</font></td>''', '''South Africa''')
 
-    @mark.xfail(reason="Not Implemented")
     def test_nested_tags(self):
         """check that we can extract items within nested tags"""
         markup = "<div><p>Extract this</p>And this</div>"
@@ -299,6 +355,7 @@ years has helped to bridge the digital divide to a limited extent.</p> \r
 
     def test_encoding_latin1(self):
         """Convert HTML input in iso-8859-1 correctly to unicode."""
+        """Also verifies that the charset declaration isn't extracted as a translation unit."""
         htmlsource = b'''<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html><!-- InstanceBegin template="/Templates/masterpage.dwt" codeOutsideHTMLIsLocked="false" -->
 <head>
@@ -320,8 +377,9 @@ years has helped to bridge the digital divide to a limited extent.</p> \r
 </html>
 '''
         pofile = self.html2po(htmlsource)
-
         self.countunits(pofile, 4)
+        self.compareunit(pofile, 1, u'FMFI - South Africa - CSIR Openphone - Overview')
+        self.compareunit(pofile, 2, u'fmfi, first mile, first inch, wireless, rural development, access devices, mobile devices, wifi, connectivity, rural connectivty, ict, low cost, cheap, digital divide, csir, idrc, community')
         self.compareunit(pofile, 3, u'We aim to please \x96 will you aim too, please?')
         self.compareunit(pofile, 4, u'South Africa\x92s language diversity can be challenging.')
 
@@ -373,18 +431,29 @@ years has helped to bridge the digital divide to a limited extent.</p> \r
         snippet = '<td width="96%"><a href="index.html">Tuisblad</a></td>'
         assert snippet in htmlresult
 
-    @mark.xfail(reason="Performing major HTML surgery")
+    def test_entityrefs_in_text(self):
+        """Should extract html entityrefs, preserving the ones representing reserved characters"""
+        """`See <https://developer.mozilla.org/en-US/docs/Glossary/Entity>`."""
+        self.check_single("<html><head></head><body><p>&lt;not an element&gt; &amp; &quot; &apos; &rsquo;</p></body></html>", u"&lt;not an element&gt; &amp; \" ' \u2019")
+
+    def test_entityrefs_in_attributes(self):
+        """Should convert html entityrefs in attribute values"""
+        # it would be even nicer if &quot; and &apos; could be preserved, but the automatic unescaping of
+        # attributes is deep inside html.HTMLParser.
+        self.check_single("<html><head></head><body><img alt=\"&lt;not an element&gt; &amp; &quot; &apos; &rsquo;\"></body></html>", u"<not an element> & \" ' \u2019")
+
+    def test_charrefs(self):
+        """Should extract html charrefs"""
+        self.check_single("<html><head></head><body><p>&#8217; &#x2019;</p></body></html>", u"\u2019 \u2019")
+
     def test_php(self):
         """Test that PHP snippets don't interfere"""
 
         # A simple string
         self.check_phpsnippet('''<?=$phpvariable?>''')
 
-        # Contains HTML tag charcters (< and >)
+        # Contains HTML tag characters (< and >)
         self.check_phpsnippet('''<?=($a < $b ? $foo : ($b > c ? $bar : $cat))?>''')
-
-        # Make sure basically any symbol can be handled
-        self.check_phpsnippet(''' <? asdfghjkl qwertyuiop 1234567890!@#$%^&*()-=_+[]\\{}|;':",./<>? ?> ''')
 
     def test_multiple_php(self):
         """Test multiple PHP snippets in a string to make sure they get restored properly"""
@@ -393,7 +462,7 @@ years has helped to bridge the digital divide to a limited extent.</p> \r
         php3 = '''<? asdfghjklqwertyuiop1234567890!@#$%^&*()-=_+[]\\{}|;':",./<>? ?>'''
 
         # Put 3 different strings into an html string
-        innertext = '<a href="' + php1 + '/site.html">Body text</a> and some ' + php2 + ' more text ' + php2 + php3
+        innertext = '<a href="' + php1 + '/site.html">Body text</a> and some ' + php2 + ' more text ' + php2 + php3 + ' even more text'
         htmlsource = '<html><head></head><body><p>' + innertext + '</p></body></html>'
         self.check_single(htmlsource, innertext)
 
@@ -405,8 +474,8 @@ def
 ghi ?>'''
 
         # Scatter the php strings throughout the file, and show what the translation should be
-        innertext = '<a href="' + php1 + '/site.html">Body text</a> and some ' + php1 + ' more text ' + php1 + php1
-        innertrans = '<a href="' + php1 + '/site.html">Texte de corps</a> et encore de ' + php1 + ' plus de texte ' + php1 + php1
+        innertext = '<a href="' + php1 + '/site.html">Body text</a> and some ' + php1 + ' more text ' + php1 + php1 + ' even more text'
+        innertrans = '<a href="' + php1 + '/site.html">Texte de corps</a> et encore de ' + php1 + ' plus de texte ' + php1 + php1 + ' encore plus de texte'
 
         htmlsource = '<html><head></head><body><p>' + innertext + '</p></body></html>'  # Current html file
         transsource = '<html><head></head><body><p>' + innertrans + '</p></body></html>'  # Expected translation
@@ -416,6 +485,10 @@ ghi ?>'''
         htmlresult = self.po2html(pofile, htmlsource)
         assert htmlresult == transsource
 
+    def test_php_with_embedded_html(self):
+        """Should not consume HTML within processing instructions"""
+        self.check_single("<html><head></head><body><p>a <? <p>b</p> ?> c</p></body></html>", "a <? <p>b</p> ?> c")
+
     def test_comments(self):
         """Test that HTML comments are converted to translator notes in output"""
         pofile = self.html2po('<!-- comment outside block --><p><!-- a comment -->A paragraph<!-- with another comment -->.</p>', keepcomments=True)
@@ -423,6 +496,13 @@ ghi ?>'''
         notes = pofile.getunits()[-1].getnotes()
         assert str(notes) == ' a comment \n with another comment '
 
+    def test_attribute_without_value(self):
+        htmlsource = '''<ul>
+                <li><a href="logoColor.eps" download>EPS färg</a></li>
+            </ul>
+'''
+        pofile = self.html2po(htmlsource)
+        self.compareunit(pofile, 1, 'EPS färg')
 
 class TestHTML2POCommand(test_convert.TestConvertCommand, TestHTML2PO):
     """Tests running actual html2po commands on files"""

--- a/translate/convert/test_po2html.py
+++ b/translate/convert/test_po2html.py
@@ -57,27 +57,57 @@ sin.
 </body>'''
         assert htmlexpected.replace("\n", " ") in self.converthtml(posource, htmlsource).replace("\n", " ")
 
-    @mark.xfail(reason="Not Implemented")
+    def test_replace_substrings(self):
+        """Should replace substrings correctly, issue #3416"""
+        htmlsource = '''<!DOCTYPE html><html><head><title>sub-strings substitution</title></head><body>
+<h2>This is heading 2</h2>
+<p>The heading says: <b>This is heading 2</b></p>
+</body></html>'''
+        posource = '#:html.body.h2:2-1\nmsgid "This is heading 2"\nmsgstr "Αυτή είναι μία Ετικέτα 2"\n\n#html.body.p:3-1\nmsgid "The heading says: <b>This is heading 2</b>"\nmsgstr "Η ετικέτα λέει: <b>Αυτή είναι μία Ετικέτα 2</b>"\n'
+        htmlexpected = '''<!DOCTYPE html><html><head><title>sub-strings substitution</title></head><body>
+<h2>Αυτή είναι μία Ετικέτα 2</h2>
+<p>Η ετικέτα λέει: <b>Αυτή είναι μία Ετικέτα 2</b></p>
+</body></html>'''
+        assert htmlexpected in self.converthtml(posource, htmlsource)
+
+    def test_attribute_outside_translatable_content(self):
+        htmlsource = '<img alt="a picture"><p>A sentence.</p>'
+        posource = '''#: html:3\nmsgid "A sentence."\nmsgstr "'n Sin."\n#: html:1\nmsgid "a picture"\nmsgstr "n prentjie"\n'''
+        htmlexpected = '''<img alt="n prentjie"><p>'n Sin.</p>'''
+        assert htmlexpected in self.converthtml(posource, htmlsource)
+
+    def test_attribute_within_translatable_content_not_embedded(self):
+        htmlsource = '<p><img alt="a picture">A sentence.</p>'
+        posource = '''#: html:3\nmsgid "A sentence."\nmsgstr "'n Sin."\n#: html:1\nmsgid "a picture"\nmsgstr "n prentjie"\n'''
+        htmlexpected = '''<p><img alt="n prentjie">'n Sin.</p>'''
+        assert htmlexpected in self.converthtml(posource, htmlsource)
+
+    def test_attribute_embedded_within_translatable_content(self):
+        htmlsource = '<p>A sentence<img alt="a picture">.</p>'
+        posource = '''#: html:3\nmsgid "A sentence<img alt="a picture">."\nmsgstr "'n Sin<img alt="n prentjie">."\n'''
+        htmlexpected = '''<p>'n Sin<img alt="n prentjie">.</p>'''
+        assert htmlexpected in self.converthtml(posource, htmlsource)
+
+    def test_attribute_without_value(self):
+        htmlsource = '<ul><li><a href="logoColor.eps" download>EPS färg</a></li></ul>'
+        posource = '''#: html:3\nmsgid "EPS färg"\nmsgstr "EPS color"\n'''
+        htmlexpected = '''<li><a href="logoColor.eps" download>EPS color</a></li>'''
+        assert htmlexpected in self.converthtml(posource, htmlsource)
+
     def test_entities(self):
         """Tests that entities are handled correctly"""
         htmlsource = '<p>5 less than 6</p>'
-        posource = '#:html:3\nmsgid "5 less than 6"\nmsgstr "5 < 6"\n'
+        posource = '#:html:3\nmsgid "5 less than 6"\nmsgstr "5 &lt; 6"\n'
         htmlexpected = '<p>5 &lt; 6</p>'
         assert htmlexpected in self.converthtml(posource, htmlsource)
 
         htmlsource = '<p>Fish &amp; chips</p>'
-        posource = '#: html:3\nmsgid "Fish & chips"\nmsgstr "Vis & skyfies"\n'
+        posource = '#: html:3\nmsgid "Fish &amp; chips"\nmsgstr "Vis &amp; skyfies"\n'
         htmlexpected = '<p>Vis &amp; skyfies</p>'
         assert htmlexpected in self.converthtml(posource, htmlsource)
 
-    @mark.xfail(reason="Not Implemented")
     def test_escapes(self):
         """Tests that PO escapes are correctly handled"""
-        htmlsource = '<div>Row 1<br />Row 2</div>'
-        posource = '#: html:3\nmsgid "Row 1\\n"\n"Row 2"\nmsgstr "Ry 1\\n"\n"Ry 2"\n'
-        htmlexpected = '<div>Ry 1<br />Ry 2</div>'
-        assert htmlexpected in self.converthtml(posource, htmlsource)
-
         htmlsource = '<p>"leverage"</p>'
         posource = '#: html3\nmsgid "\\"leverage\\""\nmsgstr "\\"ek is dom\\""\n'
         htmlexpected = '<p>"ek is dom"</p>'

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -94,7 +94,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
         "keywords"
     ]
     """Document metadata from meta elements with these names will be extracted as translation units.
-    `Reference <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name>`_"""
+    Reference `<https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name>`_"""
 
     EMPTY_HTML_ELEMENTS = [
         "area",
@@ -115,7 +115,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
     """An empty element is an element that cannot have any child nodes (i.e., nested 
     elements or text nodes). In HTML, using a closing tag on an empty element is 
     usually invalid.
-    `Reference <https://developer.mozilla.org/en-US/docs/Glossary/Empty_element>`_"""
+    Reference `<https://developer.mozilla.org/en-US/docs/Glossary/Empty_element>`_"""
 
     WHITESPACE_RE = re.compile(r"\s+")
 

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -73,17 +73,17 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
         "td", "th",
         "title"
     ]
-    """These HTML elements (tags) will be extracted as translation units, unless 
+    """These HTML elements (tags) will be extracted as translation units, unless
     they lack translatable text content.
-    In case one translatable element is embedded in another, the outer translation 
+    In case one translatable element is embedded in another, the outer translation
     unit will be split into the parts before and after the inner translation unit."""
 
     TRANSLATABLE_ATTRIBUTES = [
-        "abbr", # abbreviation for a table header cell
+        "abbr",       # abbreviation for a table header cell
         "alt",
-        "lang", # only for the html element -- see extract_translatable_attributes()
+        "lang",       # only for the html element -- see extract_translatable_attributes()
         "summary",
-        "title", # tooltip text for an element
+        "title",      # tooltip text for an element
         "value"
     ]
     """Text from these HTML attributes will be extracted as translation units.
@@ -112,8 +112,8 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
         "track",
         "wbr"
     ]
-    """An empty element is an element that cannot have any child nodes (i.e., nested 
-    elements or text nodes). In HTML, using a closing tag on an empty element is 
+    """An empty element is an element that cannot have any child nodes (i.e., nested
+    elements or text nodes). In HTML, using a closing tag on an empty element is
     usually invalid.
     Reference `<https://developer.mozilla.org/en-US/docs/Glossary/Empty_element>`_"""
 
@@ -133,7 +133,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
                  callback=None):
         html.parser.HTMLParser.__init__(self, convert_charrefs=False)
         base.TranslationStore.__init__(self)
-        
+
         # store parameters
         self.filename = getattr(inputfile, 'name', None)
         if callback is None:
@@ -182,8 +182,8 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
         self.emit_translation_unit()
         self.tu_content = []
         self.tu_location = "%s+%s:%d-%d" % (
-                            self.filename, ".".join(self.tag_path),
-                            self.getpos()[0], self.getpos()[1] + 1)
+                           self.filename, ".".join(self.tag_path),
+                           self.getpos()[0], self.getpos()[1] + 1)
 
     def end_translation_unit(self):
         # at the end of a translation unit:
@@ -191,7 +191,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
         self.emit_translation_unit()
         self.tu_content = []
         self.tu_location = None
-    
+
     def append_markup(self, markup):
         # if within a translation unit: add to the queue to be processed later.
         # otherwise handle immediately.
@@ -203,7 +203,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
 
     def emit_translation_unit(self):
         # scan through the queue:
-        # - find the first and last translatable markup elements: the captured 
+        # - find the first and last translatable markup elements: the captured
         #   interval [start, end)
         # - match start and end tags
         start = 0
@@ -213,7 +213,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
         tag = None
         for pos in range(len(self.tu_content)):
             if self.tu_content[pos]['type'] != 'endtag' \
-                and tag in self.EMPTY_HTML_ELEMENTS:
+                    and tag in self.EMPTY_HTML_ELEMENTS:
                 match = tagstack.pop()
                 tag = None
 
@@ -242,9 +242,9 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
         # scan the start and end tags captured between translatable content;
         # extend the captured interval to include the matching tags
         for pos in range(start + 1, end - 1):
-            if (self.tu_content[pos]['type'] == 'starttag' or \
-                self.tu_content[pos]['type'] == 'endtag') and \
-                pos in tagmap:
+            if (self.tu_content[pos]['type'] == 'starttag' or
+                    self.tu_content[pos]['type'] == 'endtag') and \
+                    pos in tagmap:
                 match = tagmap[pos]
                 start = min(start, match)
                 end = max(end, match + 1)
@@ -265,12 +265,12 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
                     else:
                         html_content += markup['html_content']
             normalized_content = self.WHITESPACE_RE.sub(" ", html_content.strip())
-            assert normalized_content # shouldn't be here otherwise
+            assert normalized_content  # shouldn't be here otherwise
 
             unit = self.addsourceunit(normalized_content)
             unit.addlocation(self.tu_location)
-            comments = [markup['note'] for markup in self.tu_content \
-                if markup['type'] == 'comment']
+            comments = [markup['note'] for markup in self.tu_content
+                        if markup['type'] == 'comment']
             if comments:
                 unit.addnote("\n".join(comments))
 
@@ -298,7 +298,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
         else:
             for attrname, attrvalue in attrs:
                 if attrname in self.TRANSLATABLE_ATTRIBUTES \
-                    and self.translatable_attribute_matches_tag(attrname, tag):
+                        and self.translatable_attribute_matches_tag(attrname, tag):
                     tu = self.create_attribute_tu(attrname, attrvalue)
                     if tu:
                         result.append(tu)
@@ -321,9 +321,9 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
             return {
                 'html_content': normalized_value,
                 'location': "%s+%s:%d-%d" % (
-                                self.filename, 
-                                ".".join(self.tag_path) + '[' + attrname + ']',
-                                self.getpos()[0], self.getpos()[1] + 1)
+                            self.filename,
+                            ".".join(self.tag_path) + '[' + attrname + ']',
+                            self.getpos()[0], self.getpos()[1] + 1)
             }
 
     def emit_attribute_translation_units(self, markup):
@@ -431,7 +431,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
             self.end_translation_unit()
             if any(t in self.TRANSLATABLE_ELEMENTS for t in self.tag_path):
                 self.begin_translation_unit()
-                
+
         self.tag_path.pop()
 
     def handle_data(self, data):

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -159,6 +159,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
 
     def guess_encoding(self, htmlsrc):
         """Returns the encoding of the html text.
+
         We look for 'charset=' within a meta tag to do this.
         """
         result = self.ENCODING_RE.findall(htmlsrc)

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -287,7 +287,9 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
 
     @staticmethod
     def has_translatable_content(markup):
-        return markup['type'] == 'data' and markup['html_content'].strip()
+        # processing instructions count as translatable content, because PHP
+        return markup['type'] in {'data', 'pi'} \
+            and markup['html_content'].strip()
 
     def extract_translatable_attributes(self, tag, attrs):
         result = []


### PR DESCRIPTION
A makeover of the HTML parsing to fix issues #3768 (html2po incorrectly strips html),
#3416 (incorrect sub-strings substitution), and a few other issues for which there are no bug reports. Unit tests have been added to expose those cases.

The new parsing algorithm does not use any regex-based parsing on top of the HTML parser. Instead, it puts the content inside localisable HTML elements on a queue which is processed when the end of the localisable content is reached. This means that one can use the DOM of the translatable content when extracting localisable content, which makes it easier to handle edge cases.

Also includes a fix for #3884 (translate language version in <html lang="en">). This fix is better than the PR I submitted earlier, because it does not extract the lang tag from other HTML elements.

Re-enabled disabled unit tests for po2html. Split some unit tests to do one test per method.

Apologies for the large pull request -- it would have been difficult to split this PR into smaller parts.