### PR TITLE
Factory: Accept store as parameter to getobject

### DIFF
--- a/translate/storage/factory.py
+++ b/translate/storage/factory.py
@@ -21,6 +21,8 @@
 
 import os
 
+from translate.storage.base import TranslationStore
+
 
 #TODO: Monolingual formats (with template?)
 
@@ -181,11 +183,13 @@ def getobject(storefile, localfiletype=None, ignore=None, classes=None,
               classes_str=None, hiddenclasses=None):
     """Factory that returns a usable object for the type of file presented.
 
-    :type storefile: file or str
+    :type storefile: file or str or TranslationStore
     :param storefile: File object or file name.
 
     Specify ignore to ignore some part at the back of the name (like .gz).
     """
+    if isinstance(storefile, TranslationStore):
+        return storefile
     if classes_str is None:
         classes_str = _classes_str
     if hiddenclasses is None:

--- a/translate/storage/test_factory.py
+++ b/translate/storage/test_factory.py
@@ -84,6 +84,13 @@ class BaseTestFactory:
         assert not classname("file.po.bz2") == "tmxfile"
         assert not classname("file.po.bz2") == "xlifffile"
 
+    def test_getobject_store(self):
+        """Tests that we get a valid object."""
+        fileobj = givefile(self.filename, self.file_content)
+        store = factory.getobject(fileobj)
+        assert isinstance(store, self.expected_instance)
+        assert store == factory.getobject(store)
+
     def test_getobject(self):
         """Tests that we get a valid object."""
         fileobj = givefile(self.filename, self.file_content)


### PR DESCRIPTION
This is useful to inject existing store as output for convertors.

I've originally made similar change only for one convertor in https://github.com/translate/translate/pull/4022 (now removed), but it turns out to be more generic pattern, so I think placing it into the factory makes more sense.