### PR TITLE
Add and apply pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,11 @@ repos:
         entry: isort
         language: system
         types: [python]
+      - id: pyupgrade
+        name: pyupgrade
+        entry: pyupgrade --py36-plus
+        language: system
+        types: [python]
       - id: black
         name: black
         entry: black

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,6 +15,7 @@ pydocstyle==5.1.1
 pytest==6.1.2
 pytest-cov==2.10.1
 pytest-xdist==2.1.0
+pyupgrade==2.7.4
 Sphinx==3.3.1
 twine==3.2.0
 virtualenv==20.1.0

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ packages = ["translate"]
 # This builds console scripts list. More detail please see:
 # http://python-packaging.readthedocs.org/en/latest/command-line-scripts.html#the-console-scripts-entry-point
 translatescripts = [
-    "{name}={entry}".format(name=name, entry=entry)
+    f"{name}={entry}"
     for name, entry in [
         ("csv2po", "translate.convert.csv2po:main"),
         ("csv2tbx", "translate.convert.csv2tbx:main"),
@@ -274,10 +274,10 @@ else:
             ofi.write("; will be overwritten the next time py2exe is run!\n")
             ofi.write("[Setup]\n")
             ofi.write("AppName=%s\n" % self.name)
-            ofi.write("AppVerName=%s %s\n" % (self.name, self.version))
+            ofi.write(f"AppVerName={self.name} {self.version}\n")
             ofi.write("DefaultDirName={pf}\\%s\n" % self.name)
             ofi.write("DefaultGroupName=%s\n" % self.name)
-            ofi.write("OutputBaseFilename=%s-%s-setup\n" % (self.name, self.version))
+            ofi.write(f"OutputBaseFilename={self.name}-{self.version}-setup\n")
             ofi.write("ChangesEnvironment=yes\n")
             ofi.write("\n")
             ofi.write("[Files]\n")
@@ -489,7 +489,7 @@ def parse_requirements(file_name):
     Copied from cburgmer/pdfserver.
     """
     requirements = []
-    with open(file_name, "r") as fh:
+    with open(file_name) as fh:
         for line in fh:
             # Ignore comments, blank lines and included requirements files
             if re.match(r"(\s*#)|(\s*$)|(-r .*$)", line):
@@ -554,7 +554,7 @@ def standardsetup(name, version, custompackages=[], customdatafiles=[]):
     try:
         with open("MANIFEST.in", "w") as manifest_in:
             buildmanifest_in(manifest_in, translatebashscripts)
-    except IOError as e:
+    except OSError as e:
         sys.stderr.write(
             "warning: could not recreate MANIFEST.in, continuing anyway. (%s)\n" % e
         )
@@ -611,7 +611,7 @@ def dosetup(name, version, packages, datafiles, scripts, ext_modules=[]):
         ext_modules=ext_modules,
         cmdclass=cmdclass,
         install_requires=parse_requirements("requirements/required.txt"),
-        **kwargs
+        **kwargs,
     )
 
 

--- a/tools/mozilla/buildxpi.py
+++ b/tools/mozilla/buildxpi.py
@@ -128,7 +128,7 @@ def build_xpi(
 
     try:
         # Create new .mozconfig
-        content = """
+        content = f"""
 ac_add_options --disable-compile-environment
 #ac_add_options --disable-gstreamer
 #ac_add_options --disable-ogg
@@ -139,14 +139,10 @@ ac_add_options --disable-compile-environment
 #ac_add_options --disable-alsa
 #ac_add_options --disable-pulseaudio
 #ac_add_options --disable-libjpeg-turbo
-mk_add_options MOZ_OBJDIR=%(builddir)s
-ac_add_options --with-l10n-base=%(l10nbase)s
-ac_add_options --enable-application=%(product)s
-""" % {
-            "builddir": builddir,
-            "l10nbase": l10nbase,
-            "product": product,
-        }
+mk_add_options MOZ_OBJDIR={builddir}
+ac_add_options --with-l10n-base={l10nbase}
+ac_add_options --enable-application={product}
+"""
 
         with open(MOZCONFIG, "w") as mozconf:
             mozconf.write(content)
@@ -176,9 +172,7 @@ ac_add_options --enable-application=%(product)s
 
         moz_app_version = []
         if soft_max_version:
-            with open(
-                os.path.join(srcdir, product, "config", "version.txt"), "r"
-            ) as fh:
+            with open(os.path.join(srcdir, product, "config", "version.txt")) as fh:
                 version = fh.read().strip()
             version = re.sub(r"(^[0-9]*\.[0-9]*).*", r"\1.*", version)
             moz_app_version = ["MOZ_APP_MAXVERSION=%s" % version]
@@ -188,14 +182,14 @@ ac_add_options --enable-application=%(product)s
             run(
                 ["make", "-C", os.path.join(product, "locales")]
                 + ["merge-%s" % lang]
-                + ["LOCALE_MERGEDIR=%s/merge-%s" % (mergedir, lang)]
+                + [f"LOCALE_MERGEDIR={mergedir}/merge-{lang}"]
                 + moz_app_version,
                 fail_msg="Unable to merge XPI!",
             )
             run(
                 ["make", "-C", os.path.join(product, "locales")]
                 + ["langpack-%s" % lang]
-                + ["LOCALE_MERGEDIR=%s/merge-%s" % (mergedir, lang)]
+                + [f"LOCALE_MERGEDIR={mergedir}/merge-{lang}"]
                 + moz_app_version,
                 fail_msg="Unable to successfully build XPI!",
             )

--- a/tools/mozilla/get_moz_enUS.py
+++ b/tools/mozilla/get_moz_enUS.py
@@ -44,7 +44,7 @@ def process_l10n_ini(inifile):
     """
 
     l10n = ConfigParser()
-    with open(path_neutral(inifile), "r") as fh:
+    with open(path_neutral(inifile)) as fh:
         l10n.readfp(fh)
     l10n_ini_path = os.path.dirname(inifile)
 
@@ -62,7 +62,7 @@ def process_l10n_ini(inifile):
                 print("[Existing target]: %s" % topath)
             continue
         if verbose:
-            print("%s -> %s" % (frompath, topath))
+            print(f"{frompath} -> {topath}")
         try:
             shutil.copytree(frompath, topath)
         except OSError as e:

--- a/tools/mozilla/moz_l10n_builder.py
+++ b/tools/mozilla/moz_l10n_builder.py
@@ -93,7 +93,7 @@ def delfiles(pattern, path, files):
 
 def run(cmd, expected_status=0, stdout=None, stderr=None, shell=False):
     if options["verbose"]:
-        print(">>> %s $ %s" % (os.getcwd(), " ".join(cmd)))
+        print(">>> {} $ {}".format(os.getcwd(), " ".join(cmd)))
     p = Popen(cmd, stdout=stdout, stderr=stderr, shell=shell)
     cmd_status = p.wait()
 
@@ -134,7 +134,7 @@ def get_langs(lang_args):
         if lang == "ALL":
             # Get all available languages from the locales file
             locales_filename = join(mozilladir, targetapp, "locales", "shipped-locales")
-            with open(locales_filename, "r") as fh:
+            with open(locales_filename) as fh:
                 for line in fh:
                     langcode = line.split()[0]
                     if langcode != "en-US":
@@ -311,7 +311,9 @@ def pack_pot(includes):
     except OSError:
         pass
 
-    packname = join(potpacks, "%s-%s-%s" % (products[targetapp], mozversion, timestamp))
+    packname = join(
+        potpacks, "{}-{}-{}".format(products[targetapp], mozversion, timestamp)
+    )
     run(
         [
             "tar",
@@ -338,7 +340,8 @@ def pack_po(lang, buildlang):
 
     print("    %s" % (lang))
     packname = join(
-        popacks, "%s-%s-%s-%s" % (products[targetapp], mozversion, buildlang, timestamp)
+        popacks,
+        "{}-{}-{}-{}".format(products[targetapp], mozversion, buildlang, timestamp),
     )
     run(
         [

--- a/translate/convert/convert.py
+++ b/translate/convert/convert.py
@@ -30,7 +30,7 @@ from translate.misc import optrecurse
 optparse = optrecurse.optparse
 
 
-class ConvertOptionParser(optrecurse.RecursiveOptionParser, object):
+class ConvertOptionParser(optrecurse.RecursiveOptionParser):
     """A specialized Option Parser for convertor tools..."""
 
     def __init__(

--- a/translate/convert/factory.py
+++ b/translate/convert/factory.py
@@ -52,7 +52,7 @@ class UnsupportedConversionError(Exception):
         self.templ_ext = templ_ext
 
     def __str__(self):
-        msg = "Unsupported conversion from %s to %s" % (self.in_ext, self.out_ext)
+        msg = f"Unsupported conversion from {self.in_ext} to {self.out_ext}"
         if self.templ_ext:
             msg += " with template %s" % (self.templ_ext)
         return msg

--- a/translate/convert/ical2po.py
+++ b/translate/convert/ical2po.py
@@ -72,7 +72,7 @@ class ical2po:
 
     def merge_stores(self):
         """Convert two source format files to a target format file."""
-        self.extraction_msg = "extracted from %s, %s" % (
+        self.extraction_msg = "extracted from {}, {}".format(
             self.template_store.filename,
             self.source_store.filename,
         )

--- a/translate/convert/ini2po.py
+++ b/translate/convert/ini2po.py
@@ -78,7 +78,7 @@ class ini2po:
 
     def merge_stores(self):
         """Convert two source format files to a target format file."""
-        self.extraction_msg = "extracted from %s, %s" % (
+        self.extraction_msg = "extracted from {}, {}".format(
             self.template_store.filename,
             self.source_store.filename,
         )

--- a/translate/convert/json2po.py
+++ b/translate/convert/json2po.py
@@ -52,7 +52,7 @@ class json2po:
         output_store = po.pofile()
         output_header = output_store.header()
         output_header.addnote(
-            "extracted from %s, %s" % (template_store.filename, input_store.filename),
+            f"extracted from {template_store.filename}, {input_store.filename}",
             "developer",
         )
 

--- a/translate/convert/mozfunny2prop.py
+++ b/translate/convert/mozfunny2prop.py
@@ -49,7 +49,7 @@ def inc2prop(lines):
                 commented = False
             if commented:
                 yield "# "
-            yield "%s = %s\n" % (key, value)
+            yield f"{key} = {value}\n"
         else:
             if commented:
                 yield "# "
@@ -76,11 +76,9 @@ def it2prop(lines, encoding="cp1252"):
 def funny2prop(lines, itencoding="cp1252"):
     hashstarts = len([line for line in lines if line.startswith("#")])
     if hashstarts:
-        for line in inc2prop(lines):
-            yield line
+        yield from inc2prop(lines)
     else:
-        for line in it2prop(lines, encoding=itencoding):
-            yield line
+        yield from it2prop(lines, encoding=itencoding)
 
 
 def inc2po(

--- a/translate/convert/php2po.py
+++ b/translate/convert/php2po.py
@@ -72,7 +72,7 @@ class php2po:
 
     def merge_stores(self):
         """Convert two source format files to a target format file."""
-        self.extraction_msg = "extracted from %s, %s" % (
+        self.extraction_msg = "extracted from {}, {}".format(
             self.template_store.filename,
             self.source_store.filename,
         )

--- a/translate/convert/po2idml.py
+++ b/translate/convert/po2idml.py
@@ -48,10 +48,10 @@ def translate_idml(template, input_file, translatable_files):
         """
         idml_data = open_idml(template)
         parser = etree.XMLParser(strip_cdata=False, resolve_entities=False)
-        return dict(
-            (filename, etree.fromstring(data, parser).getroottree())
+        return {
+            filename: etree.fromstring(data, parser).getroottree()
             for filename, data in idml_data.items()
-        )
+        }
 
     def load_unit_tree(input_file):
         """Return a dict with the translations grouped by files IDML package.

--- a/translate/convert/po2php.py
+++ b/translate/convert/po2php.py
@@ -62,7 +62,7 @@ class rephp:
         # handle multiline msgid if we're in one
         if self.inmultilinemsgid:
             # see if there's more
-            endpos = line.rfind("%s%s" % (self.quotechar, self.enddel))
+            endpos = line.rfind(f"{self.quotechar}{self.enddel}")
             # if there was no '; or the quote is escaped, we have to continue
             if endpos >= 0 and line[endpos - 1] != "\\":
                 self.inmultilinemsgid = False
@@ -122,7 +122,7 @@ class rephp:
                 self.quotechar = line[
                     equalspos + (postspacestart - postspaceend) + len(self.equaldel)
                 ]
-                inlinecomment_pos = line.rfind("%s%s" % (self.quotechar, self.enddel))
+                inlinecomment_pos = line.rfind(f"{self.quotechar}{self.enddel}")
                 if inlinecomment_pos > -1:
                     inlinecomment = line[inlinecomment_pos + 2 :]
                 else:
@@ -161,7 +161,7 @@ class rephp:
                     returnline = line + eol
 
                 # no string termination means carry string on to next line
-                endpos = line.rfind("%s%s" % (self.quotechar, self.enddel))
+                endpos = line.rfind(f"{self.quotechar}{self.enddel}")
                 # if there was no '; or the quote is escaped, we have to
                 # continue
                 if endpos == -1 or line[endpos - 1] == "\\":

--- a/translate/convert/po2prop.py
+++ b/translate/convert/po2prop.py
@@ -136,7 +136,7 @@ class reprop:
                     # [zero] cases are translated as separate units
                     continue
                 new_unit = self.inputstore.addsourceunit("fish")  # not used
-                new_location = "%s[%s]" % (location, category)
+                new_location = f"{location}[{category}]"
                 new_unit.addlocation(new_location)
                 new_unit.target = text
                 self.inputstore.locationindex[new_location] = new_unit
@@ -169,7 +169,7 @@ class reprop:
             for category, text in zip(names, unit.target.strings):
                 new_unit = self.inputstore.addsourceunit("fish")  # not used
                 if category != "":
-                    new_location = "%s[%s]" % (location, category)
+                    new_location = f"{location}[{category}]"
                 else:
                     new_location = "%s" % (location)
                 new_unit.addlocation(new_location)

--- a/translate/convert/po2web2py.py
+++ b/translate/convert/po2web2py.py
@@ -48,7 +48,7 @@ class po2pydict:
         str_obj.write("# -*- coding: utf-8 -*-\n")
         str_obj.write("{\n")
         for source_str, trans_str in sorted(mydict.items()):
-            str_obj.write("%s: %s,\n" % (repr(source_str), repr(trans_str)))
+            str_obj.write("{}: {},\n".format(repr(source_str), repr(trans_str)))
         str_obj.write("}\n")
         str_obj.seek(0)
         return str_obj

--- a/translate/convert/prop2mozfunny.py
+++ b/translate/convert/prop2mozfunny.py
@@ -35,19 +35,17 @@ def prop2inc(pf):
             if comment.startswith("# converted from") and "#defines" in comment:
                 pass
             else:
-                for blank in pendingblanks:
-                    yield blank
+                yield from pendingblanks
                 # TODO: could convert commented # x=y back to # #define x y
                 yield comment + "\n"
         if unit.isblank():
             pendingblanks.append("\n")
         else:
-            definition = "#define %s %s\n" % (
+            definition = "#define {} {}\n".format(
                 unit.name,
                 unit.value.replace("\n", "\\n"),
             )
-            for blank in pendingblanks:
-                yield blank
+            yield from pendingblanks
             yield definition
 
 
@@ -67,7 +65,7 @@ def prop2it(pf):
         if unit.isblank():
             yield ""
         else:
-            definition = "%s=%s\n" % (unit.name, unit.value)
+            definition = f"{unit.name}={unit.value}\n"
             yield definition
 
 

--- a/translate/convert/prop2po.py
+++ b/translate/convert/prop2po.py
@@ -190,7 +190,7 @@ class prop2po:
             "": "other",
         }
 
-        class Variants(object):
+        class Variants:
             def __init__(self, unit):
                 self.unit = unit
                 self.variants = {}

--- a/translate/convert/rc2po.py
+++ b/translate/convert/rc2po.py
@@ -58,7 +58,7 @@ class rc2po:
             x_merge_on="location",
         )
         output_header.addnote(
-            "extracted from %s, %s" % (template_store.filename, input_store.filename),
+            f"extracted from {template_store.filename}, {input_store.filename}",
             "developer",
         )
         input_store.makeindex()

--- a/translate/convert/resx2po.py
+++ b/translate/convert/resx2po.py
@@ -63,7 +63,7 @@ class resx2po:
             charset="UTF-8", encoding="8bit", x_accelerator_marker="&"
         )
         output_header.addnote(
-            "extracted from %s, %s" % (template_store.filename, input_store.filename),
+            f"extracted from {template_store.filename}, {input_store.filename}",
             "developer",
         )
 

--- a/translate/convert/sub2po.py
+++ b/translate/convert/sub2po.py
@@ -51,7 +51,7 @@ def merge_store(
     output_store = po.pofile()
     output_header = output_store.header()
     output_header.addnote(
-        "extracted from %s, %s" % (template_store.filename, input_store.filename),
+        f"extracted from {template_store.filename}, {input_store.filename}",
         "developer",
     )
 

--- a/translate/convert/symb2po.py
+++ b/translate/convert/symb2po.py
@@ -88,7 +88,7 @@ def get_template_dict(template_file):
 
 def build_output(units, template_header, template_dict):
     output_store = factory.classes["po"]()
-    ignore = set(["r_string_languagegroup_name"])
+    ignore = {"r_string_languagegroup_name"}
     header_entries = {
         "Last-Translator": template_header.get("Author", ""),
         "Language-Team": template_dict.get("r_string_languagegroup_name", ""),

--- a/translate/convert/test_convert.py
+++ b/translate/convert/test_convert.py
@@ -13,7 +13,7 @@ class TestConvertCommand:
 
     def setup_method(self, method):
         """creates a clean test directory for the given method"""
-        self.testdir = "%s_%s" % (self.__class__.__name__, method.__name__)
+        self.testdir = f"{self.__class__.__name__}_{method.__name__}"
         self.cleardir()
         os.mkdir(self.testdir)
         self.rundir = os.path.abspath(os.getcwd())
@@ -45,7 +45,7 @@ class TestConvertCommand:
             if value is True:
                 argv.append("--%s" % key)
             else:
-                argv.append("--%s=%s" % (key, value))
+                argv.append(f"--{key}={value}")
         try:
             self.convertmodule.main(argv)
         finally:

--- a/translate/convert/xliff2odf.py
+++ b/translate/convert/xliff2odf.py
@@ -44,10 +44,9 @@ def translate_odf(template, input_file):
         the etrees for each of those translatable files.
         """
         odf_data = open_odf(template)
-        return dict(
-            (filename, etree.parse(BytesIO(data)))
-            for filename, data in odf_data.items()
-        )
+        return {
+            filename: etree.parse(BytesIO(data)) for filename, data in odf_data.items()
+        }
 
     def load_unit_tree(input_file):
         """Return a dict with the translations grouped by files ODF package.

--- a/translate/convert/yaml2po.py
+++ b/translate/convert/yaml2po.py
@@ -72,7 +72,7 @@ class yaml2po:
 
     def merge_stores(self):
         """Convert two source format files to a target format file."""
-        self.extraction_msg = "extracted from %s, %s" % (
+        self.extraction_msg = "extracted from {}, {}".format(
             self.template_store.filename,
             self.source_store.filename,
         )

--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -282,12 +282,9 @@ class CheckerConfig:
         if validchars is None:
             return True
 
-        validcharsmap = dict(
-            [
-                (ord(validchar), None)
-                for validchar in data.normalized_unicode(validchars)
-            ]
-        )
+        validcharsmap = {
+            ord(validchar): None for validchar in data.normalized_unicode(validchars)
+        }
         self.validcharsmap.update(validcharsmap)
 
     def updatetargetlanguage(self, langcode):
@@ -1858,7 +1855,7 @@ class StandardChecker(TranslationChecker):
         invalid1 = str1.translate(self.config.validcharsmap)
         invalid2 = str2.translate(self.config.validcharsmap)
         invalidchars = [
-            "'%s' (\\u%04x)" % (invalidchar, ord(invalidchar))
+            "'{}' (\\u{:04x})".format(invalidchar, ord(invalidchar))
             for invalidchar in invalid2
             if invalidchar not in invalid1
         ]

--- a/translate/filters/pofilter.py
+++ b/translate/filters/pofilter.py
@@ -56,7 +56,7 @@ class pocheckfilter:
         """Lists the docs for filters available on checker."""
         filterdict = self.checker.getfilters()
         filterdocs = [
-            "%s\t%s" % (name, filterfunc.__doc__.split("\n\n")[0])
+            "{}\t{}".format(name, filterfunc.__doc__.split("\n\n")[0])
             for (name, filterfunc) in filterdict.items()
         ]
         filterdocs.sort()
@@ -184,7 +184,7 @@ class FilterOptionParser(optrecurse.RecursiveOptionParser):
                     "notranslatefile %r does not exist" % options.notranslatefile
                 )
 
-            with open(options.notranslatefile, "r") as fp:
+            with open(options.notranslatefile) as fp:
                 notranslatewords = [line.strip() for line in fp.readlines()]
             notranslatewords = dict.fromkeys([key for key in notranslatewords])
 
@@ -198,7 +198,7 @@ class FilterOptionParser(optrecurse.RecursiveOptionParser):
                     "musttranslatefile %r does not exist" % options.musttranslatefile
                 )
 
-            with open(options.musttranslatefile, "r") as fp:
+            with open(options.musttranslatefile) as fp:
                 musttranslatewords = [line.strip() for line in fp.readlines()]
             musttranslatewords = dict.fromkeys([key for key in musttranslatewords])
 
@@ -210,7 +210,7 @@ class FilterOptionParser(optrecurse.RecursiveOptionParser):
             if not os.path.exists(options.validcharsfile):
                 self.error("validcharsfile %r does not exist" % options.validcharsfile)
 
-            with open(options.validcharsfile, "r") as fp:
+            with open(options.validcharsfile) as fp:
                 validchars = fp.read()
 
             checkerconfig.updatevalidchars(validchars)

--- a/translate/filters/prefilters.py
+++ b/translate/filters/prefilters.py
@@ -156,9 +156,9 @@ def filtervariables(startmarker, endmarker, varfilter):
 # all apostrophes in the middle of the word are handled already
 wordswithpunctuation = ["'n", "'t"]  # Afrikaans
 # map all the words to their non-punctified equivalent
-wordswithpunctuation = dict(
-    [(word, "".join(filter(str.isalnum, word))) for word in wordswithpunctuation]
-)
+wordswithpunctuation = {
+    word: "".join(filter(str.isalnum, word)) for word in wordswithpunctuation
+}
 
 word_with_apos_re = re.compile(r"(?u)\w+'\w+")
 

--- a/translate/lang/data.py
+++ b/translate/lang/data.py
@@ -687,7 +687,7 @@ def get_language_iso_fullname(language_code):
         country_name = get_country_iso_name(country_code)
         if not country_name:
             return ""
-        return "%s (%s)" % (language_name, country_name)
+        return f"{language_name} ({country_name})"
     return get_language_iso_name(language_code)
 
 
@@ -709,7 +709,7 @@ def tr_lang(langcode=None):
         if match:
             language, country = match.groups()
             if country != "macrolanguage":
-                return "%s (%s)" % (
+                return "{} ({})".format(
                     _fix_language_name(langfunc(language)),
                     countryfunc(country),
                 )
@@ -813,7 +813,7 @@ def normalize_code(code):
     return code.replace("_", "-").replace("@", "-").lower()
 
 
-__normalised_languages = set(normalize_code(key) for key in languages.keys())
+__normalised_languages = {normalize_code(key) for key in languages.keys()}
 
 
 def simplify_to_common(language_code):
@@ -835,5 +835,5 @@ def get_language(code):
     code = code.replace("-", "_").replace("@", "_").lower()
     if "_" in code:
         # convert ab_cd → ab_CD
-        code = "%s_%s" % (code.split("_")[0], code.split("_", 1)[1].upper())
+        code = "{}_{}".format(code.split("_")[0], code.split("_", 1)[1].upper())
     return languages.get(code, None)

--- a/translate/lang/fa.py
+++ b/translate/lang/fa.py
@@ -34,7 +34,7 @@ def guillemets(text):
         # <a href="something">
         if prefix == "=":
             return match.group(0)
-        return "%s«%s»" % (prefix, match.group(2))
+        return "{}«{}»".format(prefix, match.group(2))
 
     # Check that there is an even number of double quotes, otherwise it is
     # probably not safe to convert them.

--- a/translate/lang/fr.py
+++ b/translate/lang/fr.py
@@ -34,7 +34,7 @@ def guillemets(text):
         # <a href="something">
         if prefix == "=":
             return match.group(0)
-        return "%s«\u00a0%s\u00a0»" % (prefix, match.group(2))  # \u00a0 is NBSP
+        return "{}«\u00a0{}\u00a0»".format(prefix, match.group(2))  # \u00a0 is NBSP
 
     # Check that there is an even number of double quotes, otherwise it is
     # probably not safe to convert them.

--- a/translate/lang/identify.py
+++ b/translate/lang/identify.py
@@ -21,7 +21,6 @@ This module contains functions for identifying languages based on language
 models.
 """
 
-import io
 from os import extsep, path
 
 from translate.lang.ngram import NGram
@@ -58,7 +57,7 @@ class LanguageIdentifier:
         """Load the mapping of language names to language codes as given in the
         configuration file.
         """
-        with open(conf_file, "r") as fp:
+        with open(conf_file) as fp:
             for line in fp:
                 parts = line.split()
                 if not parts or line.startswith("#"):
@@ -137,6 +136,6 @@ if __name__ == "__main__":
 
     script_dir = path.abspath(path.dirname(argv[0]))
     identifier = LanguageIdentifier()
-    with io.open(argv[1], "r") as fh:
+    with open(argv[1]) as fh:
         text = fh.read()
     print("Language detected:", identifier.identify_lang(text))

--- a/translate/lang/ngram.py
+++ b/translate/lang/ngram.py
@@ -24,9 +24,7 @@
 .. note:: Orignal code from http://thomas.mangin.me.uk/data/source/ngram.py
 """
 
-
 import glob
-import io
 import re
 import sys
 from os import path
@@ -110,7 +108,7 @@ class NGram:
             lang = path.split(fname)[-1][:-size]
             ngrams = {}
             try:
-                with io.open(fname, encoding="utf-8") as fp:
+                with open(fname, encoding="utf-8") as fp:
                     for i, line in enumerate(fp):
                         ngram, _t, _f = line.partition("\t")
                         ngrams[ngram] = i
@@ -150,7 +148,7 @@ class Generate:
             lang = path.split(fname)[-1][:-size]
             n = _NGram()
 
-            with io.open(fname, encoding="utf-8") as fp:
+            with open(fname, encoding="utf-8") as fp:
                 for line in fp:
                     n.addText(line)
 
@@ -160,7 +158,7 @@ class Generate:
     def save(self, folder, ext=".lm"):
         for lang in self.ngrams.keys():
             fname = path.join(folder, lang + ext)
-            with io.open(fname, mode="w", encoding="utf-8") as fp:
+            with open(fname, mode="w", encoding="utf-8") as fp:
                 for v, k in self.ngrams[lang].sorted_by_score():
                     fp.write("%s\t %d\n" % (k, v))
 

--- a/translate/lang/poedit.py
+++ b/translate/lang/poedit.py
@@ -195,7 +195,7 @@ lang_codes = {
 """ISO369 codes and names as used by Poedit.
 Mostly these are identical to ISO 639, but there are some differences."""
 
-lang_names = dict([(value, key) for (key, value) in lang_codes.items()])
+lang_names = {value: key for (key, value) in lang_codes.items()}
 """Reversed :data:`lang_codes`"""
 
 dialects = {

--- a/translate/lang/scn.py
+++ b/translate/lang/scn.py
@@ -88,7 +88,7 @@ class SicilianChecker(TranslationChecker):
         words1 = self.filteraccelerators(str1).split()
         words2 = self.filteraccelerators(str2).split()
         stopwords = [
-            "%s (%s)" % (word, errors[word])
+            "{} ({})".format(word, errors[word])
             for word in words2
             if word.lower() in errors.keys() and word not in words1
         ]
@@ -143,7 +143,7 @@ class SicilianChecker(TranslationChecker):
         for word in self.config.lang.words(str2):
             for suffix in suffixes.keys():
                 if word not in str1 and word.lower().endswith(suffix):
-                    stopwords.append("%s (-%s)" % (word, suffixes[suffix]))
+                    stopwords.append("{} (-{})".format(word, suffixes[suffix]))
 
         if stopwords:
             raise FilterFailure(

--- a/translate/lang/test_km.py
+++ b/translate/lang/test_km.py
@@ -8,7 +8,7 @@ def test_punctranslate():
     assert language.punctranslate("abc efg") == "abc efg"
     assert language.punctranslate("abc efg.") == "abc efg\u00a0។"
     print(language.punctranslate("abc efg. hij.").encode("utf-8"))
-    print("abc efg\u00a0។ hij\u00a0។".encode("utf-8"))
+    print("abc efg\u00a0។ hij\u00a0។".encode())
     assert language.punctranslate("abc efg. hij.") == "abc efg\u00a0។ hij\u00a0។"
     assert language.punctranslate("abc efg!") == "abc efg\u00a0!"
     assert language.punctranslate("abc efg? hij!") == "abc efg\u00a0? hij\u00a0!"

--- a/translate/misc/deprecation.py
+++ b/translate/misc/deprecation.py
@@ -34,7 +34,7 @@ def deprecated(message=""):
                 msg = "\n" + msg
             func_code = func.__code__
             warnings.warn_explicit(
-                "Call to deprecated function {0}.{1}".format(func.__name__, msg),
+                f"Call to deprecated function {func.__name__}.{msg}",
                 category=DeprecationWarning,
                 filename=func_code.co_filename,
                 lineno=func_code.co_firstlineno + 1,

--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -65,7 +65,7 @@ class ProgressBar:
         self._progressbar.show(filename)
 
 
-class ManPageOption(optparse.Option, object):
+class ManPageOption(optparse.Option):
     ACTIONS = optparse.Option.ACTIONS + ("manpage",)
 
     def take_action(self, action, dest, opt, value, values, parser):
@@ -169,7 +169,9 @@ class RecursiveOptionParser(optparse.OptionParser):
         )
         result.append(".SH NAME\n")
         result.append(
-            "%s \\- %s\n" % (self.get_prog_name(), self.description.split("\n\n")[0])
+            "{} \\- {}\n".format(
+                self.get_prog_name(), self.description.split("\n\n")[0]
+            )
         )
         result.append(".SH SYNOPSIS\n")
         result.append(".PP\n")
@@ -554,7 +556,7 @@ class RecursiveOptionParser(optparse.OptionParser):
                         "Output directory does not exist. Attempting to create"
                     )
                     os.mkdir(options.output)
-                except IOError:
+                except OSError:
                     self.error(
                         optparse.OptionValueError(
                             "Output directory does not exist, attempt to create failed"
@@ -590,7 +592,7 @@ class RecursiveOptionParser(optparse.OptionParser):
                     and not self.allowmissingtemplate
                 ):
                     self.warning(
-                        "No template at %s. Skipping %s." % (templatepath, inputpath)
+                        f"No template at {templatepath}. Skipping {inputpath}."
                     )
                     continue
                 outputformat, fileprocessor = self.getoutputoptions(

--- a/translate/misc/ourdom.py
+++ b/translate/misc/ourdom.py
@@ -65,14 +65,14 @@ def writexml_helper(self, writer, indent="", addindent="", newl=""):
             writer.write(">")
             for node in self.childNodes:
                 node.writexml(writer, "", "", "")
-            writer.write("</%s>%s" % (self.tagName, newl))
+            writer.write(f"</{self.tagName}>{newl}")
         else:
             # This is the normal case that we do with pretty layout
             writer.write(">%s" % (newl))
             for node in self.childNodes:
                 if node.nodeType != self.TEXT_NODE:
                     node.writexml(writer, (indent + addindent), addindent, newl)
-            writer.write("%s</%s>%s" % (indent, self.tagName, newl))
+            writer.write(f"{indent}</{self.tagName}>{newl}")
     else:
         writer.write("/>%s" % (newl))
 
@@ -90,8 +90,7 @@ def getElementsByTagName_helper(parent, name, dummy=None):
         ):
             yield node
         if node.hasChildNodes():
-            for othernode in node.getElementsByTagName(name):
-                yield othernode
+            yield from node.getElementsByTagName(name)
 
 
 def searchElementsByTagName_helper(parent, name, onlysearch):

--- a/translate/misc/selector.py
+++ b/translate/misc/selector.py
@@ -355,7 +355,7 @@ class SimpleParser:
         if name == "":
             name = "__pos%s" % self._pos
             self._pos += 1
-        return "(?P<%s>%s)" % (name, pattern)
+        return f"(?P<{name}>{pattern})"
 
     def lastly(self, regex):
         """Process the result of __call__ right before it returns.

--- a/translate/misc/xml_helpers.py
+++ b/translate/misc/xml_helpers.py
@@ -96,7 +96,7 @@ def namespaced(namespace, name):
     This is needed throughout lxml.
     """
     if namespace:
-        return "{%s}%s" % (namespace, name)
+        return f"{{{namespace}}}{name}"
     else:
         return name
 

--- a/translate/services/test_tmserver.py
+++ b/translate/services/test_tmserver.py
@@ -51,7 +51,7 @@ msgstr "Ahoj"
         thread.start()
 
         # Run test
-        response = urlopen("http://localhost:{}/en/cs/unit/Hello/".format(server_port))
+        response = urlopen(f"http://localhost:{server_port}/en/cs/unit/Hello/")
         payload = json.loads(response.read().decode("utf-8"))
         assert payload[0]["target"] == "Ahoj"
 

--- a/translate/services/tmserver.py
+++ b/translate/services/tmserver.py
@@ -92,7 +92,7 @@ class TMServer:
         params = parse.parse_qs(environ.get("QUERY_STRING", ""))
         try:
             callback = params.get("callback", [])[0]
-            response = "%s(%s)" % (callback, response)
+            response = f"{callback}({response})"
         except IndexError:
             pass
         return [response]

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -149,7 +149,7 @@ class TranslationUnit:
         # no point in showing store object.
         return ", ".join(
             [
-                "%s: %s" % (k, self.__dict__[k])
+                "{}: {}".format(k, self.__dict__[k])
                 for k in sorted(self.__dict__.keys())
                 if k != "_store"
             ]
@@ -573,8 +573,7 @@ class TranslationStore:
 
     def unit_iter(self):
         """Iterator over all the units in this store."""
-        for unit in self.units:
-            yield unit
+        yield from self.units
 
     def getunits(self):
         """Return a list of all units in this store."""
@@ -906,11 +905,11 @@ class UnitId:
     def __str__(self):
         def fmt(element, key):
             if element == "key":
-                return "{}{}".format(self.KEY_SEPARATOR, key)
+                return f"{self.KEY_SEPARATOR}{key}"
             elif element == "index":
-                return "{}[{}]".format(self.INDEX_SEPARATOR, key)
+                return f"{self.INDEX_SEPARATOR}[{key}]"
             else:
-                raise ValueError("Unsupported element: {}".format(element))
+                raise ValueError(f"Unsupported element: {element}")
 
         return "".join([fmt(*part) for part in self.parts])
 
@@ -959,7 +958,7 @@ class DictUnit(TranslationUnit):
                 if key not in target or isinstance(target[key], str):
                     target[key] = default
             else:
-                raise ValueError("Unsupported element: {}".format(element))
+                raise ValueError(f"Unsupported element: {element}")
             target = target[key]
         if override_key:
             element, key = "key", override_key
@@ -980,7 +979,7 @@ class DictUnit(TranslationUnit):
                 else:
                     target[key] = value
         else:
-            raise ValueError("Unsupported element: {}".format(element))
+            raise ValueError(f"Unsupported element: {element}")
 
     def storevalues(self, output):
         self.storevalue(output, self.value)

--- a/translate/storage/benchmark.py
+++ b/translate/storage/benchmark.py
@@ -102,7 +102,7 @@ class TranslateBenchmarker:
         for dirpath, subdirs, filenames in os.walk(file_dir, topdown=False):
             for name in filenames:
                 pofilename = os.path.join(dirpath, name)
-                parsedfile = self.StoreClass(open(pofilename, "r"))
+                parsedfile = self.StoreClass(open(pofilename))
                 count += len(parsedfile.units)
                 self.parsedfiles.append(parsedfile)
         print("counted %d units" % count)
@@ -199,10 +199,10 @@ if __name__ == "__main__":
         for methodname, methodparam in methods:
             print("_______________________________________________________")
             statsfile = (
-                "%s_%s" % (methodname, storetype)
+                f"{methodname}_{storetype}"
                 + "_%d_%d_%d_%d_%d.stats" % sample_file_sizes
             )
-            cProfile.run("benchmarker.%s(%s)" % (methodname, methodparam), statsfile)
+            cProfile.run(f"benchmarker.{methodname}({methodparam})", statsfile)
             stats = pstats.Stats(statsfile)
             stats.sort_stats("time").print_stats(20)
             print("_______________________________________________________")

--- a/translate/storage/catkeys.py
+++ b/translate/storage/catkeys.py
@@ -69,7 +69,7 @@ FIELDNAMES_HEADER_DEFAULTS = {
 """Default or minimum header entries for a catkeys file"""
 
 _unescape_map = {"\\r": "\r", "\\t": "\t", "\\n": "\n", "\\\\": "\\"}
-_escape_map = dict([(value, key) for (key, value) in _unescape_map.items()])
+_escape_map = {value: key for (key, value) in _unescape_map.items()}
 # We don't yet do escaping correctly, just for lack of time to do it.  The
 # current implementation is just based on something simple that will work with
 # investaged files.  The only escapes found were "\n", "\t", "\\n"
@@ -211,9 +211,9 @@ class CatkeysUnit(base.TranslationUnit):
         notes = self.getnotes()
         id = self.source
         if notes:
-            id = "%s\04%s" % (notes, id)
+            id = f"{notes}\04{id}"
         if context:
-            id = "%s\04%s" % (context, id)
+            id = f"{context}\04{id}"
         return id
 
     def markfuzzy(self, present=True):

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -510,7 +510,7 @@ class pounit(pocommon.pounit):
         #            id = '%s\0%s' % (id, plural)
         context = gpo.po_message_msgctxt(self._gpo_message)
         if context:
-            id = "%s\04%s" % (gpo_decode(context), id)
+            id = "{}\04{}".format(gpo_decode(context), id)
         return id
 
     def getnotes(self, origin=None):
@@ -674,7 +674,7 @@ class pounit(pocommon.pounit):
 
     def setmsgidcomment(self, msgidcomment):
         if msgidcomment:
-            self.source = "_: %s\n%s" % (msgidcomment, self.source)
+            self.source = f"_: {msgidcomment}\n{self.source}"
 
     msgidcomment = property(_extract_msgidcomments, setmsgidcomment)
 

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -56,7 +56,7 @@ class csvunit(base.TranslationUnit):
         result = self.source
         context = self.context
         if context:
-            result = "%s\04%s" % (context, result)
+            result = f"{context}\04{result}"
 
         return result
 

--- a/translate/storage/directory.py
+++ b/translate/storage/directory.py
@@ -39,8 +39,7 @@ class Directory:
         """Iterator over (dir, filename) for all files in this directory."""
         if not self.filedata:
             self.scanfiles()
-        for filetuple in self.filedata:
-            yield filetuple
+        yield from self.filedata
 
     def getfiles(self):
         """Returns a list of (dir, filename) tuples for all the file names in
@@ -53,8 +52,7 @@ class Directory:
         for dirname, filename in self.file_iter():
             store = factory.getobject(os.path.join(dirname, filename))
             # TODO: don't regenerate all the storage objects
-            for unit in store.unit_iter():
-                yield unit
+            yield from store.unit_iter()
 
     def getunits(self):
         """List of all the units in all the files in this directory."""

--- a/translate/storage/factory.py
+++ b/translate/storage/factory.py
@@ -143,7 +143,7 @@ def _getname(storefile):
 @lru_cache(maxsize=128)
 def import_class(module_name, class_name, prefix=None):
     if prefix:
-        module_name = "{}.{}".format(prefix, module_name)
+        module_name = f"{prefix}.{module_name}"
     module = import_module(module_name)
     return getattr(module, class_name)
 

--- a/translate/storage/flatxml.py
+++ b/translate/storage/flatxml.py
@@ -192,7 +192,9 @@ class FlatXMLFile(base.TranslationStore):
         self.encoding = self.document.docinfo.encoding
 
         root_name = self.namespaced(self.root_name)
-        assert self.root.tag == root_name, "expected root name to be %s but got %s" % (
+        assert (
+            self.root.tag == root_name
+        ), "expected root name to be {} but got {}".format(
             root_name,
             self.root.tag,
         )
@@ -205,14 +207,14 @@ class FlatXMLFile(base.TranslationStore):
             matching_nodes = list(self.root.iterchildren(value_name))
             assert len(
                 matching_nodes
-            ), "expected value name to be %s but first node is %s" % (
+            ), "expected value name to be {} but first node is {}".format(
                 value_name,
                 self.root[0].tag,
             )
 
             assert matching_nodes[0].get(
                 self.key_name
-            ), "expected key attribute to be %s, found attribute(s): %s" % (
+            ), "expected key attribute to be {}, found attribute(s): {}".format(
                 self.key_name,
                 ",".join(matching_nodes[0].attrib),
             )

--- a/translate/storage/fpo.py
+++ b/translate/storage/fpo.py
@@ -401,9 +401,9 @@ class pounit(pocommon.pounit):
         #        id = '\0'.join(self.source.strings)
         id = self.source
         if self.msgidcomment:
-            id = "_: %s\n%s" % (context, id)
+            id = f"_: {context}\n{id}"
         elif context:
-            id = "%s\04%s" % (context, id)
+            id = f"{context}\04{id}"
         return id
 
     @classmethod

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -372,8 +372,8 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
             if attrvalue is None:
                 attr_strings.append(" " + attrname)
             else:
-                attr_strings.append(' %s="%s"' % (attrname, attrvalue))
-        return "<%s%s%s>" % (tag, "".join(attr_strings), " /" if startend else "")
+                attr_strings.append(f' {attrname}="{attrvalue}"')
+        return "<{}{}{}>".format(tag, "".join(attr_strings), " /" if startend else "")
 
     def auto_close_empty_element(self):
         if self.tag_path and self.tag_path[-1] in self.EMPTY_HTML_ELEMENTS:

--- a/translate/storage/ical.py
+++ b/translate/storage/ical.py
@@ -134,6 +134,4 @@ class icalfile(base.TranslationStore):
                     ):
                         newunit = self.addsourceunit(property.value)
                         newunit.addnote("Start date: %s" % component.dtstart.value)
-                        newunit.addlocation(
-                            "[%s]%s" % (component.uid.value, property.name)
-                        )
+                        newunit.addlocation(f"[{component.uid.value}]{property.name}")

--- a/translate/storage/idml.py
+++ b/translate/storage/idml.py
@@ -76,11 +76,11 @@ def open_idml(filename):
     # Return a dictionary containing all the files inside the Stories
     # subdirectory, being the keys the filenames (for example
     # 'Stories/Story_u49f.xml' and the values the strings for those files.
-    return dict(
-        (filename, z.read(filename))
+    return {
+        filename: z.read(filename)
         for filename in z.namelist()
         if filename.startswith("Stories/")
-    )
+    }
 
 
 def copy_idml(input_zip, output_zip, exclusion_list):

--- a/translate/storage/ini.py
+++ b/translate/storage/ini.py
@@ -142,4 +142,4 @@ class inifile(base.TranslationStore):
             for entry in self._inifile[section]:
                 source = self._dialect.unescape(self._inifile[section][entry])
                 newunit = self.addsourceunit(source)
-                newunit.addlocation("[%s]%s" % (section, entry))
+                newunit.addlocation(f"[{section}]{entry}")

--- a/translate/storage/mozilla_lang.py
+++ b/translate/storage/mozilla_lang.py
@@ -65,8 +65,8 @@ class LangUnit(base.TranslationUnit):
                     for note in self.getnotes("developer").split("\n")
                 ]
             )
-            return "%s%s;%s%s%s" % (notes, self.eol, self.source, self.eol, target)
-        return ";%s%s%s" % (self.source, self.eol, target)
+            return f"{notes}{self.eol};{self.source}{self.eol}{target}"
+        return f";{self.source}{self.eol}{target}"
 
     def getlocations(self):
         return self.locations

--- a/translate/storage/oo.py
+++ b/translate/storage/oo.py
@@ -97,7 +97,7 @@ def makekey(ookey, long_keys):
         fullid = groupid + "." + localid
     if resourcetype:
         fullid = fullid + "." + resourcetype
-    key = "%s#%s" % (sourcebase, fullid)
+    key = f"{sourcebase}#{fullid}"
     return normalizefilename(key)
 
 
@@ -460,8 +460,7 @@ class oomultifile:
 
     def __iter__(self):
         """iterates through the subfile names"""
-        for subfile in self.listsubfiles():
-            yield subfile
+        yield from self.listsubfiles()
 
     def __contains__(self, pathname):
         """checks if this pathname is a valid subfile"""

--- a/translate/storage/php.py
+++ b/translate/storage/php.py
@@ -378,7 +378,7 @@ class phpfile(base.TranslationStore):
             # Write array start
             write("{}{}{} {}\n".format(" " * indent, name, separator, init))
             indent += 4
-            prefix = "{}->".format(arrname)
+            prefix = f"{arrname}->"
             pref_len = len(prefix)
             for item in self.units:
                 if not item.name.startswith(prefix):
@@ -428,13 +428,13 @@ class phpfile(base.TranslationStore):
                     # To update lexer current position
                     lexer.extract_name("DOUBLE_ARROW", *item.lexpositions)
                     if isinstance(item.key, BinaryOp):
-                        name = "'{0}'".format(concatenate(item.key))
+                        name = "'{}'".format(concatenate(item.key))
                     elif isinstance(item.key, (int, float)):
-                        name = "{0}".format(item.key)
+                        name = f"{item.key}"
                     else:
-                        name = "'{0}'".format(item.key)
+                        name = f"'{item.key}'"
                 if prefix:
-                    name = "{0}->{1}".format(prefix, name)
+                    name = f"{prefix}->{name}"
                 if isinstance(item.value, Array):
                     handle_array(name, item.value.nodes, lexer)
                 elif isinstance(item.value, str):

--- a/translate/storage/placeables/strelem.py
+++ b/translate/storage/placeables/strelem.py
@@ -122,8 +122,7 @@ class StringElem:
 
     def __iter__(self):
         """Create an iterator of this element's sub-elements."""
-        for elem in self.sub:
-            yield elem
+        yield from self.sub
 
     def __le__(self, rhs):
         """Emulate the ``unicode`` class."""
@@ -786,7 +785,7 @@ class StringElem:
             return True
 
         logging.debug(
-            "Could not insert between %s and %s... odd." % (repr(left), repr(right))
+            "Could not insert between {} and {}... odd.".format(repr(left), repr(right))
         )
         return False
 
@@ -816,8 +815,7 @@ class StringElem:
             if sub.isleaf() and filter(sub):
                 yield sub
             else:
-                for node in sub.iter_depth_first(filter):
-                    yield node
+                yield from sub.iter_depth_first(filter)
 
     def map(self, f, filter=None):
         """Apply ``f`` to all nodes for which ``filter`` returned ``True``
@@ -851,7 +849,7 @@ class StringElem:
         """
         indent_prefix = " " * indent * 2
         out = (
-            "%s%s [%s]" % (indent_prefix, self.__class__.__name__, str(self))
+            "{}{} [{}]".format(indent_prefix, self.__class__.__name__, str(self))
         ).encode("utf-8")
         if verbose:
             out += " " + repr(self)
@@ -862,9 +860,7 @@ class StringElem:
             if isinstance(elem, StringElem):
                 elem.print_tree(indent + 1, verbose=verbose)
             else:
-                print(
-                    ("%s%s[%s]" % (indent_prefix, indent_prefix, elem)).encode("utf-8")
-                )
+                print((f"{indent_prefix}{indent_prefix}[{elem}]").encode("utf-8"))
 
     def prune(self):
         """Remove unnecessary nodes to make the tree optimal."""

--- a/translate/storage/pocommon.py
+++ b/translate/storage/pocommon.py
@@ -71,7 +71,7 @@ class pounit(base.TranslationUnit):
 
     def adderror(self, errorname, errortext):
         """Adds an error message to this unit."""
-        text = "(pofilter) %s: %s" % (errorname, errortext)
+        text = f"(pofilter) {errorname}: {errortext}"
         # Don't add the same error twice:
         if text not in self.getnotes(origin="translator"):
             self.addnote(text, origin="translator")

--- a/translate/storage/poheader.py
+++ b/translate/storage/poheader.py
@@ -145,7 +145,7 @@ class poheader:
         mime_version=None,
         plural_forms=None,
         report_msgid_bugs_to=None,
-        **kwargs
+        **kwargs,
     ):
         """Create a header dictionary with useful defaults.
 
@@ -247,7 +247,7 @@ class poheader:
             headerString = ""
             for key, value in headeritems.items():
                 if value is not None:
-                    headerString += "%s: %s\n" % (key, value)
+                    headerString += f"{key}: {value}\n"
             header.target = headerString
             header.markfuzzy(False)  # TODO: check why we do this?
         return header
@@ -387,12 +387,12 @@ class poheader:
             "Language-Team",
             "Plural-Forms",
         )
-        retain = dict(
-            (key, newvalues[key])
+        retain = {
+            key: newvalues[key]
             for key in retain_list
             if newvalues.get(key, None)
             and newvalues[key] != default_header.get(key, None)
-        )
+        }
         self.updateheader(**retain)
 
     def updatecontributor(self, name, email=None):
@@ -437,14 +437,14 @@ class poheader:
                     # The contributor is there, but not for this year
                     if line[-1] == ".":
                         line = line[:-1]
-                    contriblines[i] = "%s, %s." % (line, year)
+                    contriblines[i] = f"{line}, {year}."
 
         if not contribexists:
             # Add a new contributor
             if email:
-                contriblines.append("%s <%s>, %s." % (name, email, year))
+                contriblines.append(f"{name} <{email}>, {year}.")
             else:
-                contriblines.append("%s, %s." % (name, year))
+                contriblines.append(f"{name}, {year}.")
 
         header.removenotes()
         header.addnote("\n".join(prelines))
@@ -463,6 +463,6 @@ class poheader:
         for (key, value) in headeritems.items():
             if value is None:
                 continue
-            headervalue += "%s: %s\n" % (key, value)
+            headervalue += f"{key}: {value}\n"
         headerpo.target = headervalue
         return headerpo

--- a/translate/storage/poparser.py
+++ b/translate/storage/poparser.py
@@ -361,12 +361,7 @@ def decode_header(unit, decode):
             setattr(
                 unit,
                 attr,
-                dict(
-                    [
-                        (key, decode_list(value, decode))
-                        for key, value in element.items()
-                    ]
-                ),
+                {key: decode_list(value, decode) for key, value in element.items()},
             )
 
 
@@ -392,4 +387,4 @@ def parse_units(parse_state, store):
         store.addunit(unit)
         unit = parse_unit(parse_state)
     if not parse_state.eof:
-        raise ValueError("Syntax error on line {}".format(parse_state.lineno))
+        raise ValueError(f"Syntax error on line {parse_state.lineno}")

--- a/translate/storage/project.py
+++ b/translate/storage/project.py
@@ -178,7 +178,7 @@ class Project:
             # If the output file already exist, we can't assume that it's safe
             # to overwrite it.
             os.unlink(converted_file.name)
-            raise IOError("Output file already exists: %s" % (output_fname))
+            raise OSError("Output file already exists: %s" % (output_fname))
 
         os.rename(converted_file.name, output_fname)
 

--- a/translate/storage/projstore.py
+++ b/translate/storage/projstore.py
@@ -231,7 +231,7 @@ class ProjectStore:
             if not rfile or not os.path.isfile(rfname):
                 rfname = getattr(rfile, "filename", None)
             if not rfile or not os.path.isfile(rfname):
-                raise IOError("Could not locate file: %s (%s)" % (rfile, fname))
+                raise OSError(f"Could not locate file: {rfile} ({fname})")
             rfile = open(rfname, mode)
             self._files[fname] = rfile
 

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -464,7 +464,7 @@ class DialectGwt(DialectJava):
         variant = cls.gwt2cldr.get(variant)
         # Some sanity checks
         if not variant:
-            raise Exception('Key "%s" variant "%s" is invalid' % (key, variant))
+            raise Exception(f'Key "{key}" variant "{variant}" is invalid')
         return (key, variant)
 
     @classmethod
@@ -477,8 +477,8 @@ class DialectGwt(DialectJava):
 
         # Some sanity checks
         if not variant:
-            raise Exception('Key "%s" variant "%s" is invalid' % (key, variant))
-        return "%s[%s]" % (key, variant)
+            raise Exception(f'Key "{key}" variant "{variant}" is invalid')
+        return f"{key}[{variant}]"
 
     @classmethod
     def encode(cls, string, encoding=None):
@@ -556,7 +556,7 @@ class proppluralunit(base.TranslationUnit):
     def __init__(self, source="", personality="java"):
         """Construct a blank propunit."""
         self.personality = get_dialect(personality)
-        super(proppluralunit, self).__init__(source)
+        super().__init__(source)
         self.units = collections.OrderedDict()
         self.name = ""
 
@@ -901,15 +901,15 @@ class propunit(base.TranslationUnit):
             kwc = self.personality.key_wrap_char
             if kwc:
                 key = key.replace(kwc, "\\%s" % kwc)
-                key = "%s%s%s" % (kwc, key, kwc)
+                key = f"{kwc}{key}{kwc}"
             # encode value, if needed
             value = self.translation or self.value
             vwc = self.personality.value_wrap_char
             if vwc:
                 value = value.replace(vwc, "\\%s" % vwc)
-                value = "%s%s%s" % (vwc, value, vwc)
+                value = f"{vwc}{value}{vwc}"
             wrappers = self.out_delimiter_wrappers
-            delimiter = "%s%s%s" % (wrappers, self.delimiter, wrappers)
+            delimiter = f"{wrappers}{self.delimiter}{wrappers}"
             ending = self.out_ending
             missing_prefix = ""
             if self.missing and self.output_missing:
@@ -1011,7 +1011,7 @@ class propfile(base.TranslationStore):
             default_encodings=[self.personality.default_encoding, "utf-8", "utf-16"],
         )
         if not text and propsrc:
-            raise IOError(
+            raise OSError(
                 "Cannot detect encoding for %s." % (self.filename or "given string")
             )
         self.encoding = encoding
@@ -1182,7 +1182,7 @@ class gwtfile(propfile):
     def __init__(self, *args, **kwargs):
         kwargs["personality"] = "gwt"
         kwargs["encoding"] = "utf-8"
-        super(gwtfile, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class stringsfile(propfile):
@@ -1331,9 +1331,9 @@ class XWikiFullPage(XWikiPageProperties):
             title = "".join(self.root.find("title").itertext())
             forparsing = ""
             if content != "":
-                forparsing += "content={}\n".format(content)
+                forparsing += f"content={content}\n"
             if title != "":
-                forparsing += "title={}\n".format(title)
+                forparsing += f"title={title}\n"
             self.extract_language()
             super(XWikiPageProperties, self).parse(forparsing.encode(self.encoding))
 

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -42,7 +42,7 @@ lsep = "\n#: "
 # general functions for quoting / unquoting po strings
 
 po_unescape_map = {"\\r": "\r", "\\t": "\t", '\\"': '"', "\\n": "\n", "\\\\": "\\"}
-po_escape_map = dict([(value, key) for (key, value) in po_unescape_map.items()])
+po_escape_map = {value: key for (key, value) in po_unescape_map.items()}
 
 
 def splitlines(text):
@@ -347,11 +347,11 @@ class pounit(pocommon.pounit):
         if isinstance(templates, list):
             templates = {0: templates}
         if isinstance(target, list):
-            self.msgstr = dict([(i, self.quote(target[i])) for i in range(len(target))])
+            self.msgstr = {i: self.quote(target[i]) for i in range(len(target))}
         elif isinstance(target, dict):
-            self.msgstr = dict(
-                [(i, self.quote(targetstring)) for i, targetstring in target.items()]
-            )
+            self.msgstr = {
+                i: self.quote(targetstring) for i, targetstring in target.items()
+            }
         else:
             self.msgstr = self.quote(target)
 
@@ -505,7 +505,7 @@ class pounit(pocommon.pounit):
                     prefix = item.split()[0]
                 list1.extend(
                     [
-                        "%s %s%s" % (prefix, item, lineend)
+                        f"{prefix} {item}{lineend}"
                         for item in splitlist2
                         if item not in splitlist1
                     ]
@@ -729,8 +729,8 @@ class pounit(pocommon.pounit):
 
         def add_prev_msgid_lines(lines, prefix, header, var):
             if var:
-                lines.append("%s %s %s\n" % (prefix, header, var[0]))
-                lines.extend("%s %s\n" % (prefix, line) for line in var[1:])
+                lines.append("{} {} {}\n".format(prefix, header, var[0]))
+                lines.extend(f"{prefix} {line}\n" for line in var[1:])
 
         def add_prev_msgid_info(lines, prefix):
             add_prev_msgid_lines(lines, prefix, "msgctxt", self.prev_msgctxt)
@@ -846,9 +846,9 @@ class pounit(pocommon.pounit):
         #        id = '\0'.join(self.source.strings)
         id = self.source
         if self.msgidcomments:
-            id = "_: %s\n%s" % (context, id)
+            id = f"_: {context}\n{id}"
         elif context:
-            id = "%s\04%s" % (context, id)
+            id = f"{context}\04{id}"
         return id
 
 

--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -123,7 +123,7 @@ class rcunit(base.TranslationUnit):
         if self.isblank():
             return "".join(self.comments + ["\n"])
         else:
-            return "".join(self.comments + ["%s=%s\n" % (self.name, self._value)])
+            return "".join(self.comments + [f"{self.name}={self._value}\n"])
 
     def getlocations(self):
         return [self.name]
@@ -241,7 +241,7 @@ def generate_stringtable_name(identifier):
 
 def generate_menu_pre_name(block_type, block_id):
     """Return the pre-name generated for elements of a menu."""
-    return "%s.%s" % (block_type, block_id)
+    return f"{block_type}.{block_id}"
 
 
 def generate_popup_pre_name(pre_name, caption):
@@ -253,7 +253,7 @@ def generate_popup_pre_name(pre_name, caption):
     :return: The subelements pre-name based in the pre-name of the popup and
              its caption.
     """
-    return "%s.%s" % (pre_name, caption.replace(" ", "_"))
+    return "{}.{}".format(pre_name, caption.replace(" ", "_"))
 
 
 def generate_popup_caption_name(pre_name):
@@ -263,17 +263,17 @@ def generate_popup_caption_name(pre_name):
 
 def generate_menuitem_name(pre_name, block_type, identifier):
     """Return the name generated for a menuitem of a popup."""
-    return "%s.%s.%s" % (pre_name, block_type, identifier)
+    return f"{pre_name}.{block_type}.{identifier}"
 
 
 def generate_dialog_caption_name(block_type, identifier):
     """Return the name generated for a caption of a dialog."""
-    return "%s.%s.%s" % (block_type, identifier, "CAPTION")
+    return "{}.{}.{}".format(block_type, identifier, "CAPTION")
 
 
 def generate_dialog_control_name(block_type, block_id, control_type, identifier):
     """Return the name generated for a control of a dialog."""
-    return "%s.%s.%s.%s" % (block_type, block_id, control_type, identifier)
+    return f"{block_type}.{block_id}.{control_type}.{identifier}"
 
 
 class rcfile(base.TranslationStore):

--- a/translate/storage/subtitles.py
+++ b/translate/storage/subtitles.py
@@ -76,7 +76,7 @@ class SubtitleUnit(base.TranslationUnit):
             return ""
 
     def getlocations(self):
-        return ["%s-->%s" % (self._start, self._end)]
+        return [f"{self._start}-->{self._end}"]
 
     def getid(self):
         return self.getlocations()[0]

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -604,24 +604,20 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
 ]>
 <resources>
     <string name="privacy_policy"><u><a href="&url_privacy_policy;">Datenschutzerklärung</a></u></string>
-</resources>""".encode(
-            "utf-8"
-        )
+</resources>""".encode()
         store = self.StoreClass()
         store.parse(content)
         assert bytes(store) == content
 
     def test_edit_plural_markup(self):
-        content = """<?xml version="1.0" encoding="utf-8"?>
+        content = b"""<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <plurals name="teststring">
         <item quantity="one"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> den</item>
         <item quantity="few"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dny</item>
         <item quantity="other"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu</item>
     </plurals>
-</resources>""".encode(
-            "utf-8"
-        )
+</resources>"""
         store = self.StoreClass()
         store.targetlanguage = "cs"
         store.parse(content)
@@ -692,7 +688,7 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
         assert bytes(store) == newcontent
 
     def test_edit_plural_others(self):
-        content = """<?xml version="1.0" encoding="utf-8"?>
+        content = b"""<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <plurals name="teststring">
         <item quantity="one"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> den</item>
@@ -700,9 +696,7 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
         <item quantity="many"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu</item>
         <item quantity="other"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu</item>
     </plurals>
-</resources>""".encode(
-            "utf-8"
-        )
+</resources>"""
         store = self.StoreClass()
         store.targetlanguage = "ru"
         store.parse(content)

--- a/translate/storage/test_base.py
+++ b/translate/storage/test_base.py
@@ -240,7 +240,7 @@ class TestTranslationStore:
 
     def setup_method(self, method):
         """Allocates a unique self.filename for the method, making sure it doesn't exist"""
-        self.filename = "%s_%s.test" % (self.__class__.__name__, method.__name__)
+        self.filename = f"{self.__class__.__name__}_{method.__name__}.test"
         if os.path.exists(self.filename):
             os.remove(self.filename)
         warnings.resetwarnings()
@@ -379,12 +379,9 @@ class TestTranslationStore:
     def test_extensions(self):
         """Test that the factory knows the extensions for this class."""
         supported = factory.supported_files()
-        supported_dict = dict(
-            [
-                (name, (extensions, mimetypes))
-                for name, extensions, mimetypes in supported
-            ]
-        )
+        supported_dict = {
+            name: (extensions, mimetypes) for name, extensions, mimetypes in supported
+        }
         if not (self.StoreClass.Name and self.StoreClass.Name in supported_dict):
             return
         detail = supported_dict[
@@ -400,12 +397,9 @@ class TestTranslationStore:
     def test_mimetypes(self):
         """Test that the factory knows the mimetypes for this class."""
         supported = factory.supported_files()
-        supported_dict = dict(
-            [
-                (name, (extensions, mimetypes))
-                for name, extensions, mimetypes in supported
-            ]
-        )
+        supported_dict = {
+            name: (extensions, mimetypes) for name, extensions, mimetypes in supported
+        }
         if not (self.StoreClass.Name and self.StoreClass.Name in supported_dict):
             return
         detail = supported_dict[

--- a/translate/storage/test_csvl10n.py
+++ b/translate/storage/test_csvl10n.py
@@ -31,7 +31,7 @@ class TestCSV(test_base.TestTranslationStore):
         assert bytes(store) == bytes(newstore)
 
     def test_utf_8(self):
-        store = self.parse_store("foo.c:1;test;zkouška sirén".encode("utf-8"))
+        store = self.parse_store("foo.c:1;test;zkouška sirén".encode())
         assert len(store.units) == 1
         assert store.units[0].source == "test"
         assert store.units[0].target == "zkouška sirén"

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -365,9 +365,7 @@ class TestWebExtensionStore(test_monolingual.TestMonolingualStore):
         }
     }
 }
-""".encode(
-            "utf-8"
-        )
+""".encode()
 
         store = self.StoreClass()
         store.parse(DATA)

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -272,7 +272,7 @@ class TestProp(test_monolingual.TestMonolingualStore):
     def test_unicode_escaping(self):
         """check that escaped unicode is converted properly"""
         propsource = "unicode=\u0411\u0416\u0419\u0428"
-        messagevalue = "\u0411\u0416\u0419\u0428".encode("UTF-8")
+        messagevalue = "\u0411\u0416\u0419\u0428".encode()
         propfile = self.propparse(propsource, personality="mozilla")
         assert len(propfile.units) == 1
         propunit = propfile.units[0]
@@ -324,7 +324,7 @@ class TestProp(test_monolingual.TestMonolingualStore):
         delimiters = [":", "=", " "]
         for delimiter in delimiters:
             propsource = "key%svalue" % delimiter
-            print("source: '%s'\ndelimiter: '%s'" % (propsource, delimiter))
+            print(f"source: '{propsource}'\ndelimiter: '{delimiter}'")
             propfile = self.propparse(propsource)
             assert len(propfile.units) == 1
             propunit = propfile.units[0]
@@ -447,7 +447,7 @@ key=value
 
     def test_mac_strings_utf8(self):
         """Ensure we can handle Unicode"""
-        propsource = """"I am a “key”" = "I am a “value”";""".encode("utf-8")
+        propsource = """"I am a “key”" = "I am a “value”";""".encode()
         propfile = self.propparse(propsource, personality="strings-utf8")
         assert len(propfile.units) == 1
         propunit = propfile.units[0]
@@ -579,8 +579,8 @@ key=value
 
     def test_joomla_set_target(self):
         """test various items used in Joomla files"""
-        propsource = """COM_EXAMPLE_FOO="This is a test"\n""".encode("utf-8")
-        proptarget = """COM_EXAMPLE_FOO="This is another test"\n""".encode("utf-8")
+        propsource = b"""COM_EXAMPLE_FOO="This is a test"\n"""
+        proptarget = b"""COM_EXAMPLE_FOO="This is another test"\n"""
         propfile = self.propparse(propsource, personality="joomla")
         assert len(propfile.units) == 1
         propunit = propfile.units[0]
@@ -592,7 +592,7 @@ key=value
 
     def test_joomla(self):
         """test various items used in Joomla files"""
-        propsource = """; comment\nVALUE="I am a "_QQ_"value"_QQ_""\n""".encode("utf-8")
+        propsource = b"""; comment\nVALUE="I am a "_QQ_"value"_QQ_""\n"""
         propfile = self.propparse(propsource, personality="joomla")
         assert len(propfile.units) == 1
         propunit = propfile.units[0]
@@ -601,7 +601,7 @@ key=value
         assert bytes(propfile) == propsource
 
     def test_serialize_missing_delimiter(self):
-        propsource = "key\n".encode("utf-8")
+        propsource = b"key\n"
         propfile = self.propparse(propsource, personality="java-utf8")
         propunit = propfile.units[0]
         assert propunit.name == "key"
@@ -610,7 +610,7 @@ key=value
         assert bytes(propfile) == propsource
 
     def test_serialize_missing_value(self):
-        propsource = "key=\n".encode("utf-8")
+        propsource = b"key=\n"
         propfile = self.propparse(propsource, personality="java-utf8")
         propunit = propfile.units[0]
         assert propunit.name == "key"
@@ -618,7 +618,7 @@ key=value
         assert bytes(propfile) == propsource
 
     def test_multi_comments(self):
-        propsource = """# This is free software; you can redistribute it and/or modify it
+        propsource = b"""# This is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as
 # published by the Free Software Foundation; either version 2.1 of
 # the License, or (at your option) any later version.
@@ -627,9 +627,7 @@ key=value
 # (generally English).
 
 job.log.begin=Starting job of type [{0}]
-""".encode(
-            "utf-8"
-        )
+"""
         propfile = self.propparse(propsource, personality="java-utf8")
         assert len(propfile.units) == 2
         propunit = propfile.units[0]

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -330,9 +330,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8-bit\n"
 "Zkouška: něco\n"
-""".encode(
-            "utf-8"
-        )
+""".encode()
         pofile = self.poparse(posource)
         assert pofile.parseheader() == {
             "Content-Transfer-Encoding": "8-bit",

--- a/translate/storage/test_statsdb.py
+++ b/translate/storage/test_statsdb.py
@@ -78,7 +78,7 @@ class TestStatsDb:
             shutil.rmtree(path)
 
     def get_test_path(self, method):
-        return os.path.realpath("%s_%s" % (self.__class__.__name__, method.__name__))
+        return os.path.realpath(f"{self.__class__.__name__}_{method.__name__}")
 
     def setup_method(self, method):
         """Allocates a unique self.filename for the method, making sure it doesn't exist"""

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -201,7 +201,9 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert target_dom_node.text == "foobaz"
 
         assert g_placeable.tag == "g"
-        print("g_placeable.text: %s (%s)" % (g_placeable.text, type(g_placeable.text)))
+        print(
+            "g_placeable.text: {} ({})".format(g_placeable.text, type(g_placeable.text))
+        )
         assert g_placeable.text is None
         assert g_placeable.attrib["id"] == "oof"
         assert g_placeable.tail is None

--- a/translate/storage/test_yaml.py
+++ b/translate/storage/test_yaml.py
@@ -36,7 +36,7 @@ class TestYAMLResourceStore(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         store.parse("key: value")
         store.units[0].target = "zkouška"
-        assert bytes(store) == "key: zkouška\n".encode("utf-8")
+        assert bytes(store) == "key: zkouška\n".encode()
 
     def test_parse_unicode_list(self):
         data = """list:

--- a/translate/storage/tiki.py
+++ b/translate/storage/tiki.py
@@ -66,7 +66,7 @@ class TikiUnit(base.TranslationUnit):
 
     def __str__(self):
         """Returns a string formatted to be inserted into a tiki language.php file."""
-        ret = '"%s" => "%s",' % (self.source, self.target)
+        ret = f'"{self.source}" => "{self.target}",'
         if self.location == ["untranslated"]:
             ret = "// " + ret
         return ret + "\n"

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -73,7 +73,7 @@ class tsunit(lisa.LISAunit):
         S_TRANSLATED: (state.UNREVIEWED, state.MAX),
     }
 
-    statemap_r = dict((i[1], i[0]) for i in statemap.items())
+    statemap_r = {i[1]: i[0] for i in statemap.items()}
     _context = None
 
     def createlanguageNode(self, lang, text, purpose):
@@ -494,7 +494,7 @@ class tsfile(lisa.LISAfile):
         ):
             e.text = ""
         # For conformance with Qt output, write XML declaration with double quotes
-        out.write(str('<?xml version="1.0" encoding="utf-8"?>\n').encode("utf-8"))
+        out.write(b'<?xml version="1.0" encoding="utf-8"?>\n')
         # For conformance with Qt output, post-process etree.tostring output,
         # replacing ' with &apos; and " with &quot; in text elements
         treestring = etree.tostring(

--- a/translate/storage/utx.py
+++ b/translate/storage/utx.py
@@ -217,17 +217,17 @@ class UtxFile(base.TranslationStore):
 
     def _write_header(self):
         """Create a UTX header"""
-        header = "#UTX-S %(version)s; %(src)s/%(tgt)s; %(date)s" % {
-            "version": self._header["version"],
-            "src": self._header["source_language"],
-            "tgt": self._header.get("target_language", ""),
-            "date": self._header["date_created"],
-        }
+        header = "#UTX-S {version}; {src}/{tgt}; {date}".format(
+            version=self._header["version"],
+            src=self._header["source_language"],
+            tgt=self._header.get("target_language", ""),
+            date=self._header["date_created"],
+        )
         items = []
         for key, value in self._header.items():
             if key in ["version", "source_language", "target_language", "date_created"]:
                 continue
-            items.append("%s: %s" % (key, value))
+            items.append(f"{key}: {value}")
         if len(items):
             items = "; ".join(items)
             header += "; " + items

--- a/translate/storage/workflow.py
+++ b/translate/storage/workflow.py
@@ -229,7 +229,7 @@ class Workflow:
             raise StateNotInWorkflowError(to_state)
         if (self._current_state, to_state) not in self.edges:
             raise TransitionError(
-                "No edge between edges %s and %s" % (self._current_state, to_state)
+                f"No edge between edges {self._current_state} and {to_state}"
             )
         self._current_state.leave(self._workflow_obj)
         self._current_state = to_state

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -112,7 +112,7 @@ class xliffunit(lisa.LISAunit):
         "final": S_SIGNED_OFF + 1,
     }
 
-    statemap_r = dict((i[1], i[0]) for i in statemap.items())
+    statemap_r = {i[1]: i[0] for i in statemap.items()}
 
     STATE = {
         S_UNTRANSLATED: (state.EMPTY, state.NEEDS_WORK),

--- a/translate/storage/xml_extract/extract.py
+++ b/translate/storage/xml_extract/extract.py
@@ -240,9 +240,9 @@ def _process_children(dom_node, state, process_func):
 
 def compact_tag(nsmap, namespace, tag):
     if namespace in nsmap:
-        return "%s:%s" % (nsmap[namespace], tag)
+        return "{}:{}".format(nsmap[namespace], tag)
     else:
-        return "{%s}%s" % (namespace, tag)
+        return f"{{{namespace}}}{tag}"
 
 
 @contextmanager
@@ -409,7 +409,7 @@ def _walk_translatable_tree(
 
 
 def reverse_map(a_map):
-    return dict((value, key) for key, value in a_map.items())
+    return {value: key for key, value in a_map.items()}
 
 
 def build_idml_store(odf_file, store, parse_state, store_adder=None):

--- a/translate/storage/xml_name.py
+++ b/translate/storage/xml_name.py
@@ -23,7 +23,7 @@ class XmlNamespace:
         self._namespace = namespace
 
     def name(self, tag):
-        return "{%s}%s" % (self._namespace, tag)
+        return f"{{{self._namespace}}}{tag}"
 
 
 class XmlNamer:
@@ -67,7 +67,7 @@ class XmlNamer:
                 # If there is no namespace in namespace_shortcut.
                 tag = namespace_shortcut.lstrip("{}")
                 return tag
-        return "{%s}%s" % (self.nsmap[namespace_shortcut], tag)
+        return "{{{}}}{}".format(self.nsmap[namespace_shortcut], tag)
 
     def namespace(self, namespace_shortcut):
         return XmlNamespace(self.nsmap[namespace_shortcut])

--- a/translate/storage/zip.py
+++ b/translate/storage/zip.py
@@ -44,8 +44,7 @@ class ZIPFile(directory.Directory):
             strfile.filename = filename
             store = factory.getobject(strfile)
             # TODO: don't regenerate all the storage objects
-            for unit in store.unit_iter():
-                yield unit
+            yield from store.unit_iter()
 
     def scanfiles(self):
         """Populate the internal file data."""

--- a/translate/tools/pocount.py
+++ b/translate/tools/pocount.py
@@ -89,7 +89,7 @@ def calcstats_old(filename):
     fuzzy = fuzzymessages(units)
     review = [unit for unit in units if unit.isreview()]
     untranslated = untranslatedmessages(units)
-    wordcounts = dict((id(unit), statsdb.wordsinunit(unit)) for unit in units)
+    wordcounts = {id(unit): statsdb.wordsinunit(unit) for unit in units}
     sourcewords = lambda elementlist: sum(
         wordcounts[id(unit)][0] for unit in elementlist
     )

--- a/translate/tools/poterminology.py
+++ b/translate/tools/poterminology.py
@@ -42,7 +42,7 @@ def create_termunit(
     if len(targets.keys()) > 1:
         txt = "; ".join(
             [
-                "%s {%s}" % (target, ", ".join(files))
+                "{} {{{}}}".format(target, ", ".join(files))
                 for target, files in targets.items()
             ]
         )
@@ -123,7 +123,7 @@ class TerminologyExtractor:
             "@": frozenset(["word", "phrase"]),
         }
 
-        with open(self.stopfile, "r") as stopfile:
+        with open(self.stopfile) as stopfile:
             line = 0
             try:
                 for stopline in stopfile:

--- a/translate/tools/pydiff.py
+++ b/translate/tools/pydiff.py
@@ -210,9 +210,9 @@ class DirDiffer:
                         filediffer = FileDiffer(fromfile, tofile, self.options)
                         filediffer.writediff(outfile)
             elif from_ok:
-                outfile.write("Only in %s: %s\n" % (self.fromdir, difffile))
+                outfile.write(f"Only in {self.fromdir}: {difffile}\n")
             elif to_ok:
-                outfile.write("Only in %s: %s\n" % (self.todir, difffile))
+                outfile.write(f"Only in {self.todir}: {difffile}\n")
 
 
 class FileDiffer:
@@ -230,7 +230,7 @@ class FileDiffer:
         """writes the actual diff to the given file"""
         validfiles = True
         if os.path.exists(self.fromfile):
-            with open(self.fromfile, "U") as fh:
+            with open(self.fromfile) as fh:
                 self.from_lines = fh.readlines()
             fromfiledate = os.stat(self.fromfile).st_mtime
         elif self.fromfile == "-":
@@ -243,7 +243,7 @@ class FileDiffer:
             outfile.write("%s: No such file or directory\n" % self.fromfile)
             validfiles = False
         if os.path.exists(self.tofile):
-            with open(self.tofile, "U") as fh:
+            with open(self.tofile) as fh:
                 self.to_lines = fh.readlines()
             tofiledate = os.stat(self.tofile).st_mtime
         elif self.tofile == "-":
@@ -267,8 +267,8 @@ class FileDiffer:
         matcher = difflib.SequenceMatcher(None, compare_from_lines, compare_to_lines)
         groups = matcher.get_grouped_opcodes(self.options.unified_lines)
         started = False
-        fromstring = "--- %s\t%s%s" % (self.fromfile, fromfiledate, lineterm)
-        tostring = "+++ %s\t%s%s" % (self.tofile, tofiledate, lineterm)
+        fromstring = f"--- {self.fromfile}\t{fromfiledate}{lineterm}"
+        tostring = f"+++ {self.tofile}\t{tofiledate}{lineterm}"
 
         for group in groups:
             hunk = "".join([line for line in self.unified_diff(group)])
@@ -317,9 +317,7 @@ class FileDiffer:
                 started = True
             outfile.write(hunk)
         if not started and self.options.report_identical_files:
-            outfile.write(
-                "Files %s and %s are identical\n" % (self.fromfile, self.tofile)
-            )
+            outfile.write(f"Files {self.fromfile} and {self.tofile} are identical\n")
 
     def get_from_lines(self, group):
         """returns the lines referred to by group, from the fromfile"""

--- a/translate/tools/test_podebug.py
+++ b/translate/tools/test_podebug.py
@@ -167,7 +167,7 @@ class TestPODebug:
         print(out_unit.target)
         print(bytes(po_out))
         rewrite_func = self.debug.rewrite_unicode
-        assert out_unit.target == "%s%%s%s" % (
+        assert out_unit.target == "{}%s{}".format(
             rewrite_func("This is a "),
             rewrite_func(" test, hooray."),
         )

--- a/translate/tools/test_pogrep.py
+++ b/translate/tools/test_pogrep.py
@@ -88,7 +88,7 @@ class TestPOGrep:
             (pounicode, queryascii, ""),
             (pounicode, queryunicode, pounicode),
         ]:
-            print("Source:\n%s\nSearch: %s\n" % (source, search))
+            print(f"Source:\n{source}\nSearch: {search}\n")
             poresult = self.pogrep(source, search).decode("utf-8")
             assert poresult.index(expected) >= 0
 
@@ -104,7 +104,7 @@ class TestPOGrep:
             (pounicode, queryascii, ""),
             (pounicode, queryunicode, pounicode),
         ]:
-            print("Source:\n%s\nSearch: %s\n" % (source, search))
+            print(f"Source:\n{source}\nSearch: {search}\n")
             poresult = self.pogrep(source, search, ["--regexp"]).decode("utf-8")
             assert poresult.index(expected) >= 0
 

--- a/translate/tools/test_pomerge.py
+++ b/translate/tools/test_pomerge.py
@@ -270,7 +270,7 @@ msgstr "blabla"
         mergepo = """msgid "Simple string\\n"\nmsgstr "Dimpled ring\\n"\n"""
         expectedpo = """msgid "Simple string\\n"\nmsgstr "Dimpled ring\\n"\n"""
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n\nMerged:\n{}".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
         templatepo = """msgid ""\n"Simple string\\n"\nmsgstr ""\n"""
@@ -278,7 +278,7 @@ msgstr "blabla"
         expectedpo = """msgid ""\n"Simple string\\n"\nmsgstr "Dimpled ring\\n"\n"""
         expectedpo2 = """msgid "Simple string\\n"\nmsgstr "Dimpled ring\\n"\n"""
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n\nMerged:\n{}".format(expectedpo, bytes(pofile)))
         assert (
             bytes(pofile).decode("utf-8") == expectedpo or bytes(pofile) == expectedpo2
         )
@@ -292,21 +292,21 @@ msgstr "blabla"
         mergepo = """msgid "Target type:"\nmsgstr "Doelsoort:"\n"""
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n\nMerged:\n{}".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
         templatepo = """msgid "&Select"\nmsgstr "Kies"\n\n"""
         mergepo = """msgid "&Select"\nmsgstr "&Kies"\n"""
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n\nMerged:\n{}".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
         templatepo = """msgid "en-us, en"\nmsgstr "en-us, en"\n"""
         mergepo = """msgid "en-us, en"\nmsgstr "af-za, af, en-za, en-gb, en-us, en"\n"""
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n\nMerged:\n{}".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
     def test_preserve_format_last_entry_in_a_file(self):
@@ -322,7 +322,7 @@ msgstr "blabla"
             """msgid "First"\nmsgstr "Eerste"\n\nmsgid "Second"\nmsgstr "Tweede"\n"""
         )
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n\nMerged:\n{}".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
         templatepo = """msgid "First"\nmsgstr ""\n\nmsgid "Second"\nmsgstr ""\n\n"""
@@ -333,7 +333,7 @@ msgstr "blabla"
             """msgid "First"\nmsgstr "Eerste"\n\nmsgid "Second"\nmsgstr "Tweede"\n"""
         )
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n\nMerged:\n{}".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
     @mark.xfail(reason="Not Implemented")
@@ -347,7 +347,7 @@ msgstr "blabla"
 msgstr "Eerste\tTweede"
 """
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n\nMerged:\n{}".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
     def test_preserve_comments_layout(self):
@@ -359,7 +359,7 @@ msgstr "Eerste\tTweede"
         mergepo = """# (pofilter) unchanged: please translate\n#: filename\nmsgid "Desktop Background.bmp"\nmsgstr "Desktop Background.bmp"\n"""
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n\nMerged:\n{}".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
     def test_merge_dos2unix(self):
@@ -440,12 +440,12 @@ msgstr "Eerste\tTweede"
         mergepo = """msgid "_: KDE comment\\n"\n"File"\nmsgstr "_: KDE comment\\n"\n"Ifayile"\n\n"""
         expectedpo = """msgid ""\n"_: KDE comment\\n"\n"File"\nmsgstr "Ifayile"\n"""
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n\nMerged:\n{}".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
         # Translated kde comment.
         mergepo = """msgid "_: KDE comment\\n"\n"File"\nmsgstr "_: KDE kommentaar\\n"\n"Ifayile"\n\n"""
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n\nMerged:\n{}".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
         # multiline KDE comment
@@ -453,7 +453,7 @@ msgstr "Eerste\tTweede"
         mergepo = """msgid "_: KDE "\n"comment\\n"\n"File"\nmsgstr "_: KDE "\n"comment\\n"\n"Ifayile"\n\n"""
         expectedpo = """msgid ""\n"_: KDE comment\\n"\n"File"\nmsgstr "Ifayile"\n"""
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n\nMerged:\n%s" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n\nMerged:\n{}".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
     def test_merging_untranslated_with_kde_disambiguation(self):
@@ -470,24 +470,24 @@ msgid "_: sendMessageCheckWindowTitle sendMessageCheckWindowTitle.accesskey\n"
 "Send Message"
 msgstr ""
 """
-        mergepo = r"""#: sendMsgTitle%ssendMsgTitle.accesskey
+        mergepo = r"""#: sendMsgTitle{}sendMsgTitle.accesskey
 msgid ""
 "_: sendMsgTitle sendMsgTitle.accesskey\n"
 "Send Message"
 msgstr "Stuur"
 
-#: sendMessageCheckWindowTitle%ssendMessageCheckWindowTitle.accesskey
+#: sendMessageCheckWindowTitle{}sendMessageCheckWindowTitle.accesskey
 msgid ""
 "_: sendMessageCheckWindowTitle sendMessageCheckWindowTitle.accesskey\n"
 "Send Message"
 msgstr "Stuur"
-""" % (
+""".format(
             po.lsep,
             po.lsep,
         )
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n---\nMerged:\n{}\n---".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
     def test_merging_header_entries(self):
@@ -549,7 +549,7 @@ msgid "Simple String"
 msgstr "Dimpled Ring"
 """
         pofile = self.mergestore(templatepo, mergepo)
-        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, bytes(pofile)))
+        print("Expected:\n{}\n---\nMerged:\n{}\n---".format(expectedpo, bytes(pofile)))
         assert bytes(pofile).decode("utf-8") == expectedpo
 
     def test_merging_different_locations(self):
@@ -609,5 +609,5 @@ msgstr "ZERSTÖRE WACHPOSTEN"
         expectedpo = mergepo
         pofile = self.mergestore(templatepo, mergepo)
         output = bytes(pofile).decode("utf-8")
-        print("Expected:\n%s\n---\nMerged:\n%s\n---" % (expectedpo, output))
+        print(f"Expected:\n{expectedpo}\n---\nMerged:\n{output}\n---")
         assert output == expectedpo or output == expectedpo2


### PR DESCRIPTION
[pyupgrade](https://github.com/asottile/pyupgrade) is nice tool to upgrade legacy Python code to use modern Python 3 features. This PR contains two commits - introduction of pyupgrade and applying it to the code base.

Again, this is probably too big PR to review, quick overview of changes:

* Use of f-strings 
* Remove not needed "r" arg from open
* Replace IOError with OSError as that is just an alias in Python 3
* Remove not needed object inheritance
* Utilize yield from instead of for..yield
* Use dict comprehensions
* Remove net needed super args
* Remove default "utf-8" arg from encode