### PR TITLE
lint: Use native isort to have just one dependency on that

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,6 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.5.2
-    hooks:
-      - id: isort
   - repo: local
     hooks:
       - id: pydocstyle
@@ -26,6 +22,11 @@ repos:
       - id: pycodestyle
         name: pycodestyle
         entry: pycodestyle
+        language: system
+        types: [python]
+      - id: isort
+        name: isort
+        entry: isort
         language: system
         types: [python]
       - id: flake8

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,8 @@
 -r optional.txt
 
 flake8==3.8.3
-isort>=4.2.3
+flake8-isort==4.0.0
+isort==5.2.2
 pre-commit==2.7.1
 pycodestyle==2.6.0
 pydocstyle==5.1.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,11 @@
 -r optional.txt
 
 flake8==3.8.3
+flake8-breakpoint==1.1.0
 flake8-isort==4.0.0
+flake8-mutable==1.2.0
+flake8-no-u-prefixed-strings==0.2
+flake8-polyfill==1.0.2
 isort==5.2.2
 pre-commit==2.7.1
 pycodestyle==2.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,9 +71,8 @@ statistics=True
 max-line-length=84
 exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,conf.py,_build,.tox,selector.py,mozilla-l10n,build,env,build,dist
 # Additional default excludes:
-# I - import plugin
 # N - naming plugin
-ignore=E129,E226,E402,E731,W503,I,N,E501,E265,E266,E741,W504
+ignore=E129,E226,E402,E731,W503,N,E265,E501,E266,E741,W504
 statistics=True
 per-file-ignores =
   translate/storage/placeables/__init__.py:F401,F403
@@ -88,7 +87,7 @@ skip=docs,
     selector.py,
 
 known_standard_library=
-known_third_party=iniparse,lxml,vobject,sphinx,pytest,cheroot,phply,bs4,ruamel,pyparsing
+known_third_party=iniparse,lxml,vobject,sphinx,pytest,cheroot,phply,bs4,ruamel,pyparsing,setuptools
 known_first_party=translate
 default_section=FIRSTPARTY
 sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ from distutils.sysconfig import get_python_lib
 from os.path import dirname, isfile, join
 
 from setuptools import setup
+
 from translate import __doc__, __version__
 
 


### PR DESCRIPTION
That makes it easier to track version which should be used.