### PR TITLE
json: Fix handling of newly created units for flat JSON format

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -75,7 +75,7 @@ from translate.misc.multistring import multistring
 from translate.storage import base
 
 
-class JsonUnit(base.DictUnit):
+class BaseJsonUnit(base.DictUnit):
     """A JSON entry"""
 
     ID_FORMAT = ".{}"
@@ -132,10 +132,24 @@ class JsonUnit(base.DictUnit):
         self.storevalue(output, self.converttarget())
 
 
+class FlatUnitId(base.UnitId):
+    @classmethod
+    def from_string(cls, text):
+        if text.startswith("."):
+            key = text[1:]
+        else:
+            key = text
+        return cls([("key", key)])
+
+
+class FlatJsonUnit(BaseJsonUnit):
+    IdClass = FlatUnitId
+
+
 class JsonFile(base.DictStore):
     """A JSON file"""
 
-    UnitClass = JsonUnit
+    UnitClass = FlatJsonUnit
 
     def __init__(self, inputfile=None, filter=None, **kwargs):
         """construct a JSON file, optionally reading in from inputfile."""
@@ -210,7 +224,7 @@ class JsonFile(base.DictStore):
             self.addunit(unit)
 
 
-class JsonNestedUnit(JsonUnit):
+class JsonNestedUnit(BaseJsonUnit):
 
     def storevalues(self, output):
         self.storevalue(output, self.converttarget())
@@ -222,7 +236,7 @@ class JsonNestedFile(JsonFile):
     UnitClass = JsonNestedUnit
 
 
-class WebExtensionJsonUnit(JsonUnit):
+class WebExtensionJsonUnit(BaseJsonUnit):
     def storevalues(self, output):
         value = OrderedDict((
             ('message', self.target),
@@ -362,7 +376,7 @@ class I18NextFile(JsonNestedFile):
                 yield x
 
 
-class GoI18NJsonUnit(JsonUnit):
+class GoI18NJsonUnit(BaseJsonUnit):
     ID_FORMAT = "{}"
 
     def getvalue(self):
@@ -425,7 +439,7 @@ class GoI18NJsonFile(JsonFile):
         out.write(b'\n')
 
 
-class ARBJsonUnit(JsonUnit):
+class ARBJsonUnit(BaseJsonUnit):
     ID_FORMAT = "{}"
 
     def __init__(self, source=None, item=None, notes=None, placeholders=None, metadata=None, **kwargs):

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -110,7 +110,7 @@ JSON_ARB = b"""{
 
 
 class TestJSONResourceUnit(test_monolingual.TestMonolingualUnit):
-    UnitClass = jsonl10n.JsonUnit
+    UnitClass = jsonl10n.BaseJsonUnit
 
 
 class TestJSONResourceStore(test_monolingual.TestMonolingualStore):
@@ -183,6 +183,20 @@ class TestJSONResourceStore(test_monolingual.TestMonolingualStore):
 
         assert out.getvalue() == JSON_COMPLEX
 
+    def test_add(self):
+        store = self.StoreClass()
+
+        unit = self.StoreClass.UnitClass(
+            "source",
+        )
+        unit.setid('simple.key')
+        store.addunit(unit)
+
+        assert bytes(store).decode() == """{
+    "simple.key": "source"
+}
+"""
+
 
 class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):
     StoreClass = jsonl10n.JsonNestedFile
@@ -228,6 +242,22 @@ class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):
         store.serialize(out)
 
         assert out.getvalue() == JSON_ARRAY
+
+    def test_add(self):
+        store = self.StoreClass()
+
+        unit = self.StoreClass.UnitClass(
+            "source",
+        )
+        unit.setid('simple.key')
+        store.addunit(unit)
+
+        assert bytes(store).decode() == """{
+    "simple": {
+        "key": "source"
+    }
+}
+"""
 
 
 class TestWebExtensionUnit(test_monolingual.TestMonolingualUnit):


### PR DESCRIPTION
This is a regression introduced by #4091 as that makes the flat JSON
file expand the unit keys.

Fixes https://github.com/WeblateOrg/weblate/issues/4779