### PR TITLE
xliff: set xliff language on all file nodes

### DIFF
--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -249,6 +249,23 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert xmltext.find('source-language="zu"') > 0
         assert xmltext.find('target-language="af"') > 0
 
+    def test_targetlanguage_multi(self):
+        xlfsource = """<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE foo [ <!ELEMENT foo ANY > <!ENTITY xxe SYSTEM "file:///etc/passwd" >]>
+<xliff version="1.1" xmlns="urn:oasis:names:tc:xliff:document:1.1">
+        <file original="doc.txt" source-language="en-US">
+        </file>
+        <file original="doc.txt" source-language="en-US">
+        </file>
+</xliff>"""
+        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile.settargetlanguage("cs")
+        xlifffile.setsourcelanguage("de")
+        xmltext = bytes(xlifffile).decode()
+        print(xmltext)
+        assert xmltext.count('source-language="de"') == 2
+        assert xmltext.count('target-language="cs"') == 2
+
     def test_notes(self):
         xlifffile = xliff.xlifffile()
         unit = xlifffile.addsourceunit("Concept")

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -739,8 +739,8 @@ class xlifffile(lisa.LISAfile):
     def setsourcelanguage(self, language):
         if not language:
             return
-        filenode = next(self.document.getroot().iterchildren(self.namespaced("file")))
-        filenode.set("source-language", language)
+        for filenode in self.document.getroot().iterchildren(self.namespaced("file")):
+            filenode.set("source-language", language)
 
     def getsourcelanguage(self):
         filenode = next(self.document.getroot().iterchildren(self.namespaced("file")))
@@ -751,8 +751,8 @@ class xlifffile(lisa.LISAfile):
     def settargetlanguage(self, language):
         if not language:
             return
-        filenode = next(self.document.getroot().iterchildren(self.namespaced("file")))
-        filenode.set("target-language", language)
+        for filenode in self.document.getroot().iterchildren(self.namespaced("file")):
+            filenode.set("target-language", language)
 
     def gettargetlanguage(self):
         filenode = next(self.document.getroot().iterchildren(self.namespaced("file")))


### PR DESCRIPTION
Setting it only on first one will produce mixed language xliff,
what is usually not desired.

Fixes https://github.com/WeblateOrg/weblate/issues/4945