### PR TITLE
chore: Don't build dependabot branches

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ on:
       - "docs/**"
       - "requirements/**"
       - "tests/cli/example_test.sh"
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
     paths:
       - "Makefile"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ on:
       - ".github/workflows/lint.yml"
       - "requirements/**"
       - "**/*.py"
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
     paths:
       - "setup.cfg"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths-ignore:
     - "docs/**"
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
     paths-ignore:
     - "docs/**"

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths-ignore:
     - "docs/**"
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
     paths-ignore:
     - "docs/**"

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -1,6 +1,10 @@
 name: Distribution
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+  pull_request:
 
 jobs:
   setup:

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths-ignore:
     - "docs/**"
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
     paths-ignore:
     - "docs/**"


### PR DESCRIPTION
This prevents the double build for DependaBot PRs, so they only run when it opens a PR, and not when it creates a branch