### PR TITLE
rc: Use code_page #pragma to detect encoding

### DIFF
--- a/translate/storage/test_rc.py
+++ b/translate/storage/test_rc.py
@@ -437,3 +437,15 @@ END
 """
         rc_file = self.source_parse(rc_source)
         assert len(rc_file.units) == 1
+
+    def test_utf_8(self):
+        rc_source = """#pragma code_page(65001)
+
+STRINGTABLE
+BEGIN
+    IDS_COPIED              "✔ Copied"
+END
+"""
+        rc_file = self.source_parse(rc_source)
+        assert len(rc_file.units) == 1
+        assert rc_file.units[0].source == "✔ Copied"


### PR DESCRIPTION
The chardet does not reliably detect utf-8, so check it's result by
looking at the code_page #pragma.

Fixes #4190