### PR TITLE
tests: Resolve duplicate method names

### DIFF
--- a/translate/convert/test_csv2po.py
+++ b/translate/convert/test_csv2po.py
@@ -125,8 +125,8 @@ msgstr ""
         assert pounit.source == "Source"
         assert pounit.target == "Target"
 
-    def test_newlines(self):
-        """Tests that things keep working with empty entries"""
+    def test_escaped_newlines(self):
+        """Tests that things keep working with escaped newlines"""
         minicsv = '"source","target"\r\n"yellow pencil","żółty\\nołówek"'
         pofile = self.csv2po(minicsv)
         assert pofile.findunit("yellow pencil") is not None

--- a/translate/storage/test_php.py
+++ b/translate/storage/test_php.py
@@ -961,7 +961,7 @@ spanning multiple lines
 using nowdoc syntax.'''
         assert phpfile.units[0].name == '$str'
 
-    def test_concatenation(self):
+    def test_plain_concatenation(self):
         """check parsing concatenated strings"""
         phpsource = """$str = 'Concatenated' . ' ' . 'string';
         $arr['x'] = 'Concatenated' . ' ' . 'string';

--- a/translate/storage/test_po.py
+++ b/translate/storage/test_po.py
@@ -1052,7 +1052,7 @@ msgstr ""
         assert unit.source == 'The actual source text'
         assert unit.target.startswith('_: ')
 
-    def test_unicode(self):
+    def test_unicode_ids(self):
         posource = b'''
 msgid ""
 msgstr ""

--- a/translate/storage/test_trados.py
+++ b/translate/storage/test_trados.py
@@ -1,6 +1,7 @@
 
 from pytest import importorskip
 
+
 trados = importorskip("translate.storage.trados")
 
 


### PR DESCRIPTION
Some test methods were duplicate leading to ignoring one of them.