### PR TITLE
Subtitles: Add basic tests for the formats

### DIFF
--- a/translate/storage/subtitles.py
+++ b/translate/storage/subtitles.py
@@ -56,11 +56,12 @@ class SubtitleUnit(base.TranslationUnit):
     """A subtitle entry that is translatable"""
 
     def __init__(self, source=None, **kwargs):
-        self._start = None
-        self._end = None
-        self._duration = None
+        self._start = "00:00:00.000"
+        self._end = "00:00:00.000"
+        self._duration = 0.0
         if source:
             self.source = source
+            self.target = source
         super().__init__(source)
 
     def getnotes(self, origin=None):

--- a/translate/storage/test_subtitles.py
+++ b/translate/storage/test_subtitles.py
@@ -1,0 +1,30 @@
+import pytest
+
+from translate.storage import subtitles, test_monolingual
+
+
+class TestSubtitleUnit(test_monolingual.TestMonolingualUnit):
+    UnitClass = subtitles.SubtitleUnit
+
+    @pytest.mark.xfail(reason="Not Implemented")
+    def test_note_sanity(self):
+        super().test_note_sanity()
+
+
+class TestSubRipFile(test_monolingual.TestMonolingualStore):
+    StoreClass = subtitles.SubRipFile
+
+
+@pytest.mark.xfail(reason="Broken, #4155")
+class TestMicroDVDFile(test_monolingual.TestMonolingualStore):
+    StoreClass = subtitles.MicroDVDFile
+
+
+@pytest.mark.xfail(reason="Broken, #4155")
+class TestAdvSubStationAlphaFile(test_monolingual.TestMonolingualStore):
+    StoreClass = subtitles.AdvSubStationAlphaFile
+
+
+@pytest.mark.xfail(reason="Broken, #4155")
+class TestSubStationAlphaFile(test_monolingual.TestMonolingualStore):
+    StoreClass = subtitles.SubStationAlphaFile


### PR DESCRIPTION
- Fix Unit class behavior to be consistent with other formats and
  provide default values which do nor crash the serialization
- Mark most of the tests a expected failure as most of the formats are
  actually broken in current aeidon, see #4155