### PR TITLE
properties: Fix round trip of empty values without delimiter

### DIFF
--- a/translate/convert/po2prop.py
+++ b/translate/convert/po2prop.py
@@ -178,7 +178,7 @@ class reprop:
                         "key": "%s%s%s" % (self.personality.key_wrap_char,
                                            key,
                                            self.personality.key_wrap_char),
-                        "del": delimiter,
+                        "del": delimiter if delimiter_pos != -1 or value else "",
                         "value": "%s%s%s" % (self.personality.value_wrap_char,
                                              self.personality.encode(value),
                                              self.personality.value_wrap_char),

--- a/translate/convert/test_po2prop.py
+++ b/translate/convert/test_po2prop.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from io import BytesIO
 
-from pytest import mark
-
 from translate.convert import po2prop, test_convert
 from translate.storage import po
 
@@ -73,7 +71,6 @@ class TestPO2Prop:
         print(propfile)
         assert propfile == propexpected
 
-    @mark.xfail(reason="This doesn't work as expected right now")
     def test_no_separator(self):
         """check that we can handle keys without separator"""
         posource = '''#: KEY\nmsgctxt "KEY"\nmsgid ""\nmsgstr ""\n'''


### PR DESCRIPTION
Fixes #3620