### PR TITLE
Storage: Include id while comparing units

### DIFF
--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -133,7 +133,7 @@ class TranslationUnit:
         :return: Returns *True* if the supplied :class:`TranslationUnit`
                  equals this unit.
         """
-        return self.source == other.source and self.target == other.target
+        return self.source == other.source and self.target == other.target and self.getid() == other.getid()
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -456,6 +456,7 @@ class TranslationUnit:
         newunit = cls(unit.source)
         newunit.target = unit.target
         newunit.markfuzzy(unit.isfuzzy())
+        newunit.setid(unit.getid())
         locations = unit.getlocations()
         if locations:
             newunit.addlocations(locations)

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -81,7 +81,10 @@ class JsonUnit(base.DictUnit):
     ID_FORMAT = ".{}"
 
     def __init__(self, source=None, item=None, notes=None, placeholders=None, **kwargs):
-        identifier = str(uuid.uuid4())
+        if source:
+            identifier = hex(hash(source))
+        else:
+            identifier = str(uuid.uuid4())
         # Global identifier across file
         self._id = self.ID_FORMAT.format(identifier)
         # Identifier at this level

--- a/translate/storage/test_base.py
+++ b/translate/storage/test_base.py
@@ -80,9 +80,7 @@ class TestTranslationUnit:
         assert unit1 == unit2
         assert unit1 != unit3
         assert unit4 != unit5
-        if unit1.__class__.__name__ in ('RESXUnit', 'dtdunit', 'TxtUnit',
-                                        'JsonUnit', 'YAMLUnit',
-                                        'WebExtensionJsonUnit'):
+        if unit1.__class__.__name__ in ('RESXUnit', 'dtdunit', 'TxtUnit'):
             # unit1 will generally equal unit6 for monolingual formats (resx, dtd, txt)
             # with the default comparison method which compare units by their
             # target and source properties only.

--- a/translate/storage/test_po.py
+++ b/translate/storage/test_po.py
@@ -166,6 +166,7 @@ class TestPOUnit(test_base.TestTranslationUnit):
         from translate.storage.php import phpunit
         unit = phpunit("test source")
         unit_copy = self.UnitClass.buildfromunit(unit)
+        unit.setid(unit_copy.getid())
         assert unit is not unit_copy
         assert unit == unit_copy
 

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -49,9 +49,11 @@ class YAMLUnit(base.DictUnit):
 
     def __init__(self, source=None, **kwargs):
         # Ensure we have ID (for serialization)
-        self._id = str(uuid.uuid4())
         if source:
             self.source = source
+            self._id = hex(hash(source))
+        else:
+            self._id = str(uuid.uuid4())
         super().__init__(source)
 
     @property


### PR DESCRIPTION
Without that, the monolingual units with same translation are treated
equal. Specifically, all untranslated monolingual units are treated
equal.