### PR TITLE
pypo: Bring line wrapping closer to gettext

### DIFF
--- a/translate/storage/test_po.py
+++ b/translate/storage/test_po.py
@@ -998,6 +998,39 @@ msgstr ""
 "\\"
 '''
 
+    def test_wrap_gettext(self):
+        posource = r"""# Test
+msgid ""
+msgstr ""
+"Project-Id-Version: kmail\n"
+"POT-Creation-Date: 2020-05-11 04:03+0200\n"
+"PO-Revision-Date: 2020-05-12 14:13+0000\n"
+"Last-Translator: Roman Savochenko <roman@oscada.org>\n"
+"Language-Team: Ukrainian <https://mirror.git.trinitydesktop.org/weblate/"
+"projects/tdepim/kmail/uk/>\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 4.0.4\n"
+
+#: configuredialog.cpp:4580
+msgid ""
+"x: to be continued with \"do not loop\", \"loop in current folder\", and "
+"\"loop in all folders\".\n"
+"When trying to find unread messages:"
+msgstr "При спробі знайти не прочитані повідомлення:"
+
+msgid ""
+"You can get a copy of your Recovery Key by going to &syncBrand.shortName."
+"label; Options on your other device, and selecting  \"My Recovery Key\" "
+"under \"Manage Account\"."
+msgstr ""
+"""
+        assert self.poreflow(posource) == posource
+
     def test_msgidcomments(self):
         posource = r'''
 msgid ""

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -57,7 +57,7 @@ class TestHelpers():
 
         See :issue:`3140`
         """
-        assert pypo.quoteforpo('''You can get a copy of your Recovery Key by going to &syncBrand.shortName.label; Options on your other device, and selecting  "My Recovery Key" under "Manage Account".''') == [u'""', u'"You can get a copy of your Recovery Key by going to "', u'"&syncBrand.shortName.label; Options on your other device, and selecting  \\""', u'"My Recovery Key\\" under \\"Manage Account\\"."']
+        assert pypo.quoteforpo('''You can get a copy of an recovery key by going to "My Recovery Key" under "Manage Account".''') == ['""', '"You can get a copy of an recovery key by going to \\"My Recovery Key\\" under "', '"\\"Manage Account\\"."']
 
 
 class TestPYPOUnit(test_po.TestPOUnit):


### PR DESCRIPTION
The line wrapping in Getext is more complex and the regexp based
splitter is always an approximation of that, but this makes it behave
more similar to what the original implementation does.

The PO wrapper is now a class instead of monkey patched instance of
generic wrapper.

Fixes https://github.com/WeblateOrg/weblate/issues/3852