### PR TITLE
ini: Raise error on module import

### DIFF
--- a/translate/storage/ini.py
+++ b/translate/storage/ini.py
@@ -35,7 +35,7 @@ from io import StringIO, BytesIO
 try:
     from iniparse import INIConfig
 except ImportError:
-    INIConfig = None
+    raise ImportError("Missing iniparse library.")
 
 from translate.storage import base
 
@@ -100,9 +100,6 @@ class inifile(base.TranslationStore):
 
     def __init__(self, inputfile=None, dialect="default", **kwargs):
         """construct an INI file, optionally reading in from inputfile."""
-        if INIConfig is None:
-            raise NotImplementedError("Missing iniparse library.")
-
         self._dialect = dialects.get(dialect, DialectDefault)()  # fail correctly/use getattr/
         super().__init__(**kwargs)
         self.filename = ''


### PR DESCRIPTION
This is how other formats behave and it is easier to handle than
catching error in constructor.