### PR TITLE
chore: Add 3.6 to macOS matrix

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         requirements: [latest]
-        python-version: [3.5, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Now matches the Linux coverage, minus the minimal build