### PR TITLE
Android: Fix escaping double space with HTML

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -214,6 +214,9 @@ class AndroidResourceUnit(base.TranslationUnit):
         # Join the string together again, but w/o EOF marker
         return "".join(text[:-1])
 
+    def xml_escape_space(self, matchobj):
+        return matchobj.group(0).replace('  ', r' \u0020')
+
     def escape(self, text, quote_wrapping_whitespaces=True):
         """Escape all the characters which need to be escaped in an Android XML
         file.
@@ -240,9 +243,13 @@ class AndroidResourceUnit(base.TranslationUnit):
         if text.startswith('@'):
             text = '\\@' + text[1:]
         # Quote strings with more whitespace
-        if ((quote_wrapping_whitespaces and (text[0] in WHITESPACE or text[-1] in WHITESPACE))
-                or len(MULTIWHITESPACE.findall(text))) > 0:
+        multispace = MULTIWHITESPACE.findall(text)
+        if (quote_wrapping_whitespaces and (text[0] in WHITESPACE or text[-1] in WHITESPACE or multispace)):
             return '"%s"' % text
+        # In xml multispace
+        if not quote_wrapping_whitespaces and multispace:
+            return MULTIWHITESPACE.sub(self.xml_escape_space, text)
+
         return text
 
     @base.TranslationUnit.source.getter

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -177,13 +177,13 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
 
     def test_escape_html_double_space(self):
         string = '<b>html code \'to  escape\'</b> some \'here\''
-        xml = ('<string name="teststring"><b>"html code \\\'to  escape\\\'"</b> some \\\'here\\\''
+        xml = ('<string name="teststring"><b>html code \\\'to \\u0020escape\\\'</b> some \\\'here\\\''
                '</string>\n')
         self.__check_escape(string, xml)
 
     def test_escape_html_deep_double_space(self):
         string = '<b>html code \'to  <i>escape</i>\'</b> some \'here\''
-        xml = ('<string name="teststring"><b>"html code \\\'to  "<i>escape</i>\\\'</b> some \\\'here\\\''
+        xml = ('<string name="teststring"><b>html code \\\'to \\u0020<i>escape</i>\\\'</b> some \\\'here\\\''
                '</string>\n')
         self.__check_escape(string, xml)
 
@@ -372,7 +372,7 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
 
     def test_parse_html_double_space_quoted(self):
         string = '<b>html code \'to  escape\'</b> some \'here\''
-        xml = ('<string name="teststring"><b>"html code \'to  escape\'"</b>" some \'here\'"'
+        xml = ('<string name="teststring"><b>html code \'to \\u0020escape\'</b> some \'here\''
                '</string>\n')
         self.__check_parse(string, xml)
 
@@ -597,3 +597,16 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
             '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu',
         ])
         assert bytes(store) == content
+
+    def test_markup_quotes_set(self):
+        template = '''<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="id">Test</string>
+</resources>'''
+        content = template.encode()
+        newcontent = template.replace('>Test<', '>Test <b>string</b> with \\u0020space<')
+        store = self.StoreClass()
+        store.parse(content)
+        assert bytes(store) == content
+        store.units[0].target = 'Test <b>string</b> with  space'
+        assert bytes(store).decode() == newcontent


### PR DESCRIPTION
Using quotes does not work well with HTML markup, so another escaping is
needed. Using unicode quote seems to be safest in this case.