### PR TITLE
misc: Remove not necessary conversion from bytes

### DIFF
--- a/translate/convert/po2ts.py
+++ b/translate/convert/po2ts.py
@@ -38,10 +38,6 @@ class po2ts:
             source = inputunit.source
             translation = inputunit.target
             comment = inputunit.getnotes("translator")
-            if isinstance(source, bytes):
-                source = source.decode("utf-8")
-            if isinstance(translation, bytes):
-                translation = translation.decode("utf-8")
             for sourcelocation in inputunit.getlocations():
                 if context is None:
                     if "#" in sourcelocation:

--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -211,10 +211,10 @@ class CheckerConfig:
 
         # Inits with default values
         self.punctuation = self._init_default(
-            data.normalized_unicode(punctuation), self.lang.punctuation
+            data.normalize(punctuation), self.lang.punctuation
         )
         self.endpunctuation = self._init_default(
-            data.normalized_unicode(endpunctuation), self.lang.sentenceend
+            data.normalize(endpunctuation), self.lang.sentenceend
         )
         self.ignoretags = self._init_default(ignoretags, common_ignoretags)
         self.canchangetags = self._init_default(canchangetags, common_canchangetags)
@@ -222,15 +222,12 @@ class CheckerConfig:
         # Other data
         # TODO: allow user configuration of untranslatable words
         self.notranslatewords = dict.fromkeys(
-            [data.normalized_unicode(key) for key in self._init_list(notranslatewords)]
+            [data.normalize(key) for key in self._init_list(notranslatewords)]
         )
         self.musttranslatewords = dict.fromkeys(
-            [
-                data.normalized_unicode(key)
-                for key in self._init_list(musttranslatewords)
-            ]
+            [data.normalize(key) for key in self._init_list(musttranslatewords)]
         )
-        validchars = data.normalized_unicode(validchars)
+        validchars = data.normalize(validchars)
         self.validcharsmap = {}
         self.updatevalidchars(validchars)
 
@@ -283,7 +280,7 @@ class CheckerConfig:
             return True
 
         validcharsmap = {
-            ord(validchar): None for validchar in data.normalized_unicode(validchars)
+            ord(validchar): None for validchar in data.normalize(validchars)
         }
         self.validcharsmap.update(validcharsmap)
 
@@ -586,8 +583,8 @@ class TranslationChecker(UnitChecker):
         """Do some optimisation by caching some data of the unit for the
         benefit of :meth:`~TranslationChecker.run_test`.
         """
-        self.str1 = data.normalized_unicode(unit.source) or ""
-        self.str2 = data.normalized_unicode(unit.target) or ""
+        self.str1 = data.normalize(unit.source) or ""
+        self.str2 = data.normalize(unit.target) or ""
         self.hasplural = unit.hasplural()
         self.locations = unit.getlocations()
 
@@ -2846,8 +2843,8 @@ def runtests(str1, str2, ignorelist=()):
     """Verifies that the tests pass for a pair of strings."""
     from translate.storage import base
 
-    str1 = data.normalized_unicode(str1)
-    str2 = data.normalized_unicode(str2)
+    str1 = data.normalize(str1)
+    str2 = data.normalize(str2)
     unit = base.TranslationUnit(str1)
     unit.target = str2
     checker = StandardChecker(excludefilters=ignorelist)

--- a/translate/filters/test_checks.py
+++ b/translate/filters/test_checks.py
@@ -7,9 +7,9 @@ from translate.storage import po, xliff
 
 def strprep(str1, str2, message=None):
     return (
-        data.normalized_unicode(str1),
-        data.normalized_unicode(str2),
-        data.normalized_unicode(message),
+        data.normalize(str1),
+        data.normalize(str2),
+        data.normalize(message),
     )
 
 

--- a/translate/lang/data.py
+++ b/translate/lang/data.py
@@ -23,6 +23,7 @@ import gettext
 import locale
 import os
 import re
+import unicodedata
 
 
 try:
@@ -776,35 +777,7 @@ def normalize(string, normal_form="NFC"):
     """
     if string is None:
         return None
-    else:
-        import unicodedata
-
-        return unicodedata.normalize(normal_form, string)
-
-
-def forceunicode(string):
-    """Ensures that the string is in unicode.
-
-    :param string: A text string
-    :type string: Unicode, String
-    :return: String converted to Unicode and normalized as needed.
-    :rtype: Unicode
-    """
-    if string is None:
-        return None
-    from translate.storage.placeables import StringElem
-
-    if isinstance(string, bytes):
-        encoding = getattr(string, "encoding", "utf-8")
-        string = string.decode(encoding)
-    elif isinstance(string, StringElem):
-        string = str(string)
-    return string
-
-
-def normalized_unicode(string):
-    """Forces the string to unicode and does normalization."""
-    return normalize(forceunicode(string))
+    return unicodedata.normalize(normal_form, string)
 
 
 def normalize_code(code):

--- a/translate/lang/ngram.py
+++ b/translate/lang/ngram.py
@@ -46,9 +46,6 @@ class _NGram:
             self.ngrams = dict()
 
     def addText(self, text):
-        if isinstance(text, bytes):
-            text = text.decode("utf-8")
-
         ngrams = dict()
 
         for word in white_space_re.split(text):

--- a/translate/misc/multistring.py
+++ b/translate/misc/multistring.py
@@ -53,8 +53,6 @@ class multistring(str):
                 return cmp_compat(self.strings[1:], otherstring.strings[1:])
         elif isinstance(otherstring, str):
             return cmp_compat(str(self), otherstring)
-        elif isinstance(otherstring, bytes):
-            return cmp_compat(self.encode("utf-8"), otherstring)
         elif isinstance(otherstring, list) and otherstring:
             return cmp_compat(self, multistring(otherstring))
         else:

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -286,16 +286,14 @@ class AndroidResourceUnit(base.TranslationUnit):
             if cloned_target.text is not None:
                 tmp_element = etree.Element("t")
                 tmp_element.text = cloned_target.text
-                target = data.forceunicode(
-                    etree.tostring(tmp_element, encoding="utf-8")[3:-4]
-                )
+                target = etree.tostring(tmp_element, encoding="unicode")[3:-4]
             else:
                 target = ""
 
             # Include markup as well
             target += "".join(
                 [
-                    data.forceunicode(etree.tostring(child, encoding="utf-8"))
+                    etree.tostring(child, encoding="unicode")
                     for child in cloned_target.iterchildren()
                 ]
             )
@@ -364,7 +362,7 @@ class AndroidResourceUnit(base.TranslationUnit):
             return self.get_xml_text_value(self.xmlelement)
         return multistring(
             [
-                data.forceunicode(self.get_xml_text_value(entry))
+                self.get_xml_text_value(entry)
                 for entry in self.xmlelement.iterchildren("item")
             ]
         )

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -45,7 +45,6 @@ from ctypes import (
     cdll,
 )
 
-from translate.lang import data
 from translate.misc.multistring import multistring
 from translate.storage import base, pocommon, pypo
 
@@ -534,7 +533,6 @@ class pounit(pocommon.pounit):
         # ignore empty strings and strings without non-space characters
         if not (text and text.strip()):
             return
-        text = data.forceunicode(text)
         oldnotes = self.getnotes(origin)
         newnotes = None
         if oldnotes:
@@ -720,7 +718,6 @@ class pounit(pocommon.pounit):
             return msgidcomment
 
     def setcontext(self, context):
-        context = data.forceunicode(context)
         gpo.po_message_set_msgctxt(self._gpo_message, gpo_encode(context))
 
     @classmethod

--- a/translate/storage/dtd.py
+++ b/translate/storage/dtd.py
@@ -168,8 +168,6 @@ def unquotefromdtd(source):
     extracted, quotefinished = quote.extractwithoutquotes(
         source, quotechar, quotechar, allowreentry=False
     )
-    if isinstance(extracted, bytes):
-        extracted = extracted.decode("utf-8")
     if quotechar == "'":
         extracted = extracted.replace("&apos;", "'")
     extracted = quote.entitydecode(extracted, _DTD_NAME2CODEPOINT)

--- a/translate/storage/flatxml.py
+++ b/translate/storage/flatxml.py
@@ -20,7 +20,6 @@
 
 from lxml import etree
 
-from translate.lang import data
 from translate.misc.xml_helpers import getText, namespaced, reindent
 from translate.storage import base
 
@@ -64,7 +63,6 @@ class FlatXMLUnit(base.TranslationUnit):
     @target.setter
     def target(self, target):
         """Updates the translated string of this unit."""
-        target = data.forceunicode(target)
         if self.target == target:
             return
         self.xmlelement.text = target

--- a/translate/storage/fpo.py
+++ b/translate/storage/fpo.py
@@ -31,7 +31,6 @@ import copy
 import logging
 import re
 
-from translate.lang import data
 from translate.misc.multistring import multistring
 from translate.storage import base, cpo, pocommon
 
@@ -89,7 +88,6 @@ class pounit(pocommon.pounit):
     @source.setter
     def source(self, source):
         self._rich_source = None
-        source = data.forceunicode(source or "")
         source = source or ""
         if isinstance(source, multistring):
             self._source = source
@@ -141,7 +139,6 @@ class pounit(pocommon.pounit):
         # ignore empty strings and strings without non-space characters
         if not (text and text.strip()):
             return
-        text = data.forceunicode(text)
         commentlist = self.othercomments
         autocomments = False
         if origin in ["programmer", "developer", "source code"]:
@@ -206,15 +203,6 @@ class pounit(pocommon.pounit):
         """
 
         def mergelists(list1, list2, split=False):
-            # Decode where necessary (either all bytestrings or all unicode)
-            if str in [type(item) for item in list2] + [type(item) for item in list1]:
-                for position, item in enumerate(list1):
-                    if isinstance(item, bytes):
-                        list1[position] = item.decode("utf-8")
-                for position, item in enumerate(list2):
-                    if isinstance(item, bytes):
-                        list2[position] = item.decode("utf-8")
-
             # Determine the newline style of list2
             lineend = ""
             if list2 and list2[0]:
@@ -388,8 +376,7 @@ class pounit(pocommon.pounit):
         return self._msgctxt + self.msgidcomment
 
     def setcontext(self, context):
-        context = data.forceunicode(context or "")
-        self._msgctxt = context
+        self._msgctxt = context or ""
 
     def getid(self):
         """Returns a unique identifier for this unit."""

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -20,7 +20,6 @@
 
 from lxml import etree
 
-from translate.lang import data
 from translate.misc.xml_helpers import getText, getXMLlang, getXMLspace, namespaced
 from translate.storage import base
 
@@ -114,7 +113,6 @@ class LISAunit(base.TranslationUnit):
 
     def setsource(self, text, sourcelang="en"):
         self._rich_source = None
-        text = data.forceunicode(text)
         self.source_dom = self.createlanguageNode(sourcelang, text, "source")
 
     def set_target_dom(self, dom_node, append=False):
@@ -152,7 +150,6 @@ class LISAunit(base.TranslationUnit):
         # need to propagate it
         if self._rich_target is not None:
             self._rich_target = None
-        target = data.forceunicode(target)
         # Firstly deal with reinitialising to None or setting to identical
         # string
         if self.target == target:

--- a/translate/storage/oo.py
+++ b/translate/storage/oo.py
@@ -32,7 +32,6 @@ comments.
 
 import os
 import re
-import struct
 import warnings
 from io import BytesIO
 
@@ -44,16 +43,9 @@ from translate.misc import quote, wStringIO
 normalfilenamechars = (
     b"/#.0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 )
-normalizetable = b""
-int2byte = struct.Struct(">B").pack
-for i in map(int2byte, range(256)):
-    if i in normalfilenamechars:
-        normalizetable += i
-    else:
-        normalizetable += b"_"
 
 
-class unormalizechar(dict):
+class normalizechar(dict):
     def __init__(self, normalchars):
         self.normalchars = {}
         for char in normalchars:
@@ -63,15 +55,12 @@ class unormalizechar(dict):
         return self.normalchars.get(key, "_")
 
 
-unormalizetable = unormalizechar(normalfilenamechars.decode("ascii"))
+normalizetable = normalizechar(normalfilenamechars.decode("ascii"))
 
 
 def normalizefilename(filename):
     """converts any non-alphanumeric (standard roman) characters to _"""
-    if isinstance(filename, bytes):
-        return filename.translate(normalizetable)
-    else:
-        return filename.translate(unormalizetable)
+    return filename.translate(normalizetable)
 
 
 def makekey(ookey, long_keys):

--- a/translate/storage/poxliff.py
+++ b/translate/storage/poxliff.py
@@ -26,7 +26,6 @@ import re
 
 from lxml import etree
 
-from translate.lang import data
 from translate.misc.multistring import multistring
 from translate.misc.xml_helpers import setXMLspace
 from translate.storage import base, lisa, poheader, xliff
@@ -124,7 +123,7 @@ class PoXliffUnit(xliff.xliffunit):
 
     def gettarget(self, lang=None):
         if self.hasplural():
-            strings = [data.forceunicode(unit.target) for unit in self.units]
+            strings = [unit.target for unit in self.units]
             if strings:
                 return multistring(strings)
             else:
@@ -160,8 +159,6 @@ class PoXliffUnit(xliff.xliffunit):
 
     def addnote(self, text, origin=None, position="append"):
         """Add a note specifically in a "note" tag"""
-        if isinstance(text, bytes):
-            text = text.decode("utf-8")
         note = etree.SubElement(self.xmlelement, self.namespaced("note"))
         note.text = text
         if origin:

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -860,9 +860,7 @@ class propunit(base.TranslationUnit):
     @source.setter
     def source(self, source):
         self._rich_source = None
-        self.value = self.personality.encode(
-            data.forceunicode(source) or "", self.encoding
-        )
+        self.value = self.personality.encode(source or "", self.encoding)
 
     @property
     def target(self):
@@ -871,7 +869,6 @@ class propunit(base.TranslationUnit):
     @target.setter
     def target(self, target):
         self._rich_target = None
-        target = data.forceunicode(target)
         self.translation = self.personality.encode(target or "", self.encoding)
         self.explicitely_missing = not bool(target)
 
@@ -932,7 +929,6 @@ class propunit(base.TranslationUnit):
 
     def addnote(self, text, origin=None, position="append"):
         if origin in ["programmer", "developer", "source code", None]:
-            text = data.forceunicode(text)
             self.comments.append(text)
         else:
             return super().addnote(text, origin=origin, position=position)

--- a/translate/storage/resx.py
+++ b/translate/storage/resx.py
@@ -21,7 +21,6 @@
 
 from lxml import etree
 
-from translate.lang import data
 from translate.misc.xml_helpers import reindent, setXMLspace
 from translate.storage import lisa
 from translate.storage.placeables import general
@@ -57,7 +56,7 @@ class RESXUnit(lisa.LISAunit):
         if targetnode is None:
             etree.SubElement(self.xmlelement, self.namespaced("value"))
             return None
-        return data.forceunicode(targetnode.text) or ""
+        return targetnode.text or ""
 
     @target.setter
     def target(self, target):
@@ -68,12 +67,10 @@ class RESXUnit(lisa.LISAunit):
             return
         targetnode = self._gettargetnode()
         targetnode.clear()
-        targetnode.text = data.forceunicode(target) or ""
+        targetnode.text = target or ""
 
     def addnote(self, text, origin=None, position="append"):
         """Add a note specifically in the appropriate "comment" tag"""
-        if isinstance(text, bytes):
-            text = text.decode("utf-8")
         current_notes = self.getnotes(origin)
         self.removenotes(origin)
         note = etree.SubElement(self.xmlelement, self.namespaced("comment"))

--- a/translate/storage/statistics.py
+++ b/translate/storage/statistics.py
@@ -137,13 +137,8 @@ class Statistics:
             classes.append("blank")
         if unit.istranslated():
             classes.append("translated")
-        # TODO: we don't handle checking plurals at all yet, as this is tricky...
-        source = unit.source
-        target = unit.target
-        if isinstance(source, bytes) and isinstance(target, str):
-            source = source.decode(getattr(unit, "encoding", "utf-8"))
         # TODO: decoding should not be done here
-        #        checkresult = self.checker.run_filters(unit, source, target)
+        #        checkresult = self.checker.run_filters(unit, unit.source, unit.target)
         checkresult = {}
         for checkname, checkmessage in checkresult.items():
             classes.append("check-" + checkname)

--- a/translate/storage/statsdb.py
+++ b/translate/storage/statsdb.py
@@ -25,7 +25,6 @@ import logging
 import os.path
 import re
 import stat
-import sys
 from collections import UserDict
 from sqlite3 import dbapi2
 from threading import current_thread
@@ -355,8 +354,6 @@ class StatsCache:
                     cachedir = os.path.join(userdir, ".translate_toolkit")
                 if not os.path.exists(cachedir):
                     os.mkdir(cachedir)
-                if isinstance(cachedir, bytes):
-                    cachedir = str(cachedir, sys.getfilesystemencoding())
                 cls.defaultfile = os.path.realpath(os.path.join(cachedir, "stats.db"))
             statsfile = cls.defaultfile
         else:
@@ -446,8 +443,6 @@ class StatsCache:
 
         store can be a TranslationFile object or a callback that returns one.
         """
-        if isinstance(filename, bytes):
-            filename = str(filename, sys.getfilesystemencoding())
         realpath = os.path.realpath(filename)
         self.cur.execute(
             """SELECT fileid, st_mtime, st_size FROM files

--- a/translate/storage/tbx.py
+++ b/translate/storage/tbx.py
@@ -35,8 +35,6 @@ class tbxunit(lisa.LISAunit):
 
     def createlanguageNode(self, lang, text, purpose):
         """returns a langset xml Element setup with given parameters"""
-        if isinstance(text, bytes):
-            text = text.decode("utf-8")
         langset = etree.Element(self.languageNode)
         setXMLlang(langset, lang)
         tig = etree.SubElement(langset, "tig")  # or ntig with termGrp inside
@@ -65,8 +63,6 @@ class tbxunit(lisa.LISAunit):
             text = text.strip()
         if not text:
             return
-        if isinstance(text, bytes):
-            text = text.decode("utf-8")
         note = etree.SubElement(self.xmlelement, self.namespaced("note"))
         note.text = text
         if origin:

--- a/translate/storage/test_base.py
+++ b/translate/storage/test_base.py
@@ -370,8 +370,6 @@ class TestTranslationStore:
         unit = store.addsourceunit("Beziér curve")
         unit.target = "Beziér-kurwe"
         answer = store.translate("Beziér curve")
-        if isinstance(answer, bytes):
-            answer = answer.decode("utf-8")
         assert answer == "Beziér-kurwe"
         # Just test that __str__ doesn't raise exception:
         store.serialize(BytesIO())

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -280,7 +280,6 @@ class TestPYPOFile(test_po.TestPOFile):
         halfstr = b"\xbd ...".decode("latin-1")
         thepo.target = halfstr
         assert halfstr in str(thepo)
-        thepo.target = halfstr.encode("UTF-8")
 
     def test_posections(self):
         """checks the content of all the expected sections of a PO message"""

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -343,7 +343,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         unit.addalttrans("targetx", sourcetxt="sourcex")
         # test that the source node is before the target node:
         alt = unit.getalttrans()[0]
-        altformat = etree.tostring(alt.xmlelement).decode("utf-8")
+        altformat = etree.tostring(alt.xmlelement, encoding="unicode")
         print(altformat)
         assert altformat.find("<source") < altformat.find("<target")
 

--- a/translate/storage/tmdb.py
+++ b/translate/storage/tmdb.py
@@ -272,8 +272,6 @@ DROP TRIGGER IF EXISTS sources_delete_trig;
 
     def translate_unit(self, unit_source, source_langs, target_langs):
         """return TM suggestions for unit_source"""
-        if isinstance(unit_source, bytes):
-            unit_source = unit_source.decode("utf-8")
         if isinstance(source_langs, list):
             source_langs = [data.normalize_code(lang) for lang in source_langs]
             source_langs = ",".join(source_langs)

--- a/translate/storage/tmx.py
+++ b/translate/storage/tmx.py
@@ -34,8 +34,6 @@ class tmxunit(lisa.LISAunit):
 
     def createlanguageNode(self, lang, text, purpose):
         """returns a langset xml Element setup with given parameters"""
-        if isinstance(text, bytes):
-            text = text.decode("utf-8")
         langset = etree.Element(self.languageNode)
         setXMLlang(langset, lang)
         seg = etree.SubElement(langset, self.textNode)
@@ -60,8 +58,6 @@ class tmxunit(lisa.LISAunit):
 
         The origin parameter is ignored
         """
-        if isinstance(text, bytes):
-            text = text.decode("utf-8")
         note = etree.SubElement(self.xmlelement, self.namespaced("note"))
         note.text = text.strip()
 

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -107,7 +107,7 @@ class tsunit(lisa.LISAunit):
     @lisa.LISAunit.source.getter
     def source(self):
         # TODO: support <byte>. See bug 528.
-        text = data.forceunicode(self._getsourcenode().text)
+        text = self._getsourcenode().text
         if self.hasplural():
             return multistring([text])
         return text
@@ -117,11 +117,9 @@ class tsunit(lisa.LISAunit):
         targetnode = self._gettargetnode()
         if self.hasplural():
             numerus_nodes = targetnode.findall(self.namespaced("numerusform"))
-            return multistring(
-                [data.forceunicode(node.text) or "" for node in numerus_nodes]
-            )
+            return multistring([node.text or "" for node in numerus_nodes])
         else:
-            return data.forceunicode(targetnode.text) or ""
+            return targetnode.text or ""
 
     @target.setter
     def target(self, target):
@@ -150,17 +148,15 @@ class tsunit(lisa.LISAunit):
             self.xmlelement.set("numerus", "yes")
             for string in strings:
                 numerus = etree.SubElement(targetnode, self.namespaced("numerusform"))
-                numerus.text = data.forceunicode(string) or ""
+                numerus.text = string or ""
         else:
-            targetnode.text = data.forceunicode(target) or ""
+            targetnode.text = target or ""
 
     def hasplural(self):
         return self.xmlelement.get("numerus") == "yes"
 
     def addnote(self, text, origin=None, position="append"):
         """Add a note specifically in the appropriate *comment* tag"""
-        if isinstance(text, bytes):
-            text = text.decode("utf-8")
         current_notes = self.getnotes(origin)
         self.removenotes(origin)
         if origin in ["programmer", "developer", "source code"]:
@@ -283,8 +279,6 @@ class tsunit(lisa.LISAunit):
         return "\n".join(contexts)
 
     def addlocation(self, location):
-        if isinstance(location, bytes):
-            location = location.decode("utf-8")
         newlocation = etree.SubElement(self.xmlelement, self.namespaced("location"))
         try:
             filename, line = location.split(":", 1)

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -255,13 +255,9 @@ class xliffunit(lisa.LISAunit):
 
         # TODO: support adding a source tag ad match quality attribute.  At the
         # source tag is needed to inject fuzzy matches from a TM.
-        if isinstance(txt, bytes):
-            txt = txt.decode("utf-8")
         alttrans = etree.SubElement(self.xmlelement, self.namespaced("alt-trans"))
         setXMLspace(alttrans, "preserve")
         if sourcetxt:
-            if isinstance(sourcetxt, bytes):
-                sourcetxt = sourcetxt.decode("utf-8")
             altsource = etree.SubElement(alttrans, self.namespaced("source"))
             altsource.text = sourcetxt
         alttarget = etree.SubElement(alttrans, self.namespaced("target"))
@@ -318,8 +314,6 @@ class xliffunit(lisa.LISAunit):
             text = text.strip()
         if not text:
             return
-        if isinstance(text, bytes):
-            text = text.decode("utf-8")
         note = etree.SubElement(self.xmlelement, self.namespaced("note"))
         note.text = text
         if origin:
@@ -540,8 +534,6 @@ class xliffunit(lisa.LISAunit):
         if purpose:
             group.set("purpose", purpose)
         for type, text in contexts:
-            if isinstance(text, bytes):
-                text = text.decode("utf-8")
             context = etree.SubElement(group, self.namespaced("context"))
             context.text = text
             context.set("context-type", type)

--- a/translate/storage/xml_extract/extract.py
+++ b/translate/storage/xml_extract/extract.py
@@ -357,7 +357,7 @@ def make_postore_adder(store, id_maker, filename):
 
         # Get the plain text for the unit source. The output is enclosed within
         # XLIFF source tags we don't want, so strip them.
-        unit_source = etree.tostring(xliff_unit.source_dom).decode()
+        unit_source = etree.tostring(xliff_unit.source_dom, encoding="unicode")
         unit_source = unit_source[unit_source.find(">", 1) + 1 :]
         unit_source = unit_source[: unit_source.rfind("<", 1)]
 


### PR DESCRIPTION
This code is there from Python 2, where it was reasonable to expect that
the parameters can be both unicode or str. In Python 3, it is safe to
assume that it is always a str and bytes should be properly handled at
caller.