### PR TITLE
Deps: Increase minimal Python version to 3.6

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       matrix:
         requirements: [latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         include:
           - requirements: minimal
-            python-version: 3.5
+            python-version: 3.6
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         requirements: [latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ feature set. This cal be easily specified during pip installation::
    Will install all optional dependencies convering support for many other
    formats.
 
-The Toolkit requires Python 3.5 or newer.
+The Toolkit requires Python 3.6 or newer.
 
 The package lxml is required. You should install version 4.0.0 or later.
 <http://lxml.de/> Depending on your platform, the easiest way to install might

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,6 +7,5 @@ pytest==6.0.2
 pytest-cov==2.10.1
 pytest-xdist==2.1.0
 Sphinx==3.2.1
-twine==3.2.0;  python_version >= '3.6'
-twine==1.15.0; python_version < '3.6'
+twine==3.2.0
 virtualenv==20.0.31

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,6 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Unix",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -515,7 +514,7 @@ def dosetup(name, version, packages, datafiles, scripts, ext_modules=[]):
     setup(
         name=name,
         version=version,
-        python_requires=">=3.5",
+        python_requires=">=3.6",
         license="GNU General Public License (GPL)",
         description=description,
         long_description=long_description,


### PR DESCRIPTION
Python 3.5 reached the end of its life on September 13th, 2020. pip 21.0
will drop support for Python 3.5 in January 2021 and others will
probably follow.