### PR TITLE
Single-file output option for html2po

### DIFF
--- a/docs/commands/html2po.rst
+++ b/docs/commands/html2po.rst
@@ -14,16 +14,18 @@ Usage
 
 ::
 
-  html2po [options] <html> <po>
-  po2html [options] <po> <html>
+  html2po [options] <html-src> <po>
+  po2html [options] -i <po> -t <html-src> -o <html-dest>
 
 Where:
 
-+---------+-----------------------------------------------+
-| <html>  | is an HTML file or a directory of HTML files  |
-+---------+-----------------------------------------------+
-| <po>    | is a PO file or directory of PO files         |
-+---------+-----------------------------------------------+
++-------------+---------------------------------------------------------------+
+| <html-src>  | is an HTML file or a directory of HTML files, source language |
++-------------+---------------------------------------------------------------+
+| <html-dest> | is an HTML file or a directory of HTML files, translated      |
++-------------+---------------------------------------------------------------+
+| <po>        | is a PO file or directory of PO files                         |
++-------------+---------------------------------------------------------------+
 
 Options (html2po):
 
@@ -45,6 +47,11 @@ Options (html2po):
                       what to do with duplicate strings (identical source
                       text): :doc:`merge, msgctxt <option_duplicates>`
                       (default: 'msgctxt')
+--multifile=MULTIFILESTYLE
+                      how to split po/pot files (:doc:`single, toplevel or
+                      onefile <option_multifile>`)
+                      (default: 'single'; if set to 'onefile', a single po/pot
+                      file will be written. 'toplevel' not used.)
 
 
 Options (po2html):
@@ -83,7 +90,14 @@ You can create and update PO files for different languages using the
 
 ::
 
-  po2html -t site -i xh -o site-xh
+  html2po -P --multifile=onefile site file.pot
+
+This will find all HTML files in *site* and write a single pot file with all
+translatable content.
+
+::
+
+  po2html -i xh -t site -o site-xh
 
 All the PO translations in *xh* will be converted to HTML using HTML files in
 *site* as templates and outputting new translated HTML files in *site-xh*.

--- a/docs/commands/option_multifile.rst
+++ b/docs/commands/option_multifile.rst
@@ -4,7 +4,7 @@
 --multifile=MULTIFILESTYLE
 **************************
 
-This options determines how the POT/PO files are spli from the source files.
+This options determines how the POT/PO files are split from the source files.
 In many cases you have source files that generate either too many small files
 or one large files which you would rather see split up into smaller files.
 
@@ -20,12 +20,12 @@ Output individual files.
 toplevel
 ========
 
-Split the source files at the top level.  Ie you see a number of top level
+Split the source files at the top level.  I.e., you see a number of top level
 files.
 
-.. _option_multifile#onefiles:
+.. _option_multifile#onefile:
 
-onefiles
-========
+onefile
+=======
 
 One large file instead of many smaller files.

--- a/translate/convert/html2po.py
+++ b/translate/convert/html2po.py
@@ -74,7 +74,7 @@ class Html2POOptionParser(convert.ConvertOptionParser):
             convertor.convertfile_inner(inputfile, self.outputstore, keepcomments)
         else:
             outputstore = convertor.convertfile(inputfile, getattr(inputfile, "name",
-                                                                "unknown"),
+                                                                   "unknown"),
                                                 duplicatestyle=duplicatestyle,
                                                 keepcomments=keepcomments)
             outputstore.serialize(outputfile)

--- a/translate/convert/html2po.py
+++ b/translate/convert/html2po.py
@@ -28,12 +28,11 @@ from translate.storage import html, po
 
 class html2po:
 
-    def convertfile(self, inputfile, filename, includeuntagged=False,
-                    duplicatestyle="msgctxt", keepcomments=False):
+    def convertfile(self, inputfile, filename, duplicatestyle="msgctxt",
+                    keepcomments=False):
         """converts a html file to .po format"""
         thetargetfile = po.pofile()
-        htmlparser = html.htmlfile(includeuntaggeddata=includeuntagged,
-                                   inputfile=inputfile)
+        htmlparser = html.htmlfile(inputfile=inputfile)
         for htmlunit in htmlparser.units:
             thepo = thetargetfile.addsourceunit(htmlunit.source)
             thepo.addlocations(htmlunit.getlocations())
@@ -43,15 +42,14 @@ class html2po:
         return thetargetfile
 
 
-def converthtml(inputfile, outputfile, templates, includeuntagged=False,
-                pot=False, duplicatestyle="msgctxt", keepcomments=False):
+def converthtml(inputfile, outputfile, templates, pot=False,
+                duplicatestyle="msgctxt", keepcomments=False):
     """reads in stdin using fromfileclass, converts using convertorclass,
     writes to stdout
     """
     convertor = html2po()
     outputstore = convertor.convertfile(inputfile, getattr(inputfile, "name",
                                                            "unknown"),
-                                        includeuntagged,
                                         duplicatestyle=duplicatestyle,
                                         keepcomments=keepcomments)
     outputstore.serialize(outputfile)
@@ -68,10 +66,6 @@ def main(argv=None):
     }
     parser = convert.ConvertOptionParser(formats, usepots=True,
                                          description=__doc__)
-    parser.add_option("-u", "--untagged", dest="includeuntagged",
-                      default=False, action="store_true",
-                      help="include untagged sections")
-    parser.passthrough.append("includeuntagged")
     parser.add_option("--keepcomments", dest="keepcomments", default=False,
                       action="store_true",
                       help="preserve html comments as translation notes in the output")

--- a/translate/convert/html2po.py
+++ b/translate/convert/html2po.py
@@ -24,54 +24,99 @@ for examples and usage instructions.
 """
 
 from translate.storage import html, po
+from translate.convert import convert
 
 
 class html2po:
 
     def convertfile(self, inputfile, filename, duplicatestyle="msgctxt",
                     keepcomments=False):
-        """converts a html file to .po format"""
-        thetargetfile = po.pofile()
+        """Convert an html file to .po format."""
+        outputstore = po.pofile()
+        self.convertfile_inner(inputfile, outputstore, keepcomments)
+        outputstore.removeduplicates(duplicatestyle)
+        return outputstore
+
+    def convertfile_inner(self, inputfile, outputstore, keepcomments):
+        """Extract translation units from an html file and add to a pofile object."""
         htmlparser = html.htmlfile(inputfile=inputfile)
         for htmlunit in htmlparser.units:
-            thepo = thetargetfile.addsourceunit(htmlunit.source)
+            thepo = outputstore.addsourceunit(htmlunit.source)
             thepo.addlocations(htmlunit.getlocations())
             if keepcomments:
                 thepo.addnote(htmlunit.getnotes(), "developer")
-        thetargetfile.removeduplicates(duplicatestyle)
-        return thetargetfile
 
 
-def converthtml(inputfile, outputfile, templates, pot=False,
-                duplicatestyle="msgctxt", keepcomments=False):
-    """reads in stdin using fromfileclass, converts using convertorclass,
-    writes to stdout
-    """
-    convertor = html2po()
-    outputstore = convertor.convertfile(inputfile, getattr(inputfile, "name",
-                                                           "unknown"),
-                                        duplicatestyle=duplicatestyle,
-                                        keepcomments=keepcomments)
-    outputstore.serialize(outputfile)
-    return 1
+class Html2POOptionParser(convert.ConvertOptionParser):
+
+    def __init__(self):
+        formats = {
+            "html": ("po", self.converthtml),
+            "htm": ("po", self.converthtml),
+            "xhtml": ("po", self.converthtml),
+            None: ("po", self.converthtml),
+        }
+        super().__init__(formats, usetemplates=False, usepots=True,
+                         description=__doc__)
+        self.add_option("--keepcomments", dest="keepcomments", default=False,
+                        action="store_true",
+                        help="preserve html comments as translation notes in the output")
+        self.passthrough.append("keepcomments")
+        self.add_duplicates_option()
+        self.add_multifile_option()
+        self.passthrough.append("pot")
+
+    def converthtml(self, inputfile, outputfile, templates, pot=False,
+                    duplicatestyle="msgctxt", multifilestyle="single", keepcomments=False):
+        """Extract translation units from one html file."""
+        convertor = html2po()
+        if hasattr(self, "outputstore"):
+            convertor.convertfile_inner(inputfile, self.outputstore, keepcomments)
+        else:
+            outputstore = convertor.convertfile(inputfile, getattr(inputfile, "name",
+                                                                "unknown"),
+                                                duplicatestyle=duplicatestyle,
+                                                keepcomments=keepcomments)
+            outputstore.serialize(outputfile)
+        return 1
+
+    def recursiveprocess(self, options):
+        """Recurse through directories and process files. (override)"""
+        if options.multifilestyle == "onefile":
+            self.outputstore = po.pofile()
+            super().recursiveprocess(options)
+            if not self.outputstore.isempty():
+                self.outputstore.removeduplicates(options.duplicatestyle)
+                outputfile = super().openoutputfile(options, options.output)
+                self.outputstore.serialize(outputfile)
+                if options.output:
+                    outputfile.close()
+        else:
+            super().recursiveprocess(options)
+
+    def isrecursive(self, fileoption, filepurpose='input'):
+        """Check if fileoption is a recursive file. (override)"""
+        if hasattr(self, "outputstore") and filepurpose == "output":
+            return True
+        return super().isrecursive(fileoption, filepurpose=filepurpose)
+
+    def checkoutputsubdir(self, options, subdir):
+        """Check if subdir under options.output needs to be created,
+        creates if neccessary. Do nothing if in single-output-file mode. (override)
+        """
+        if hasattr(self, "outputstore"):
+            return
+        super().checkoutputsubdir(options, subdir)
+
+    def openoutputfile(self, options, fulloutputpath):
+        """Open the output file, or do nothing if in single-output-file mode. (override)"""
+        if hasattr(self, "outputstore"):
+            return None
+        return super().openoutputfile(options, fulloutputpath)
 
 
 def main(argv=None):
-    from translate.convert import convert
-    formats = {
-        "html": ("po", converthtml),
-        "htm": ("po", converthtml),
-        "xhtml": ("po", converthtml),
-        None: ("po", converthtml),
-    }
-    parser = convert.ConvertOptionParser(formats, usepots=True,
-                                         description=__doc__)
-    parser.add_option("--keepcomments", dest="keepcomments", default=False,
-                      action="store_true",
-                      help="preserve html comments as translation notes in the output")
-    parser.passthrough.append("keepcomments")
-    parser.add_duplicates_option()
-    parser.passthrough.append("pot")
+    parser = Html2POOptionParser()
     parser.run(argv)
 
 

--- a/translate/convert/test_html2po.py
+++ b/translate/convert/test_html2po.py
@@ -523,7 +523,7 @@ class TestHTML2POCommand(test_convert.TestConvertCommand, TestHTML2PO):
         assert os.path.isfile(self.get_testfilename("pots/file2.pot"))
         content = str(self.read_testfile("pots/file1.pot"))
         assert 'coming through' in content
-        assert not 'cannot hear' in content
+        assert 'cannot hear' not in content
 
     def test_multifile_onefile(self):
         """Test the --multifile=onefile option and make sure it produces a file, not a directory."""

--- a/translate/convert/test_html2po.py
+++ b/translate/convert/test_html2po.py
@@ -1,3 +1,4 @@
+import os
 from io import BytesIO
 
 from translate.convert import html2po, po2html, test_convert
@@ -513,9 +514,41 @@ class TestHTML2POCommand(test_convert.TestConvertCommand, TestHTML2PO):
     convertmodule = html2po
     defaultoptions = {"progress": "none"}
 
+    def test_multifile_single(self):
+        """Test the --multifile=single option and make sure it produces one pot file per input file."""
+        self.create_testfile("file1.html", '<div>You are only coming through in waves</div>')
+        self.create_testfile("file2.html", '<div>Your lips move but I cannot hear what you say</div>')
+        self.run_command("./", "pots", pot=True, multifile="single")
+        assert os.path.isfile(self.get_testfilename("pots/file1.pot"))
+        assert os.path.isfile(self.get_testfilename("pots/file2.pot"))
+        content = str(self.read_testfile("pots/file1.pot"))
+        assert 'coming through' in content
+        assert not 'cannot hear' in content
+
+    def test_multifile_onefile(self):
+        """Test the --multifile=onefile option and make sure it produces a file, not a directory."""
+        self.create_testfile("file1.html", '<div>You are only coming through in waves</div>')
+        self.create_testfile("file2.html", '<div>Your lips move but I cannot hear what you say</div>')
+        self.run_command("./", "one.pot", pot=True, multifile="onefile")
+        assert os.path.isfile(self.get_testfilename("one.pot"))
+        content = str(self.read_testfile("one.pot"))
+        assert 'coming through' in content
+        assert 'cannot hear' in content
+
+    def test_multifile_onefile_to_stdout(self, capsys):
+        """Test the --multifile=onefile option without specifying an output file. Default is stdout."""
+        self.create_testfile("file1.html", '<div>You are only coming through in waves</div>')
+        self.create_testfile("file2.html", '<div>Your lips move but I cannot hear what you say</div>')
+        self.run_command("./", pot=True, multifile="onefile")
+        content, err = capsys.readouterr()
+        assert 'coming through' in content
+        assert 'cannot hear' in content
+        assert err == ""
+
     def test_help(self, capsys):
-        """tests getting help"""
+        """Test getting help."""
         options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")
-        options = self.help_check(options, "--keepcomments", last=True)
+        options = self.help_check(options, "--keepcomments")
+        options = self.help_check(options, "--multifile=MULTIFILESTYLE", last=True)

--- a/translate/convert/test_html2po.py
+++ b/translate/convert/test_html2po.py
@@ -5,11 +5,11 @@ from translate.convert import html2po, po2html, test_convert
 
 class TestHTML2PO:
 
-    def html2po(self, markup, includeuntagged=False, duplicatestyle="msgctxt", keepcomments=False):
+    def html2po(self, markup, duplicatestyle="msgctxt", keepcomments=False):
         """Helper to convert html to po without a file."""
         inputfile = BytesIO(markup.encode() if isinstance(markup, str) else markup)
         convertor = html2po.html2po()
-        outputpo = convertor.convertfile(inputfile, "test", includeuntagged, duplicatestyle, keepcomments)
+        outputpo = convertor.convertfile(inputfile, "test", duplicatestyle, keepcomments)
         return outputpo
 
     def po2html(self, posource, htmltemplate):
@@ -518,5 +518,4 @@ class TestHTML2POCommand(test_convert.TestConvertCommand, TestHTML2PO):
         options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")
-        options = self.help_check(options, "--keepcomments")
-        options = self.help_check(options, "-u, --untagged", last=True)
+        options = self.help_check(options, "--keepcomments", last=True)

--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -98,7 +98,8 @@ class ManHelpFormatter(optparse.HelpFormatter):
 
 
 class StdoutWrapper:
-    out = sys.stdout
+    def __init__(self):
+        self.out = sys.stdout
 
     def __getattr__(self, name):
         return getattr(self.out, name)
@@ -505,6 +506,9 @@ class RecursiveOptionParser(optparse.OptionParser):
                                      self.isrecursive(options.template, 'template') and
                                      getattr(options, "allowrecursivetemplate", True))
         progress_bar = ProgressBar(options.progress, inputfiles)
+        # sort the input files to preserve the order between runs as much as possible.
+        # this makes for more merge-friendly content in single-output-file mode.
+        inputfiles.sort()
         for inputpath in inputfiles:
             try:
                 templatepath = self.gettemplatename(options, inputpath)

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -127,8 +127,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
                                 \s*?["']\s*?>
                              ''', re.VERBOSE | re.IGNORECASE)
 
-    def __init__(self, includeuntaggeddata=None, inputfile=None,
-                 callback=None):
+    def __init__(self, inputfile=None, callback=None):
         html.parser.HTMLParser.__init__(self, convert_charrefs=False)
         base.TranslationStore.__init__(self)
 
@@ -138,7 +137,6 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
             self.callback = self._simple_callback
         else:
             self.callback = callback
-        self.includeuntaggeddata = includeuntaggeddata
 
         # initialize state
         self.filesrc = ""


### PR DESCRIPTION
Sometimes it can be more convenient to work with a single pot/po file for an entire web site, or part of a web site, instead of one per html file. This PR adds that option to html2po.

The function is invoked through the "multifile" command-line option, an option which is provided by some of the other converters for similar purposes.

The PR also removes an obsolete and non-functional option to include untagged content from html2po.