### PR TITLE
chore: expand Windows matrix

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         requirements: [latest]
-        python-version: [3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
3.5 is currently failing for python-Levenshtein https://github.com/nschonni/translate/runs/639706148?check_suite_focus=true#step:6:131 so still not added to matrix