### PR TITLE
Use LRU cache for imports

### DIFF
--- a/translate/lang/factory.py
+++ b/translate/lang/factory.py
@@ -18,8 +18,9 @@
 
 """This module provides a factory to instantiate language classes."""
 
-
 import pkgutil
+from functools import lru_cache
+from importlib import import_module
 
 from translate.lang import common, data
 
@@ -27,6 +28,7 @@ from translate.lang import common, data
 prefix = "code_"
 
 
+@lru_cache(maxsize=128)
 def getlanguage(code):
     """This returns a language class.
 
@@ -41,8 +43,7 @@ def getlanguage(code):
             internal_code = prefix + code
         else:
             internal_code = code
-        module = __import__("translate.lang.%s" % internal_code, globals(), {},
-                            internal_code)
+        module = import_module("translate.lang.%s" % internal_code)
         langclass = getattr(module, internal_code)
         return langclass(code)
     except ImportError:

--- a/translate/storage/benchmark.py
+++ b/translate/storage/benchmark.py
@@ -22,6 +22,7 @@ import os
 import pstats
 import random
 import sys
+from importlib import import_module
 
 from translate.storage import factory, placeables
 
@@ -117,8 +118,7 @@ if __name__ == "__main__":
 
     if storetype in factory.classes_str:
         _module, _class = factory.classes_str[storetype]
-        module = __import__("translate.storage.%s" % _module,
-                            globals(), fromlist=_module)
+        module = import_module("translate.storage.%s" % _module)
         storeclass = getattr(module, _class)
     else:
         print("StoreClass: '%s' is not a base class that the class factory can load" % storetype)


### PR DESCRIPTION
- User functools.lru_cache to cache imports
- Switch to import_module for doing imports
- Remove own cache implementation in versioncontrol

Based on suggestions in #3492