### PR TITLE
storage: Preserve structured IDs on round trip

### DIFF
--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -52,6 +52,25 @@ JSON_ARRAY = b"""{
     ]
 }
 """
+JSON_COMPLEX = b"""{
+    "key": "value",
+    "key.key": "value",
+    "key[0]": "value2",
+    "key3": [
+        "one",
+        "two"
+    ],
+    "key4": [
+        {
+            "nested": "one"
+        },
+        [
+            "one",
+            "two"
+        ]
+    ]
+}
+"""
 JSON_GOI18N = b"""[
     {
         "id": "tag",
@@ -154,6 +173,15 @@ class TestJSONResourceStore(test_monolingual.TestMonolingualStore):
         out = BytesIO()
         store.serialize(out)
         assert out.getvalue() == content
+
+    def test_complex(self):
+        store = self.StoreClass()
+        store.parse(JSON_COMPLEX)
+
+        out = BytesIO()
+        store.serialize(out)
+
+        assert out.getvalue() == JSON_COMPLEX
 
 
 class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):

--- a/translate/storage/test_yaml.py
+++ b/translate/storage/test_yaml.py
@@ -417,3 +417,20 @@ class TestRubyYAMLResourceStore(test_monolingual.TestMonolingualStore):
         store.parse(data)
         assert len(store.units) == 5
         assert bytes(store).decode('ascii') == data
+
+    def test_type_change(self):
+        original = '''en:
+  days_on: '["Sunday", "Monday"]'
+'''
+        changed = '''en:
+  days_on:
+  - Sunday
+  - Monday
+'''
+        store = self.StoreClass()
+        store.parse(original)
+        update = self.StoreClass()
+        update.parse(changed)
+        for unit in update.units:
+            store.addunit(unit)
+        assert bytes(store).decode('ascii') == changed


### PR DESCRIPTION
YAML and JSON storages now preserve structure on round trip even when it contains strings used in the unit IDs. The structure is kept in separate object and is used when saving.

Fixes #3819
Fixes #3857
Fixes #3541

Supersedes https://github.com/translate/translate/pull/3835

Built on top of https://github.com/translate/translate/pull/4090, only last commit is relevant here.