### PR TITLE
fix: Final fixes for XWiki Format

### DIFF
--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -1229,8 +1229,10 @@ class XWikiPageProperties(xwikifile):
         kwargs['personality'] = "xwiki"
         kwargs['encoding'] = "utf-8"
         self.root = None
-        self.parser = etree.XMLParser(strip_cdata=False, resolve_entities=False)
         super(xwikifile, self).__init__(*args, **kwargs)
+
+    def get_parser(self):
+        return etree.XMLParser(strip_cdata=False, resolve_entities=False)
 
     def extract_language(self):
         language_node = self.root.find("language")
@@ -1243,7 +1245,7 @@ class XWikiPageProperties(xwikifile):
 
     def parse(self, propsrc):
         if propsrc != b"\n":
-            self.root = etree.XML(propsrc, self.parser)
+            self.root = etree.XML(propsrc, self.get_parser())
             content = "".join(self.root.find("content").itertext())
             content = unescape(content).encode(self.encoding)
             self.extract_language()
@@ -1273,7 +1275,7 @@ class XWikiPageProperties(xwikifile):
 
     def serialize(self, out):
         if self.root is None:
-            self.root = etree.XML(self.XWIKI_BASIC_XML, self.parser)
+            self.root = etree.XML(self.XWIKI_BASIC_XML, self.get_parser())
         newroot = deepcopy(self.root)
         # We add a line break to ensure to have a line break before
         # closing of content tag.
@@ -1295,7 +1297,7 @@ class XWikiFullPage(XWikiPageProperties):
 
     def parse(self, propsrc):
         if propsrc != b"\n":
-            self.root = etree.XML(propsrc, self.parser)
+            self.root = etree.XML(propsrc, self.get_parser())
             content = ""\
                 .join(self.root.find("content").itertext())\
                 .replace("\n", "\\n")
@@ -1317,7 +1319,7 @@ class XWikiFullPage(XWikiPageProperties):
         unit_title = self.findid("title")
         unit_content = self.findid("content")
         if self.root is None:
-            self.root = etree.XML(self.XWIKI_BASIC_XML, self.parser)
+            self.root = etree.XML(self.XWIKI_BASIC_XML, self.get_parser())
         newroot = deepcopy(self.root)
         if unit_title is not None:
             newroot.find("title").text = self.output_unit(unit_title)

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -135,8 +135,8 @@ from translate.misc import quote
 from translate.misc.multistring import multistring
 from translate.storage import base
 from copy import deepcopy
-from xml.etree import ElementTree
-from xml.sax.saxutils import escape, unescape
+from lxml import etree as ElementTree
+from xml.sax.saxutils import unescape
 
 
 labelsuffixes = (".label", ".title")
@@ -1274,7 +1274,7 @@ class XWikiPageProperties(xwikifile):
 
     def serialize(self, out):
         if self.root is None:
-            self.root = ElementTree.XML(self.XML_HEADER + self.XWIKI_BASIC_XML)
+            self.root = ElementTree.XML(self.XWIKI_BASIC_XML)
         newroot = deepcopy(self.root)
         # We add a line break to ensure to have a line break before
         # closing of content tag.
@@ -1318,7 +1318,7 @@ class XWikiFullPage(XWikiPageProperties):
         unit_title = self.findid("title")
         unit_content = self.findid("content")
         if self.root is None:
-            self.root = ElementTree.XML(self.XML_HEADER + self.XWIKI_BASIC_XML)
+            self.root = ElementTree.XML(self.XWIKI_BASIC_XML)
         newroot = deepcopy(self.root)
         if unit_title is not None:
             newroot.find("title").text = self.output_unit(unit_title)

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -136,7 +136,6 @@ from translate.misc.multistring import multistring
 from translate.storage import base
 from copy import deepcopy
 from lxml import etree
-from xml.sax.saxutils import unescape
 
 
 labelsuffixes = (".label", ".title")
@@ -1247,9 +1246,9 @@ class XWikiPageProperties(xwikifile):
         if propsrc != b"\n":
             self.root = etree.XML(propsrc, self.get_parser())
             content = "".join(self.root.find("content").itertext())
-            content = unescape(content).encode(self.encoding)
+            content = content.encode(self.encoding)
             self.extract_language()
-            super(XWikiPageProperties, self).parse(content)
+            super().parse(content)
 
     def set_xwiki_xml_attributes(self, newroot):
         for e in newroot.findall("object"):
@@ -1304,9 +1303,9 @@ class XWikiFullPage(XWikiPageProperties):
             title = "".join(self.root.find("title").itertext())
             forparsing = ""
             if content != "":
-                forparsing += "content={}\n".format(unescape(content))
+                forparsing += "content={}\n".format(content)
             if title != "":
-                forparsing += "title={}\n".format(unescape(title))
+                forparsing += "title={}\n".format(title)
             self.extract_language()
             super(XWikiPageProperties, self).parse(forparsing.encode(self.encoding))
 

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -668,7 +668,7 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
     FILE_SCHEME = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc locale="%(language)s">
     <translation>1</translation>
     <language>%(language)s</language>
-    <title />
+    <title/>
     <content>%(content)s</content>
     </xwikidoc>"""
 
@@ -864,7 +864,7 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
             <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
             <version>1.1</version>
             <title>AdminTranslations</title>
-            <comment />
+            <comment/>
             <minorEdit>false</minorEdit>
             <syntaxId>plain/1.0</syntaxId>
             <hidden>true</hidden>
@@ -1127,7 +1127,7 @@ class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
             <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
             <version>1.1</version>
             <title>Un titre de page</title>
-            <comment />
+            <comment/>
             <minorEdit>false</minorEdit>
             <syntaxId>plain/1.0</syntaxId>
             <hidden>true</hidden>

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -1105,7 +1105,6 @@ class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
         propfile.settargetlanguage("fr")
         propfile.serialize(generatedcontent)
 
-
         expected_xml = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc reference="XWiki.AdminTranslations" locale="fr">
             <web>XWiki</web>
             <name>AdminTranslations</name>

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -1,4 +1,4 @@
-
+import sys
 from io import BytesIO
 
 from pytest import raises
@@ -665,7 +665,7 @@ class TestXWiki(test_monolingual.TestMonolingualStore):
 
 class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
     StoreClass = properties.XWikiPageProperties
-    FILE_SCHEME = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc>
+    FILE_SCHEME = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc locale="%(language)s">
     <translation>1</translation>
     <language>%(language)s</language>
     <title />
@@ -847,7 +847,12 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
         propunit.target = "Je peux coder !"
         generatedcontent = BytesIO()
         propfile.serialize(generatedcontent)
-        expected_xml = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc reference="XWiki.AdminTranslations">
+        ## ElementTree changed the way to process the attribute between Python 3.7 and 3.8
+        if sys.version_info.minor >= 8:
+            xml_open = "<xwikidoc reference=\"XWiki.AdminTranslations\" locale=\"fr\">"
+        else:
+            xml_open = "<xwikidoc locale=\"fr\" reference=\"XWiki.AdminTranslations\">"
+        expected_xml = properties.XWikiPageProperties.XML_HEADER + xml_open + """
             <web>XWiki</web>
             <name>AdminTranslations</name>
             <language>fr</language>
@@ -873,7 +878,7 @@ test_me=Je peux coder !
 
 class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
     StoreClass = properties.XWikiFullPage
-    FILE_SCHEME = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc>
+    FILE_SCHEME = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc locale="%(language)s">
     <translation>1</translation>
     <language>%(language)s</language>
     <title>%(title)s</title>
@@ -1104,7 +1109,13 @@ class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
         generatedcontent = BytesIO()
         propfile.settargetlanguage("fr")
         propfile.serialize(generatedcontent)
-        expected_xml = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc reference="XWiki.AdminTranslations">
+
+        ## ElementTree changed the way to process the attribute between Python 3.7 and 3.8
+        if sys.version_info.minor >= 8:
+            xml_open = "<xwikidoc reference=\"XWiki.AdminTranslations\" locale=\"fr\">"
+        else:
+            xml_open = "<xwikidoc locale=\"fr\" reference=\"XWiki.AdminTranslations\">"
+        expected_xml = properties.XWikiPageProperties.XML_HEADER + xml_open + """
             <web>XWiki</web>
             <name>AdminTranslations</name>
             <language>fr</language>

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -754,16 +754,17 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
         assert generatedcontent.getvalue().decode(propfile.encoding) == propsource + "\n"
 
     def test_definition_with_encoded_html(self):
-        propsource = self.getcontent("test_me=A translation &lt; another one.")
+        propsource = self.getcontent("test_me=A &amp; is represented with &amp;amp;")
         propfile = self.propparse(propsource)
         assert len(propfile.units) == 1
         propunit = propfile.units[0]
         assert propunit.name == "test_me"
-        assert propunit.source == "A translation < another one."
+        assert propunit.source == "A & is represented with &amp;"
         assert not propunit.missing
         generatedcontent = BytesIO()
         propfile.serialize(generatedcontent)
-        assert generatedcontent.getvalue().decode(propfile.encoding) == propsource + "\n"
+        assert generatedcontent.getvalue().decode(
+            propfile.encoding) == propsource + "\n"
 
     def test_cleaning_attributes(self):
         """Ensure that the XML is correctly formatted during serialization:

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -847,12 +847,7 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
         propunit.target = "Je peux coder !"
         generatedcontent = BytesIO()
         propfile.serialize(generatedcontent)
-        ## ElementTree changed the way to process the attribute between Python 3.7 and 3.8
-        if sys.version_info.minor >= 8:
-            xml_open = "<xwikidoc reference=\"XWiki.AdminTranslations\" locale=\"fr\">"
-        else:
-            xml_open = "<xwikidoc locale=\"fr\" reference=\"XWiki.AdminTranslations\">"
-        expected_xml = properties.XWikiPageProperties.XML_HEADER + xml_open + """
+        expected_xml = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc reference="XWiki.AdminTranslations" locale="fr">
             <web>XWiki</web>
             <name>AdminTranslations</name>
             <language>fr</language>
@@ -1110,12 +1105,8 @@ class TestXWikiFullPage(test_monolingual.TestMonolingualStore):
         propfile.settargetlanguage("fr")
         propfile.serialize(generatedcontent)
 
-        ## ElementTree changed the way to process the attribute between Python 3.7 and 3.8
-        if sys.version_info.minor >= 8:
-            xml_open = "<xwikidoc reference=\"XWiki.AdminTranslations\" locale=\"fr\">"
-        else:
-            xml_open = "<xwikidoc locale=\"fr\" reference=\"XWiki.AdminTranslations\">"
-        expected_xml = properties.XWikiPageProperties.XML_HEADER + xml_open + """
+
+        expected_xml = properties.XWikiPageProperties.XML_HEADER + """<xwikidoc reference="XWiki.AdminTranslations" locale="fr">
             <web>XWiki</web>
             <name>AdminTranslations</name>
             <language>fr</language>


### PR DESCRIPTION
  - Fix extracting language for XWiki Full Page format
  - Use language or default language
  - Ensure to output properly the unit when serializing by using source
    or translation
  - Ensure to serialize the locale in root node.