### PR TITLE
deps: Include twine and virtualenv in dev deps

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -33,7 +33,6 @@ jobs:
     - name: Install pip dependencies
       run: |
         pip install -r requirements/dev.txt
-        pip install twine virtualenv
     - name: Build sdist
       run: make build
     - name: Twine check

--- a/docs/developers/releasing.rst
+++ b/docs/developers/releasing.rst
@@ -260,7 +260,6 @@ Run the following to publish the package on PyPI:
 .. code-block:: console
 
     $ workon build-ttk-release
-    (build-ttk-release)$ pip install --upgrade pyopenssl ndg-httpsclient pyasn1 twine
     (build-ttk-release)$ twine upload dist/translate-toolkit-*
     (build-ttk-release)$ deactivate
     $ rmvirtualenv build-ttk-release

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,3 +7,6 @@ pytest==6.0.2
 pytest-cov==2.10.1
 pytest-xdist==2.1.0
 Sphinx==3.2.1
+twine==3.2.0;  python_version >= '3.6'
+twine==1.15.0; python_version < '3.6'
+virtualenv==20.0.31


### PR DESCRIPTION
This avoids need to manually install those at release and CI time and
makes the release process more controlled as both versions are pinned.