### PR TITLE
convert: Fix conversion to multiple formats

### DIFF
--- a/translate/convert/odf2xliff.py
+++ b/translate/convert/odf2xliff.py
@@ -53,42 +53,42 @@ def convertodf(inputfile, outputfile, templates):
 
 def main(argv=None):
     # For formats see OpenDocument 1.2 draft 7 Appendix C
-    formats = {
-        "sxw": ("xlf", convertodf),
-        "odt": ("xlf", convertodf),  # Text
-        "ods": ("xlf", convertodf),  # Spreadsheet
-        "odp": ("xlf", convertodf),  # Presentation
-        "odg": ("xlf", convertodf),  # Drawing
-        "odc": ("xlf", convertodf),  # Chart
-        "odf": ("xlf", convertodf),  # Formula
-        "odi": ("xlf", convertodf),  # Image
-        "odm": ("xlf", convertodf),  # Master Document
-        "ott": ("xlf", convertodf),  # Text template
-        "ots": ("xlf", convertodf),  # Spreadsheet template
-        "otp": ("xlf", convertodf),  # Presentation template
-        "otg": ("xlf", convertodf),  # Drawing template
-        "otc": ("xlf", convertodf),  # Chart template
-        "otf": ("xlf", convertodf),  # Formula template
-        "oti": ("xlf", convertodf),  # Image template
-        "oth": ("xlf", convertodf),  # Web page template
-        "sxw": ("xliff", convertodf),
-        "odt": ("xliff", convertodf),  # Text
-        "ods": ("xliff", convertodf),  # Spreadsheet
-        "odp": ("xliff", convertodf),  # Presentation
-        "odg": ("xliff", convertodf),  # Drawing
-        "odc": ("xliff", convertodf),  # Chart
-        "odf": ("xliff", convertodf),  # Formula
-        "odi": ("xliff", convertodf),  # Image
-        "odm": ("xliff", convertodf),  # Master Document
-        "ott": ("xliff", convertodf),  # Text template
-        "ots": ("xliff", convertodf),  # Spreadsheet template
-        "otp": ("xliff", convertodf),  # Presentation template
-        "otg": ("xliff", convertodf),  # Drawing template
-        "otc": ("xliff", convertodf),  # Chart template
-        "otf": ("xliff", convertodf),  # Formula template
-        "oti": ("xliff", convertodf),  # Image template
-        "oth": ("xliff", convertodf),  # Web page template
-    }
+    formats = (
+        ("sxw", ("xlf", convertodf)),
+        ("odt", ("xlf", convertodf)),  # Text
+        ("ods", ("xlf", convertodf)),  # Spreadsheet
+        ("odp", ("xlf", convertodf)),  # Presentation
+        ("odg", ("xlf", convertodf)),  # Drawing
+        ("odc", ("xlf", convertodf)),  # Chart
+        ("odf", ("xlf", convertodf)),  # Formula
+        ("odi", ("xlf", convertodf)),  # Image
+        ("odm", ("xlf", convertodf)),  # Master Document
+        ("ott", ("xlf", convertodf)),  # Text template
+        ("ots", ("xlf", convertodf)),  # Spreadsheet template
+        ("otp", ("xlf", convertodf)),  # Presentation template
+        ("otg", ("xlf", convertodf)),  # Drawing template
+        ("otc", ("xlf", convertodf)),  # Chart template
+        ("otf", ("xlf", convertodf)),  # Formula template
+        ("oti", ("xlf", convertodf)),  # Image template
+        ("oth", ("xlf", convertodf)),  # Web page template
+        ("sxw", ("xliff", convertodf)),
+        ("odt", ("xliff", convertodf)),  # Text
+        ("ods", ("xliff", convertodf)),  # Spreadsheet
+        ("odp", ("xliff", convertodf)),  # Presentation
+        ("odg", ("xliff", convertodf)),  # Drawing
+        ("odc", ("xliff", convertodf)),  # Chart
+        ("odf", ("xliff", convertodf)),  # Formula
+        ("odi", ("xliff", convertodf)),  # Image
+        ("odm", ("xliff", convertodf)),  # Master Document
+        ("ott", ("xliff", convertodf)),  # Text template
+        ("ots", ("xliff", convertodf)),  # Spreadsheet template
+        ("otp", ("xliff", convertodf)),  # Presentation template
+        ("otg", ("xliff", convertodf)),  # Drawing template
+        ("otc", ("xliff", convertodf)),  # Chart template
+        ("otf", ("xliff", convertodf)),  # Formula template
+        ("oti", ("xliff", convertodf)),  # Image template
+        ("oth", ("xliff", convertodf)),  # Web page template
+    )
     parser = convert.ConvertOptionParser(formats, description=__doc__)
     parser.run(argv)
 

--- a/translate/convert/oo2xliff.py
+++ b/translate/convert/oo2xliff.py
@@ -157,12 +157,12 @@ def convertoo(inputfile, outputfile, templates, pot=False, sourcelanguage=None, 
 
 def main(argv=None):
     from translate.convert import convert
-    formats = {
-        "oo": ("xlf", convertoo),
-        "sdf": ("xlf", convertoo),
-        "oo": ("xliff", convertoo),
-        "sdf": ("xliff", convertoo),
-    }
+    formats = (
+        ("oo", ("xlf", convertoo)),
+        ("sdf", ("xlf", convertoo)),
+        ("oo", ("xliff", convertoo)),
+        ("sdf", ("xliff", convertoo)),
+    )
     # always treat the input as an archive unless it is a directory
     archiveformats = {(None, "input"): oo.oomultifile}
     parser = convert.ArchiveConvertOptionParser(formats, usepots=False,

--- a/translate/convert/po2xliff.py
+++ b/translate/convert/po2xliff.py
@@ -101,12 +101,12 @@ def convertpo(inputfile, outputfile, templatefile):
 
 def main(argv=None):
     from translate.convert import convert
-    formats = {
-        "po": ("xlf", convertpo),
-        ("po", "xlf"): ("xlf", convertpo),
-        "po": ("xliff", convertpo),
-        ("po", "xliff"): ("xliff", convertpo),
-    }
+    formats = (
+        ("po", ("xlf", convertpo)),
+        (("po", "xlf"), ("xlf", convertpo)),
+        ("po", ("xliff", convertpo)),
+        (("po", "xliff"), ("xliff", convertpo)),
+    )
     parser = convert.ConvertOptionParser(formats, usetemplates=True,
                                          description=__doc__)
     parser.run(argv)

--- a/translate/convert/po2yaml.py
+++ b/translate/convert/po2yaml.py
@@ -96,12 +96,12 @@ def run_converter(inputfile, outputfile, templatefile=None, includefuzzy=False,
                    outputthreshold).run()
 
 
-formats = {
-    ("po", "yml"): ("yml", run_converter),
-    "po": ("yml", run_converter),
-    ("po", "yaml"): ("yaml", run_converter),
-    "po": ("yaml", run_converter),
-}
+formats = (
+    (("po", "yml"), ("yml", run_converter)),
+    ("po", ("yml", run_converter)),
+    (("po", "yaml"), ("yaml", run_converter)),
+    ("po", ("yaml", run_converter)),
+)
 
 
 def main(argv=None):

--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -249,7 +249,7 @@ class RecursiveOptionParser(optparse.OptionParser):
     def setformats(self, formats, usetemplates):
         """Sets the format options using the given format dictionary.
 
-        :type formats: Dictionary
+        :type formats: Dictionary or iterable
         :param formats: The dictionary *keys* should be:
 
                         - Single strings (or 1-tuples) containing an
@@ -268,7 +268,9 @@ class RecursiveOptionParser(optparse.OptionParser):
         templateformats = []
         self.outputoptions = {}
         self.usetemplates = usetemplates
-        for formatgroup, outputoptions in formats.items():
+        if isinstance(formats, dict):
+            formats = formats.items()
+        for formatgroup, outputoptions in formats:
             if isinstance(formatgroup, str) or formatgroup is None:
                 formatgroup = (formatgroup, )
             if not isinstance(formatgroup, tuple):


### PR DESCRIPTION
The dictionaries had duplicate keys, which are silently ignored. Changed
optrecurse to accept iterable and store the formats in tuple instead.