### PR TITLE
csv: Allow to specify sample length for CSV sniffer

### DIFF
--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -283,13 +283,16 @@ class csvfile(base.TranslationStore):
             inputfile.close()
             self.parse(csvsrc)
 
-    def parse(self, csvsrc):
+    def parse(self, csvsrc, sample_length=1024):
         text, encoding = self.detect_encoding(csvsrc, default_encodings=['utf-8', 'utf-16'])
         #FIXME: raise parse error if encoding detection fails?
         self.encoding = encoding or 'utf-8'
 
         sniffer = csv.Sniffer()
-        sample = text[:1024]
+        if sample_length:
+            sample = text[:sample_length]
+        else:
+            sample = text
 
         try:
             self.dialect = sniffer.sniff(sample)

--- a/translate/storage/test_csvl10n.py
+++ b/translate/storage/test_csvl10n.py
@@ -61,8 +61,7 @@ GENERAL@2|Notes,"cable, motor, switch"
     @mark.xfail(reason="Bug #3356")
     def test_context_is_parsed(self):
         """Tests that units with the same source are different based on context."""
-        source = ('"65066","Ogre","Ogro"\n'
-                  '"65067","Ogre","Ogros"')
+        source = b'"65066","Ogre","Ogro"\n"65067","Ogre","Ogros"'
         store = self.parse_store(source)
         assert len(store.units) == 2
         unit1 = store.units[0]

--- a/translate/storage/test_csvl10n.py
+++ b/translate/storage/test_csvl10n.py
@@ -82,3 +82,12 @@ GENERAL@2|Notes,"cable, motor, switch"
         assert store.units[0].source == 'te\\nst'
         assert store.units[0].target == 'ot\\nher'
         assert bytes(store) == content
+
+    def test_parse_sample(self):
+        content = b'"location";"source";"target"\r\n"foo.c:1";"te\\nst";"ot\\nher"\r\n'
+        store = self.StoreClass()
+        store.parse(content, sample_length=None)
+        assert len(store.units) == 1
+        assert store.units[0].source == 'te\\nst'
+        assert store.units[0].target == 'ot\\nher'
+        assert bytes(store) == content


### PR DESCRIPTION
This allows to keep the decision on sample length on the application, giving it control
on accurancy / speed / memory consumption tradeoff.

See https://github.com/WeblateOrg/weblate/issues/2805