### PR TITLE
Support XWiki Formats

### DIFF
--- a/translate/misc/quote.py
+++ b/translate/misc/quote.py
@@ -330,10 +330,13 @@ def java_utf8_properties_encode(source):
     return output
 
 
-def xwiki_properties_encode(source):
+def xwiki_properties_encode(source, encoding):
     if re.search(r"\{[0-9]+\}", source):
         source = source.replace("'", "''")
-    return javapropertiesencode(source)
+    if encoding == 'utf-8':
+        return java_utf8_properties_encode(source)
+    else:
+        return javapropertiesencode(source)
 
 
 def escapespace(char):

--- a/translate/misc/quote.py
+++ b/translate/misc/quote.py
@@ -22,6 +22,7 @@ delimiters
 
 import html.entities
 import logging
+import re
 
 
 def find_all(searchin, substr):
@@ -328,6 +329,10 @@ def java_utf8_properties_encode(source):
             output += char
     return output
 
+def xwiki_properties_encode(source):
+    if re.search(r"\{[0-9]+\}", source):
+        source = source.replace("'", "''")
+    return javapropertiesencode(source)
 
 def escapespace(char):
     assert(len(char) == 1)
@@ -458,6 +463,10 @@ def propertiesdecode(source):
             output += c  # Drop any \ that we don't specifically handle
     return output
 
+def xwiki_properties_decode(source):
+    if re.search(r"\{[0-9]+\}", source):
+        source = source.replace("''", "'")
+    return propertiesdecode(source)
 
 def findend(string, substring):
     s = string.find(substring)

--- a/translate/misc/quote.py
+++ b/translate/misc/quote.py
@@ -329,10 +329,12 @@ def java_utf8_properties_encode(source):
             output += char
     return output
 
+
 def xwiki_properties_encode(source):
     if re.search(r"\{[0-9]+\}", source):
         source = source.replace("'", "''")
     return javapropertiesencode(source)
+
 
 def escapespace(char):
     assert(len(char) == 1)
@@ -463,10 +465,12 @@ def propertiesdecode(source):
             output += c  # Drop any \ that we don't specifically handle
     return output
 
+
 def xwiki_properties_decode(source):
     if re.search(r"\{[0-9]+\}", source):
         source = source.replace("''", "'")
     return propertiesdecode(source)
+
 
 def findend(string, substring):
     s = string.find(substring)

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -1226,9 +1226,9 @@ class XWikiPageProperties(xwikifile):
     """
 
     def __init__(self, *args, **kwargs):
-        kwargs['personality'] = "java-utf8"
+        kwargs['personality'] = "xwiki"
         kwargs['encoding'] = "utf-8"
-        super(XWikiPageProperties, self).__init__(*args, **kwargs)
+        super(xwikifile, self).__init__(*args, **kwargs)
         self.root = None
 
     def parse(self, propsrc):
@@ -1249,7 +1249,7 @@ class XWikiPageProperties(xwikifile):
 
     def write_xwiki_xml(self, newroot, out):
         xml_content = ElementTree.tostring(newroot,
-                                           encoding=None,
+                                           encoding=self.encoding,
                                            method="xml")
         out.write(self.XML_HEADER.encode(self.encoding))
         out.write(xml_content)

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -33,6 +33,7 @@ Currently we support:
 - Adobe Flex files
 - MacOS X .strings files
 - Skype .lang files
+- XWiki .properties
 
 The following provides references and descriptions of the various
 dialects supported:
@@ -72,6 +73,13 @@ Flex
 
 Skype
     Skype .lang files seem to be UTF-16 encoded .properties files.
+
+XWiki
+    XWiki translations files are standard Java .properties but with specific escaping
+    support for simple quotes, and support of missing translations.
+    This
+    `page <https://dev.xwiki.org/xwiki/bin/view/Community/XWiki%20Translations%20Formats/>`_
+    provides the information used to implement the dialect.
 
 A simple summary of what is permissible follows.
 
@@ -726,6 +734,10 @@ class proppluralunit(base.TranslationUnit):
     @property
     def missing(self):
         return self._get_source_unit().missing
+
+    @missing.setter
+    def missing(self, missing):
+        self._get_source_unit().missing = missing
 
     def __str__(self):
         """Convert to a string. Double check that unicode is handled

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -1228,8 +1228,8 @@ class XWikiPageProperties(xwikifile):
     def __init__(self, *args, **kwargs):
         kwargs['personality'] = "xwiki"
         kwargs['encoding'] = "utf-8"
-        super(xwikifile, self).__init__(*args, **kwargs)
         self.root = None
+        super(xwikifile, self).__init__(*args, **kwargs)
 
     def parse(self, propsrc):
         if propsrc != b"\n":

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -395,7 +395,7 @@ class DialectXWiki(DialectJava):
 
     @classmethod
     def encode(cls, string, encoding=None):
-        return quote.xwiki_properties_encode(string or "")
+        return quote.xwiki_properties_encode(string or "", encoding)
 
     @classmethod
     def decode(cls, string):

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -1234,8 +1234,7 @@ class XWikiPageProperties(xwikifile):
     def parse(self, propsrc):
         if propsrc != b"\n":
             self.root = ElementTree.XML(propsrc)
-            content = ""\
-                .join(self.root.find("content").itertext())
+            content = "".join(self.root.find("content").itertext())
             content = unescape(content).encode(self.encoding)
             super(XWikiPageProperties, self).parse(content)
 

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -802,7 +802,7 @@ class propunit(base.TranslationUnit):
     @property
     def missing(self):
         return self.explicitely_missing\
-               or (not bool(self.translation) and not bool(self.source))
+            or (not bool(self.translation) and not bool(self.source))
 
     @missing.setter
     def missing(self, missing):

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -1190,6 +1190,7 @@ class XWikiPageProperties(xwikifile):
     Represents an XWiki Page containing translation properties as described in
     https://dev.xwiki.org/xwiki/bin/view/Community/XWiki%20Translations%20Formats/#HXWikiPageProperties
     """
+
     Name = "XWiki Page Properties"
     Extensions = ['xml']
     XML_HEADER = """<?xml version="1.1" encoding="UTF-8"?>
@@ -1216,7 +1217,7 @@ class XWikiPageProperties(xwikifile):
 
     """
 
-    XWIKI_BASIC_XML = """<xwikidoc version="1.3" reference="" locale="">
+    XWIKI_BASIC_XML = """<xwikidoc>
     <translation>0</translation>
     <language/>
     <content/>
@@ -1270,6 +1271,7 @@ class XWikiFullPage(XWikiPageProperties):
     More information on
     https://dev.xwiki.org/xwiki/bin/view/Community/XWiki%20Translations%20Formats/#HXWikiFullContentTranslation
     """
+    
     Name = "XWiki Full Page"
 
     def parse(self, propsrc):

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -1283,8 +1283,7 @@ class XWikiFullPage(XWikiPageProperties):
             title = "".join(self.root.find("title").itertext())
             forparsing = ""
             if content != "":
-                forparsing += "content={}\n"\
-                    .format(unescape(content))
+                forparsing += "content={}\n".format(unescape(content))
             if title != "":
                 forparsing += "title={}\n" \
                     .format(unescape(title))

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -1285,8 +1285,7 @@ class XWikiFullPage(XWikiPageProperties):
             if content != "":
                 forparsing += "content={}\n".format(unescape(content))
             if title != "":
-                forparsing += "title={}\n" \
-                    .format(unescape(title))
+                forparsing += "title={}\n".format(unescape(title))
             super(XWikiPageProperties, self).parse(forparsing.encode(self.encoding))
 
     def serialize(self, out):

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -1280,8 +1280,7 @@ class XWikiFullPage(XWikiPageProperties):
             content = ""\
                 .join(self.root.find("content").itertext())\
                 .replace("\n", "\\n")
-            title = ""\
-                .join(self.root.find("title").itertext())
+            title = "".join(self.root.find("title").itertext())
             forparsing = ""
             if content != "":
                 forparsing += "content={}\n"\

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -78,7 +78,7 @@ XWiki
     XWiki translations files are standard Java .properties but with specific escaping
     support for simple quotes, and support of missing translations.
     This
-    `page <https://dev.xwiki.org/xwiki/bin/view/Community/XWiki%20Translations%20Formats/>`_
+    `XWiki document <https://dev.xwiki.org/xwiki/bin/view/Community/XWiki%20Translations%20Formats/>`_
     provides the information used to implement the dialect.
 
 A simple summary of what is permissible follows.

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -380,6 +380,7 @@ class DialectXWiki(DialectJava):
     simple quotes: they are escaped by doubling them when an argument on the form "{X}"
     is provided, X being a number.
     """
+
     name = "xwiki"
     default_encoding = "iso-8859-1"
     delimiters = ["=", ":", " "]
@@ -931,10 +932,12 @@ class propunit(base.TranslationUnit):
 
 
 class xwikiunit(propunit):
-    """Represents an XWiki translation unit. The difference with a propunit is twofold:
+    """
+    Represents an XWiki translation unit. The difference with a propunit is twofold:
             1. the dialect used is xwiki for simple quote escape handling
             2. missing translations are output with a dedicated "### Missing: " prefix
-        """
+    """
+
     def __init__(self, source="", personality="xwiki"):
         super().__init__(source, personality)
         self.output_missing = True

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -1,5 +1,5 @@
 
-from io import BytesIO, StringIO
+from io import BytesIO
 
 from pytest import raises
 
@@ -1103,5 +1103,4 @@ class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
             D'autres trucs.
             </content>
             </xwikidoc>"""
-        assert generatedcontent.getvalue().decode(
-            propfile.encoding) == expected_xml + "\n"
+        assert generatedcontent.getvalue().decode(propfile.encoding) == expected_xml + "\n"

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -617,6 +617,15 @@ class TestXWiki(test_monolingual.TestMonolingualStore):
         assert propunit.missing
         propunit.target = "Je peux coder"
         assert not propunit.missing
+        # Check encoding
+        propunit.target = "تىپتىكى خىزمەتنى باشلاش"
+        expected_content = "test_me=\\u062A\\u0649\\u067E\\u062A\\u0649\\u0643\\u0649 " \
+                           "\\u062E\\u0649\\u0632\\u0645\\u06D5\\u062A\\u0646\\u0649 " \
+                           "\\u0628\\u0627\\u0634\\u0644\\u0627\\u0634"
+
+        generatedcontent = BytesIO()
+        propfile.serialize(generatedcontent)
+        assert generatedcontent.getvalue().decode(propfile.encoding) == expected_content + "\n"
 
     def test_missing_definition_source(self):
         propsource = '### Missing: test_me=I can code!'
@@ -694,6 +703,11 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
         assert propunit.missing
         propunit.target = "Je peux coder"
         assert not propunit.missing
+        propunit.target = "تىپتىكى خىزمەتنى باشلاش"
+        expected_content = self.getcontent("test_me=تىپتىكى خىزمەتنى باشلاش")
+        generatedcontent = BytesIO()
+        propfile.serialize(generatedcontent)
+        assert generatedcontent.getvalue().decode(propfile.encoding) == expected_content + "\n"
 
     def test_missing_definition_source(self):
         propsource = self.getcontent('### Missing: test_me=I can code!')
@@ -710,7 +724,7 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
         assert not propunit.missing
         generatedcontent = BytesIO()
         propfile.serialize(generatedcontent)
-        assert generatedcontent.getvalue().decode("utf-8") == propsource + "\n"
+        assert generatedcontent.getvalue().decode(propfile.encoding) == propsource + "\n"
 
     def test_definition_with_simple_quote_and_argument(self):
         propsource = self.getcontent("test_me=A ''quoted'' translation for {0}")
@@ -722,17 +736,17 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
         assert not propunit.missing
         generatedcontent = BytesIO()
         propfile.serialize(generatedcontent)
-        assert generatedcontent.getvalue().decode("utf-8") == propsource + "\n"
+        assert generatedcontent.getvalue().decode(propfile.encoding) == propsource + "\n"
 
 
 class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
     StoreClass = properties.XWikiFullPage
     FILE_SCHEME = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc>
-        <translation>1</translation>
-        <language />
-        <title>%(title)s</title>
-        <content>%(content)s</content>
-        </xwikidoc>"""
+    <translation>1</translation>
+    <language />
+    <title>%(title)s</title>
+    <content>%(content)s</content>
+    </xwikidoc>"""
 
     def getcontent(self, content, title):
         return self.FILE_SCHEME % {'content': content, 'title': title}
@@ -757,10 +771,17 @@ class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
         assert propunit.name == "content"
         assert propunit.source == "I can code!"
         assert not propunit.missing
+        propunit.target = "A new code!"
         propunit = propfile.units[1]
         assert propunit.name == "title"
         assert propunit.source == "This is a title"
         assert not propunit.missing
+        # Check encoding
+        propunit.target = "تىپتىكى خىزمەتنى باشلاش"
+        expected_content = self.getcontent("A new code!", "تىپتىكى خىزمەتنى باشلاش")
+        generatedcontent = BytesIO()
+        propfile.serialize(generatedcontent)
+        assert generatedcontent.getvalue().decode(propfile.encoding) == expected_content + "\n"
 
     def test_parse(self):
         """Tests converting to a string and parsing the resulting string.

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -580,6 +580,7 @@ job.log.begin=Starting job of type [{0}]
         print(propsource)
         assert bytes(propfile) == propsource
 
+
 class TestXWiki(test_monolingual.TestMonolingualStore):
     StoreClass = properties.xwikifile
 

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -753,7 +753,10 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
         """Ensure that the XML is correctly formatted during serialization:
         it should not contain objects or attachments tags, and translation should be
         set to 1."""
-        propsource = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc version="1.3" reference="XWiki.AdminTranslations" locale="">
+        ## Real XWiki files are containing multiple attributes on xwikidoc tag: we're not testing it there
+        ## because ElementTree changed its implementation between Python 3.7 and 3.8 which changed the order of output of the attributes
+        ## it makes it more difficult to assert it on multiple versions of Python.
+        propsource = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc reference="XWiki.AdminTranslations">
             <web>XWiki</web>
             <name>AdminTranslations</name>
             <language/>
@@ -828,7 +831,7 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
         propunit.target = "Je peux coder !"
         generatedcontent = BytesIO()
         propfile.serialize(generatedcontent)
-        expected_xml = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc version="1.3" reference="XWiki.AdminTranslations" locale="">
+        expected_xml = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc reference="XWiki.AdminTranslations">
             <web>XWiki</web>
             <name>AdminTranslations</name>
             <language>fr</language>
@@ -986,7 +989,10 @@ class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
         """Ensure that the XML is correctly formatted during serialization:
         it should not contain objects or attachments tags, and translation should be
         set to 1."""
-        propsource = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc version="1.3" reference="XWiki.AdminTranslations" locale="">
+        ## Real XWiki files are containing multiple attributes on xwikidoc tag: we're not testing it there
+        ## because ElementTree changed its implementation between Python 3.7 and 3.8 which changed the order of output of the attributes
+        ## it makes it more difficult to assert it on multiple versions of Python.
+        propsource = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc reference="XWiki.AdminTranslations">
             <web>XWiki</web>
             <name>AdminTranslations</name>
             <language/>
@@ -1080,7 +1086,7 @@ class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
         generatedcontent = BytesIO()
         propfile.settargetlanguage("fr")
         propfile.serialize(generatedcontent)
-        expected_xml = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc version="1.3" reference="XWiki.AdminTranslations" locale="">
+        expected_xml = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc reference="XWiki.AdminTranslations">
             <web>XWiki</web>
             <name>AdminTranslations</name>
             <language>fr</language>

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -749,6 +749,106 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
         propfile.serialize(generatedcontent)
         assert generatedcontent.getvalue().decode(propfile.encoding) == propsource + "\n"
 
+    def test_cleaning_attributes(self):
+        """Ensure that the XML is correctly formatted during serialization:
+        it should not contain objects or attachments tags, and translation should be
+        set to 1."""
+        propsource = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc version="1.3" reference="XWiki.AdminTranslations" locale="">
+            <web>XWiki</web>
+            <name>AdminTranslations</name>
+            <language/>
+            <defaultLanguage>en</defaultLanguage>
+            <translation>0</translation>
+            <creator>xwiki:XWiki.Admin</creator>
+            <parent>XWiki.WebHome</parent>
+            <author>xwiki:XWiki.Admin</author>
+            <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+            <version>1.1</version>
+            <title>AdminTranslations</title>
+            <comment/>
+            <minorEdit>false</minorEdit>
+            <syntaxId>plain/1.0</syntaxId>
+            <hidden>true</hidden>
+            <content># Users Section
+            test_me=I can code!
+            </content>
+            <object>
+                <name>XWiki.AdminTranslations</name>
+                <number>0</number>
+                <className>XWiki.TranslationDocumentClass</className>
+                <guid>554b2ee4-98dc-48ef-b436-ef0cf7d38c4f</guid>
+                <class>
+                  <name>XWiki.TranslationDocumentClass</name>
+                  <customClass/>
+                  <customMapping/>
+                  <defaultViewSheet/>
+                  <defaultEditSheet/>
+                  <defaultWeb/>
+                  <nameField/>
+                  <validationScript/>
+                  <scope>
+                    <cache>0</cache>
+                    <disabled>0</disabled>
+                    <displayType>select</displayType>
+                    <freeText>forbidden</freeText>
+                    <multiSelect>0</multiSelect>
+                    <name>scope</name>
+                    <number>1</number>
+                    <prettyName>Scope</prettyName>
+                    <relationalStorage>0</relationalStorage>
+                    <separator> </separator>
+                    <separators>|, </separators>
+                    <size>1</size>
+                    <unmodifiable>0</unmodifiable>
+                    <values>GLOBAL|WIKI|USER|ON_DEMAND</values>
+                    <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+                  </scope>
+                </class>
+                <property>
+                  <scope>WIKI</scope>
+                </property>
+            </object>
+            <attachment>
+                <filename>XWikiLogo.png</filename>
+                <mimetype>image/png</mimetype>
+                <filesize>1390</filesize>
+                <author>xwiki:XWiki.Admin</author>
+                <version>1.1</version>
+                <comment/>
+                <content>something=toto</content>
+            </attachment>
+        </xwikidoc>"""
+        propfile = self.propparse(propsource)
+        assert len(propfile.units) == 1
+        propunit = propfile.units[0]
+        propfile.settargetlanguage("fr")
+        assert propunit.name == "test_me"
+        assert propunit.source == "I can code!"
+        assert not propunit.missing
+        propunit.target = "Je peux coder !"
+        generatedcontent = BytesIO()
+        propfile.serialize(generatedcontent)
+        expected_xml = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc version="1.3" reference="XWiki.AdminTranslations" locale="">
+            <web>XWiki</web>
+            <name>AdminTranslations</name>
+            <language>fr</language>
+            <defaultLanguage>en</defaultLanguage>
+            <translation>1</translation>
+            <creator>xwiki:XWiki.Admin</creator>
+            <parent>XWiki.WebHome</parent>
+            <author>xwiki:XWiki.Admin</author>
+            <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+            <version>1.1</version>
+            <title>AdminTranslations</title>
+            <comment />
+            <minorEdit>false</minorEdit>
+            <syntaxId>plain/1.0</syntaxId>
+            <hidden>true</hidden>
+            <content># Users Section
+test_me=Je peux coder !</content>
+            </xwikidoc>"""
+        assert generatedcontent.getvalue().decode(propfile.encoding) == expected_xml + "\n"
+
 
 class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
     StoreClass = properties.XWikiFullPage
@@ -881,3 +981,127 @@ class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
         assert newstore.units[0]._get_source_unit().source == store.units[2].target
         assert newstore.units[1]._get_source_unit().name == store.units[3].name
         assert newstore.units[1]._get_source_unit().source == store.units[3].target
+
+    def test_cleaning_attributes(self):
+        """Ensure that the XML is correctly formatted during serialization:
+        it should not contain objects or attachments tags, and translation should be
+        set to 1."""
+        propsource = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc version="1.3" reference="XWiki.AdminTranslations" locale="">
+            <web>XWiki</web>
+            <name>AdminTranslations</name>
+            <language/>
+            <defaultLanguage>en</defaultLanguage>
+            <translation>0</translation>
+            <creator>xwiki:XWiki.Admin</creator>
+            <parent>XWiki.WebHome</parent>
+            <author>xwiki:XWiki.Admin</author>
+            <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+            <version>1.1</version>
+            <title>Some page title</title>
+            <comment/>
+            <minorEdit>false</minorEdit>
+            <syntaxId>plain/1.0</syntaxId>
+            <hidden>true</hidden>
+            <content>A Lorem Ipsum or whatever might be contained there.
+
+            == A wiki title ==
+
+            Some other stuff.
+            </content>
+            <object>
+                <name>XWiki.AdminTranslations</name>
+                <number>0</number>
+                <className>XWiki.TranslationDocumentClass</className>
+                <guid>554b2ee4-98dc-48ef-b436-ef0cf7d38c4f</guid>
+                <class>
+                  <name>XWiki.TranslationDocumentClass</name>
+                  <customClass/>
+                  <customMapping/>
+                  <defaultViewSheet/>
+                  <defaultEditSheet/>
+                  <defaultWeb/>
+                  <nameField/>
+                  <validationScript/>
+                  <scope>
+                    <cache>0</cache>
+                    <disabled>0</disabled>
+                    <displayType>select</displayType>
+                    <freeText>forbidden</freeText>
+                    <multiSelect>0</multiSelect>
+                    <name>scope</name>
+                    <number>1</number>
+                    <prettyName>Scope</prettyName>
+                    <relationalStorage>0</relationalStorage>
+                    <separator> </separator>
+                    <separators>|, </separators>
+                    <size>1</size>
+                    <unmodifiable>0</unmodifiable>
+                    <values>GLOBAL|WIKI|USER|ON_DEMAND</values>
+                    <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+                  </scope>
+                </class>
+                <property>
+                  <scope>WIKI</scope>
+                </property>
+            </object>
+            <attachment>
+                <filename>XWikiLogo.png</filename>
+                <mimetype>image/png</mimetype>
+                <filesize>1390</filesize>
+                <author>xwiki:XWiki.Admin</author>
+                <version>1.1</version>
+                <comment/>
+                <content>something=toto</content>
+            </attachment>
+        </xwikidoc>"""
+        propfile = self.propparse(propsource)
+        assert len(propfile.units) == 2
+        propunit = propfile.units[0]
+        assert propunit.name == "content"
+        assert propunit.source == """A Lorem Ipsum or whatever might be contained there.
+
+            == A wiki title ==
+
+            Some other stuff.
+            """
+        assert not propunit.missing
+        propunit.target = """Un Lorem Ipsum ou quoi que ce soit qui puisse être là.
+
+            == Un titre de wiki ==
+
+            D'autres trucs.
+            """
+        propunit = propfile.units[1]
+        assert propunit.name == "title"
+        assert propunit.source == "Some page title"
+        assert not propunit.missing
+        propunit.target = "Un titre de page"
+
+        generatedcontent = BytesIO()
+        propfile.settargetlanguage("fr")
+        propfile.serialize(generatedcontent)
+        expected_xml = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc version="1.3" reference="XWiki.AdminTranslations" locale="">
+            <web>XWiki</web>
+            <name>AdminTranslations</name>
+            <language>fr</language>
+            <defaultLanguage>en</defaultLanguage>
+            <translation>1</translation>
+            <creator>xwiki:XWiki.Admin</creator>
+            <parent>XWiki.WebHome</parent>
+            <author>xwiki:XWiki.Admin</author>
+            <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+            <version>1.1</version>
+            <title>Un titre de page</title>
+            <comment />
+            <minorEdit>false</minorEdit>
+            <syntaxId>plain/1.0</syntaxId>
+            <hidden>true</hidden>
+            <content>Un Lorem Ipsum ou quoi que ce soit qui puisse être là.
+
+            == Un titre de wiki ==
+
+            D'autres trucs.
+            </content>
+            </xwikidoc>"""
+        assert generatedcontent.getvalue().decode(
+            propfile.encoding) == expected_xml + "\n"

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -785,8 +785,10 @@ class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
         store.makeindex()
         newstore = self.reparse(store)
         assert 2 == len(newstore.units)
-        assert newstore.units[0] == newstore.units[0]
-        assert newstore.units[1] == newstore.units[1]
+        assert newstore.units[0]._get_source_unit().name == store.units[2].name
+        assert newstore.units[0]._get_source_unit().source == store.units[2].target
+        assert newstore.units[1]._get_source_unit().name == store.units[3].name
+        assert newstore.units[1]._get_source_unit().source == store.units[3].target
 
     def test_files(self):
         """Tests saving to and loading from files
@@ -811,8 +813,10 @@ class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
         store.savefile(self.filename)
         newstore = self.StoreClass.parsefile(self.filename)
         assert 2 == len(newstore.units)
-        assert newstore.units[0] == newstore.units[0]
-        assert newstore.units[1] == newstore.units[1]
+        assert newstore.units[0]._get_source_unit().name == store.units[2].name
+        assert newstore.units[0]._get_source_unit().source == store.units[2].target
+        assert newstore.units[1]._get_source_unit().name == store.units[3].name
+        assert newstore.units[1]._get_source_unit().source == store.units[3].target
 
     def test_save(self):
         """Tests that we can save directly back to the original file.
@@ -839,5 +843,7 @@ class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
         store.save()
         newstore = self.StoreClass.parsefile(self.filename)
         assert 2 == len(newstore.units)
-        assert newstore.units[0] == newstore.units[0]
-        assert newstore.units[1] == newstore.units[1]
+        assert newstore.units[0]._get_source_unit().name == store.units[2].name
+        assert newstore.units[0]._get_source_unit().source == store.units[2].target
+        assert newstore.units[1]._get_source_unit().name == store.units[3].name
+        assert newstore.units[1]._get_source_unit().source == store.units[3].target

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -646,14 +646,14 @@ class TestXWiki(test_monolingual.TestMonolingualStore):
 
 class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
     StoreClass = properties.XWikiPageProperties
-    FILE_SCHEME = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc version="1.3" reference="" locale="">
+    FILE_SCHEME = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc>
     <translation>1</translation>
     <language />
     <content>%(content)s</content>
     </xwikidoc>"""
 
     def getcontent(self, content):
-        return self.FILE_SCHEME % { 'content': content }
+        return self.FILE_SCHEME % {'content': content}
 
     def propparse(self, propsource):
         """helper that parses properties source without requiring files"""

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -601,7 +601,7 @@ class TestXWiki(test_monolingual.TestMonolingualStore):
         propunit = propfile.units[0]
         assert propunit.name == "test_me"
         assert propunit.source == "I can code!"
-        assert propunit.missing == False
+        assert not propunit.missing
 
     def test_missing_definition(self):
         """checks that a simple missing properties definition is parsed correctly"""
@@ -611,11 +611,11 @@ class TestXWiki(test_monolingual.TestMonolingualStore):
         propunit = propfile.units[0]
         assert propunit.name == "test_me"
         assert propunit.source == "I can code!"
-        assert propunit.missing == True
+        assert propunit.missing
         propunit.target = ""
-        assert propunit.missing == True
+        assert propunit.missing
         propunit.target = "Je peux coder"
-        assert propunit.missing == False
+        assert not propunit.missing
 
     def test_missing_definition_source(self):
         propsource = '### Missing: test_me=I can code!'
@@ -629,7 +629,7 @@ class TestXWiki(test_monolingual.TestMonolingualStore):
         propunit = propfile.units[0]
         assert propunit.name == "test_me"
         assert propunit.source == "A 'quoted' translation"
-        assert propunit.missing == False
+        assert not propunit.missing
         assert propunit.getoutput() == propsource + "\n"
 
     def test_definition_with_simple_quote_and_argument(self):
@@ -639,5 +639,5 @@ class TestXWiki(test_monolingual.TestMonolingualStore):
         propunit = propfile.units[0]
         assert propunit.name == "test_me"
         assert propunit.source == "A 'quoted' translation for {0}"
-        assert propunit.missing == False
+        assert not propunit.missing
         assert propunit.getoutput() == propsource + "\n"


### PR DESCRIPTION
  * Informations about XWiki Translation Format are available there: https://dev.xwiki.org/xwiki/bin/view/Community/XWiki%20Translations%20Formats/
  * Add new xwiki dialect to handle special escape of simple quotes
  * Improve propunit to allow handling missing translations serialized
    in comments
  * Add xwiki unit that uses xwiki dialect and a specific comment prefix
    for missing translations
  * Add xwiki file that uses xwiki units