### PR TITLE
Android: Fix round trip of strings with newlines

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -166,8 +166,14 @@ class AndroidResourceUnit(base.TranslationUnit):
                         # in the clauses below without issue.
                         pass
                     elif c == 'n' or c == 'N':
-                        text[i-1:i+1] = '\n'  # an actual newline
-                        i -= 1
+                        # Remove whitespace just before newline. Most likely this is result of
+                        # having real newline in the XML in front of \n.
+                        if i >= 2 and text[i-2] == " ":
+                            offset = 2
+                        else:
+                            offset = 1
+                        text[i - offset:i + 1] = '\n'  # an actual newline
+                        i -= offset
                     elif c == 't' or c == 'T':
                         text[i-1:i+1] = '\t'  # an actual tab
                         i -= 1

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -194,6 +194,15 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
                '</string>\n')
         self.__check_escape(string, xml)
 
+    def test_escape_quoted_newlines(self):
+        self.__check_escape(
+            "\n\nstring with newlines",
+            r"""<string name="teststring">"
+\n
+\nstring with newlines"</string>
+"""
+        )
+
     ############################ Check string parse ###########################
 
     def test_parse_message_with_newline(self):
@@ -202,7 +211,7 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
         self.__check_parse(string, xml)
 
     def test_parse_message_with_newline_in_xml(self):
-        string = 'message \nwith\n newline\n in xml'
+        string = 'message\nwith\n newline\n in xml'
         xml = ('<string name="teststring">message\n\\nwith\\n\nnewline\\n\nin xml'
                '</string>\n')
         self.__check_parse(string, xml)
@@ -231,6 +240,15 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
         string = ' leading space'
         xml = '<string name="teststring">" leading space"</string>\n'
         self.__check_parse(string, xml)
+
+    def test_parse_quoted_newlines(self):
+        self.__check_parse(
+            "\n\nstring with newlines",
+            r"""<string name="teststring">"
+\n
+\nstring with newlines"</string>
+"""
+        )
 
     def test_parse_xml_entities(self):
         string = '>xml&entities'


### PR DESCRIPTION
Additional whitespace would be included in the string due to inserting
newline to XML for better readability. Android itself seems to strip
this as well.