### PR TITLE
storage: Consolidate index usage

### DIFF
--- a/translate/convert/po2dtd.py
+++ b/translate/convert/po2dtd.py
@@ -88,6 +88,7 @@ class redtd:
     def handleinunit(self, inunit, includefuzzy):
         entities = inunit.getlocations()
         mixedentities = self.mixer.match_entities(entities)
+        self.dtdfile.require_index()
         for entity in entities:
             if entity in self.dtdfile.id_index:
                 # now we need to replace the definition of entity with msgstr

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -703,10 +703,7 @@ class pofile(pocommon.pofile):
             self._encoding = kwargs.get('encoding')
             self._gpo_memory_file = gpo.po_file_create()
             self._gpo_message_iterator = gpo.po_message_iterator(self._gpo_memory_file, None)
-            if not noheader:
-                self.init_headers()
-        else:
-            super().__init__(inputfile=inputfile, **kwargs)
+        super().__init__(inputfile=inputfile, noheader=noheader, **kwargs)
 
     def addunit(self, unit, new=True):
         if new:

--- a/translate/storage/pocommon.py
+++ b/translate/storage/pocommon.py
@@ -184,12 +184,12 @@ class pofile(poheader.poheader, base.TranslationStore):
     # We don't want windows line endings on Windows:
     _binary = True
 
-    def __init__(self, inputfile=None, **kwargs):
+    def __init__(self, inputfile=None, noheader=False, **kwargs):
         super().__init__(**kwargs)
         self.filename = ''
         if inputfile is not None:
             self.parse(inputfile)
-        else:
+        elif not noheader:
             self.init_headers()
 
     @property

--- a/translate/storage/test_dtd.py
+++ b/translate/storage/test_dtd.py
@@ -245,7 +245,7 @@ class TestDTD(test_monolingual.TestMonolingualStore):
         assert len(dtdfile.units) == 1
         dtdunit = dtdfile.units[0]
         print(dtdunit)
-        assert dtdunit.isnull()
+        assert dtdunit.isblank()
 
     def test_newlines_in_entity(self):
         """tests that we can handle newlines in the entity itself"""


### PR DESCRIPTION
- initialize index attributes in __init__
- require index for find as we scan all units anyway
- fix super __init__ invocation in cpo
- make isblank and index usage consistent with other formats in dtd