### PR TITLE
requirements: make lxml required

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,10 +103,9 @@ feature set. This cal be easily specified during pip installation::
 
 The Toolkit requires Python 3.5 or newer.
 
-The package lxml is needed for XML file processing. You should install version
-3.5.0 or later. <http://lxml.de/> Depending on your platform, the easiest way
-to install might be through your system's package management. Alternatively you
-can try ::
+The package lxml is required. You should install version 4.0.0 or later.
+<http://lxml.de/> Depending on your platform, the easiest way to install might
+be through your system's package management. Alternatively you can try ::
 
     pip install lxml
 

--- a/requirements/recommended.txt
+++ b/requirements/recommended.txt
@@ -4,9 +4,6 @@
 # Recommended #
 ###############
 
-# lxml - for XML processing (XLIFF, TMX, TBX, ts, Android)
-lxml>=4.0,!=4.3.1           # XML
-
 # Faster matching in e.g. pot2po
 python-Levenshtein>=0.12    # Levenshtein
 

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -1,0 +1,2 @@
+# lxml - for XML processing (XLIFF, TMX, TBX, ts, Android)
+lxml>=4.0,!=4.3.1

--- a/translate/storage/dtd.py
+++ b/translate/storage/dtd.py
@@ -86,10 +86,8 @@ Escaping in Android DTD
 import re
 import warnings
 from io import BytesIO
-try:
-    from lxml import etree
-except ImportError:
-    etree = None
+
+from lxml import etree
 
 from translate.misc import quote
 from translate.storage import base
@@ -584,7 +582,7 @@ class dtdfile(base.TranslationStore):
         :rtype: Boolean
         """
         # Android files are invalid DTDs
-        if etree is not None and not self.android:
+        if not self.android:
             # #expand is a Mozilla hack and are removed as they are not valid in DTDs
             _input = re.sub(b"#expand", b"", content)
             try:

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -19,15 +19,11 @@
 
 """Parent class for LISA standards (TMX, TBX, XLIFF)"""
 
-
-try:
-    from lxml import etree
-    from translate.misc.xml_helpers import (getText, getXMLlang, getXMLspace,
-                                            namespaced)
-except ImportError as e:
-    raise ImportError("lxml is not installed. It might be possible to continue without support for XML formats.")
+from lxml import etree
 
 from translate.lang import data
+from translate.misc.xml_helpers import (getText, getXMLlang, getXMLspace,
+                                        namespaced)
 from translate.storage import base
 
 


### PR DESCRIPTION
Lot of code uses it without catching the import error and I think it is
used often enough to be required.

Fixes https://github.com/translate/translate/issues/4004

Alternative approach could be to remove now empty requirements.txt, see https://github.com/translate/translate/pull/4002