### PR TITLE
Po2html: option for single PO file input

### DIFF
--- a/docs/commands/html2po.rst
+++ b/docs/commands/html2po.rst
@@ -2,10 +2,10 @@
 .. _html2po:
 .. _po2html:
 
-html2po
-*******
+html2po, po2html
+****************
 
-Convert translatable items in HTML to the PO format.
+Convert translatable items in HTML to the PO format. Insert translated text into HTML templates.
 
 .. _html2po#usage:
 
@@ -19,13 +19,13 @@ Usage
 
 Where:
 
-+-------------+---------------------------------------------------------------+
-| <html-src>  | is an HTML file or a directory of HTML files, source language |
-+-------------+---------------------------------------------------------------+
-| <html-dest> | is an HTML file or a directory of HTML files, translated      |
-+-------------+---------------------------------------------------------------+
-| <po>        | is a PO file or directory of PO files                         |
-+-------------+---------------------------------------------------------------+
++-------------+---------------------------------------------------------------------------------+
+| <html-src>  | is an HTML file or a directory of HTML files, source language                   |
++-------------+---------------------------------------------------------------------------------+
+| <html-dest> | is an HTML file or a directory of HTML files, translated to the target language |
++-------------+---------------------------------------------------------------------------------+
+| <po>        | is a PO file or directory of PO files                                           |
++-------------+---------------------------------------------------------------------------------+
 
 Options (html2po):
 
@@ -86,14 +86,14 @@ This will find all HTML files (.htm, .html, .xhtml) in *site*, convert them to
 POT files and place them in *pot*.
 
 You can create and update PO files for different languages using the
-:doc:`pot2po` command. For example, you can create po files for a translation to
+:doc:`pot2po` command. For example, you can create PO files for a translation to
 Xhosa like this:
 
 ::
 
   pot2po -i pot -t site -o xh
 
-This will merge the pot files in *pot* into the po files in *xh* (if any).
+This will merge the POT files in *pot* into the PO files in *xh* (if any).
 
 And then, after editing the PO files in *xh*, you can generate the translated
 version of the web site like so:
@@ -105,16 +105,24 @@ version of the web site like so:
 All the PO translations in *xh* will be converted to HTML using HTML files in
 *site* as templates and outputting new translated HTML files in *site-xh*.
 
-Should you prefer a single po/pot file for your web site, you can create one
+Should you prefer a single PO/POT file for your web site, you can create one
 like so:
 
 ::
 
   html2po -P --multifile=onefile site file.pot
 
-Be aware that po2html does not have a corresponding flag, so you will have to
-call it once for every html file to be translated.
+When po2html is invoked with a single PO file as input, and a directory of template
+HTML files, it will produce one output file per template file. So to generate translated
+output files from a single PO file, invoke po2html like so:
 
+::
+
+  po2html -i xh.po -t site -o site-xh
+
+In this example, *xh.po* is the translation file for Xhosa, *site* is the directory where
+the HTML files in the source language can be found, and *site-xh* is the directory where
+the translated HTML files will end up.
 
 .. _html2po#notes:
 

--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -10,30 +10,30 @@ Converters
    :hidden:
 
    general_usage
-   moz2po
-   oo2po
-   odf2xliff
-   prop2po
-   php2po
-   sub2po
-   txt2po
-   po2wordfast
-   po2tmx
-   pot2po
    csv2po
    csv2tbx
-   tbx2po
-   html2po
    flatxml2po
+   html2po
    ical2po
    ini2po
    json2po
-   web2py2po
+   moz2po
+   odf2xliff
+   oo2po
+   php2po
+   po2tmx
+   po2wordfast
+   pot2po
+   prop2po
    rc2po
    resx2po
+   sub2po
    symb2po
+   tbx2po
    tiki2po
    ts2po
+   txt2po
+   web2py2po
    xliff2po
    yaml2po
 
@@ -41,49 +41,49 @@ Converters
    :maxdepth: 1
    :hidden:
 
-   option_errorlevel
+   option_accelerator
    option_duplicates
-   option_progress
+   option_errorlevel
    option_filteraction
    option_multifile
    option_personality
-   option_accelerator
+   option_progress
 
 Converters change many different formats to PO and back again. Sometimes only
 one direction is supported, or conversion is done using non-PO formats.  The
 converters follow a :doc:`general pattern of usage <general_usage>`,
 understanding that will make the converters much easier to use and understand.
 
-* :doc:`moz2po <moz2po>` -- Mozilla .properties and .dtd converter.  Works with
-  Firefox and Thunderbird
-* :doc:`oo2po <oo2po>` -- OpenOffice.org SDF converter (Also works as
-  ``oo2xliff``).
-* :doc:`odf2xliff <odf2xliff>` -- Convert OpenDocument (ODF) documents to XLIFF
-  and vice-versa.
-* :doc:`prop2po <prop2po>` -- Java property file (.properties) converter
-* :doc:`php2po <php2po>` -- PHP localisable string arrays converter.
-* :doc:`sub2po <sub2po>` -- Converter for various subtitle files
-* :doc:`txt2po <txt2po>` -- Plain text to PO converter
-* :doc:`po2wordfast <po2wordfast>` -- Wordfast Translation Memory converter
-* :doc:`po2tmx <po2tmx>` -- TMX (Translation Memory Exchange) converter
-* :doc:`pot2po <pot2po>` -- initialise PO Template files for translation
 * :doc:`csv2po <csv2po>` -- Comma Separated Value (CSV) converter. Useful for
   doing translations using a spreadsheet.
 * :doc:`csv2tbx <csv2tbx>` -- Create TBX (TermBase eXchange) files from Comma
   Separated Value (CSV) files
-* :doc:`html2po <html2po>` -- HTML converter
 * :doc:`flatxml2po <flatxml2po>` -- Flat XML converter
+* :doc:`html2po <html2po>` -- HTML converter
 * :doc:`ical2po <ical2po>` -- iCalendar file converter
 * :doc:`ini2po <ini2po>` -- Windows INI file converter
 * :doc:`json2po <json2po>` -- JSON file converter
-* :doc:`web2py2po` -- web2py translation to PO converter
+* :doc:`moz2po <moz2po>` -- Mozilla .properties and .dtd converter.  Works with
+  Firefox and Thunderbird
+* :doc:`odf2xliff <odf2xliff>` -- Convert OpenDocument (ODF) documents to XLIFF
+  and vice-versa.
+* :doc:`oo2po <oo2po>` -- OpenOffice.org SDF converter (Also works as
+  ``oo2xliff``).
+* :doc:`php2po <php2po>` -- PHP localisable string arrays converter.
+* :doc:`po2tmx <po2tmx>` -- TMX (Translation Memory Exchange) converter
+* :doc:`po2wordfast <po2wordfast>` -- Wordfast Translation Memory converter
+* :doc:`pot2po <pot2po>` -- initialise PO Template files for translation
+* :doc:`prop2po <prop2po>` -- Java property file (.properties) converter
 * :doc:`rc2po <rc2po>` -- Windows Resource .rc (C++ Resource Compiler)
   converter
 * :doc:`resx2po <resx2po>` -- .Net Resource (.resx) file converter
+* :doc:`sub2po <sub2po>` -- Converter for various subtitle files
 * :doc:`symb2po <symb2po>` -- Symbian-style translation to PO converter
 * :doc:`tiki2po <tiki2po>` -- `TikiWiki <http://tikiwiki.org/>`_ language.php
   converter
 * :doc:`ts2po <ts2po>` -- Qt Linguist .ts converter
+* :doc:`txt2po <txt2po>` -- Plain text to PO converter
+* :doc:`web2py2po` -- web2py translation to PO converter
 * :doc:`xliff2po <xliff2po>` -- XLIFF (XML Localisation Interchange File
   Format) converter
 * :doc:`yaml2po <yaml2po>` -- YAML (Yet Another Markup Language) converter
@@ -105,17 +105,19 @@ Quality Assurance
    :maxdepth: 1
    :hidden:
 
+   junitmsgfmt
    poconflicts
    pofilter
    pofilter_tests
    pogrep
    pomerge
    porestructure
-   junitmsgfmt
 
 These tools are especially useful for measuring and improving translation
 quality.
 
+* :doc:`junitmsgfmt` -- run msgfmt and provide JUnit type output for use in
+  continuous integration systems like Hudson and Jenkins
 * :doc:`poconflicts` -- extract messages that have conflicting translation
 * :doc:`pofilter` -- filter PO files to find common errors using a :doc:`number
   of tests <pofilter_tests>`
@@ -124,8 +126,6 @@ quality.
   files
 * :doc:`porestructure` -- restructures PO files according to poconflict
   directives
-* :doc:`junitmsgfmt` -- run msgfmt and provide JUnit type output for use in
-  continuous integration systems like Hudson and Jenkins
 
 .. _commands#other_tools:
 
@@ -136,38 +136,38 @@ Other tools
    :maxdepth: 1
    :hidden:
 
-   tmserver
-   poterminology
-   poterminology_stopword_file
+   levenshtein_distance
+   option_rewrite
+   poclean
+   pocompile
    pocount
    podebug
-   option_rewrite
    posegment
-   pocompile
    poswap
-   poclean
+   poterminology
+   poterminology_stopword_file
    pretranslate
-   levenshtein_distance
+   tmserver
 
-* :doc:`tmserver` -- a Translation Memory server, can be queried over HTTP
-  using JSON
-* :doc:`poterminology` -- extracts potential terminology from your translation
-  files
+* :doc:`levenshtein_distance` -- edit distance algorithms for translation
+  memory matching
+* :doc:`poclean` -- produces a clean file from an unclean file
+  (Trados/Wordfast) by stripping out the tw4win indicators
+* :doc:`pocompile` -- create an MO (Machine Object) file from a PO or XLIFF
+  file
 * :doc:`pocount` -- Count words and strings in PO, XLIFF and other types of
   translatable files
 * :doc:`podebug` -- Add debug strings to messages
 * :doc:`posegment` -- Break a PO or XLIFF files into sentence segments, useful
   for creating a segmented translation memory
-* :doc:`pocompile` -- create an MO (Machine Object) file from a PO or XLIFF
-  file
 * :doc:`poswap` -- uses a translation of another language that you would rather
   use than English as source language
-* :doc:`poclean` -- produces a clean file from an unclean file
-  (Trados/Wordfast) by stripping out the tw4win indicators
+* :doc:`poterminology` -- extracts potential terminology from your translation
+  files
 * :doc:`pretranslate` -- fill any missing translations from translation memory
   via fuzzy matching.
-* :doc:`levenshtein_distance` -- edit distance algorithms for translation
-  memory matching
+* :doc:`tmserver` -- a Translation Memory server, can be queried over HTTP
+  using JSON
 
 .. _commands#scripts:
 
@@ -178,11 +178,11 @@ Scripts
    :maxdepth: 1
    :hidden:
 
-   mozilla_l10n_scripts
    moz-l10n-builder
+   mozilla_l10n_scripts
    phase
-   pocompendium
    pocommentclean
+   pocompendium
    pomigrate2
    popuretext
    poreencode

--- a/translate/convert/po2html.py
+++ b/translate/convert/po2html.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-"""Convert Gettext PO localization files to HTML files.
+"""Translate HTML files using Gettext PO localization files.
 
 See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/commands/html2po.html
 for examples and usage instructions.
@@ -27,9 +27,7 @@ from translate.storage import html, po
 
 
 class po2html:
-    """po2html can take a po file and generate html. best to give it a template
-    file otherwise will just concat msgstrs
-    """
+    """Read inputfile (po) and templatefile (html), write to outputfile (html)."""
 
     def lookup(self, string):
         unit = self.inputstore.sourceindex.get(string, None)
@@ -43,9 +41,9 @@ class po2html:
         return unit.source
 
     def mergestore(self, inputstore, templatetext, includefuzzy):
-        """converts a file to .po format"""
+        """Convert a file to html format"""
         self.inputstore = inputstore
-        self.inputstore.makeindex()
+        self.inputstore.require_index()
         self.includefuzzy = includefuzzy
         output_store = html.htmlfile(inputfile=templatetext, callback=self.lookup)
         return output_store.filesrc
@@ -54,9 +52,7 @@ class po2html:
 def converthtml(
     inputfile, outputfile, templatefile, includefuzzy=False, outputthreshold=None
 ):
-    """reads in stdin using fromfileclass, converts using convertorclass,
-    writes to stdout
-    """
+    """Read inputfile (po) and templatefile (html), write to outputfile (html)."""
     inputstore = po.pofile(inputfile)
 
     if not convert.should_output_store(inputstore, outputthreshold):

--- a/translate/convert/test_po2html.py
+++ b/translate/convert/test_po2html.py
@@ -8,7 +8,7 @@ from translate.convert import po2html, test_convert
 
 class TestPO2Html:
     def converthtml(self, posource, htmltemplate, includefuzzy=False):
-        """helper to exercise the command line function"""
+        """helper to exercise the command line function."""
         inputfile = BytesIO(posource.encode())
         print(inputfile.getvalue())
         outputfile = BytesIO()
@@ -18,14 +18,16 @@ class TestPO2Html:
         return outputfile.getvalue().decode("utf-8")
 
     def test_simple(self):
-        """simple po to html test"""
+        """simple po to html test."""
         htmlsource = "<p>A sentence.</p>"
         posource = """#: html:3\nmsgid "A sentence."\nmsgstr "'n Sin."\n"""
         htmlexpected = """<p>'n Sin.</p>"""
         assert htmlexpected in self.converthtml(posource, htmlsource)
 
     def test_linebreaks(self):
-        """Test that a po file can be merged into a template with linebreaks in it."""
+        """Test that a po file can be merged into a template with linebreaks in
+        it.
+        """
         htmlsource = """<html>
 <head>
 </head>
@@ -61,7 +63,7 @@ sin.
         ).replace("\n", " ")
 
     def test_replace_substrings(self):
-        """Should replace substrings correctly, issue #3416"""
+        """Should replace substrings correctly, issue #3416."""
         htmlsource = """<!DOCTYPE html><html><head><title>sub-strings substitution</title></head><body>
 <h2>This is heading 2</h2>
 <p>The heading says: <b>This is heading 2</b></p>
@@ -98,7 +100,7 @@ sin.
         assert htmlexpected in self.converthtml(posource, htmlsource)
 
     def test_entities(self):
-        """Tests that entities are handled correctly"""
+        """Tests that entities are handled correctly."""
         htmlsource = "<p>5 less than 6</p>"
         posource = '#:html:3\nmsgid "5 less than 6"\nmsgstr "5 &lt; 6"\n'
         htmlexpected = "<p>5 &lt; 6</p>"
@@ -110,14 +112,14 @@ sin.
         assert htmlexpected in self.converthtml(posource, htmlsource)
 
     def test_escapes(self):
-        """Tests that PO escapes are correctly handled"""
+        """Tests that PO escapes are correctly handled."""
         htmlsource = '<p>"leverage"</p>'
         posource = '#: html3\nmsgid "\\"leverage\\""\nmsgstr "\\"ek is dom\\""\n'
         htmlexpected = '<p>"ek is dom"</p>'
         assert htmlexpected in self.converthtml(posource, htmlsource)
 
     def test_states_translated(self):
-        """Test that we use target when translated"""
+        """Test that we use target when translated."""
         htmlsource = "<div>aaa</div>"
         posource = 'msgid "aaa"\nmsgstr "bbb"\n'
         htmltarget = "<div>bbb</div>"
@@ -125,14 +127,14 @@ sin.
         assert htmlsource not in self.converthtml(posource, htmlsource)
 
     def test_states_untranslated(self):
-        """Test that we use source when a string is untranslated"""
+        """Test that we use source when a string is untranslated."""
         htmlsource = "<div>aaa</div>"
         posource = 'msgid "aaa"\nmsgstr ""\n'
         htmltarget = htmlsource
         assert htmltarget in self.converthtml(posource, htmlsource)
 
     def test_states_fuzzy(self):
-        """Test that we use source when a string is fuzzy
+        """Test that we use source when a string is fuzzy.
 
         This fixes :issue:`3145`
         """
@@ -151,7 +153,9 @@ sin.
         )
 
     def test_untranslated_attributes(self):
-        """Verify that untranslated attributes are output as source, not dropped."""
+        """Verify that untranslated attributes are output as source, not
+        dropped.
+        """
         htmlsource = '<meta name="keywords" content="life, the universe, everything" />'
         posource = '#: test.html+:-1\nmsgid "life, the universe, everything"\nmsgstr ""'
         expected = '<meta name="keywords" content="life, the universe, everything" />'
@@ -159,13 +163,15 @@ sin.
 
 
 class TestPO2HtmlCommand(test_convert.TestConvertCommand, TestPO2Html):
-    """Tests running actual po2html commands on files"""
+    """Tests running actual po2html commands on files."""
 
     convertmodule = po2html
 
     def test_individual_files(self):
-        """Test the fully non-recursive case where all inputs and outputs (input po, template html, output html) are
-        specified as individual files."""
+        """Test the fully non-recursive case where all inputs and outputs
+        (input po, template html, output html) are specified as individual
+        files.
+        """
         self.given_html_test_file("file1.html")
         self.given_po_test_file("file1.po")
 
@@ -174,8 +180,9 @@ class TestPO2HtmlCommand(test_convert.TestConvertCommand, TestPO2Html):
         self.then_html_file_is_translated("out.html")
 
     def test_fully_recursive(self):
-        """Test the fully recursive case where all inputs and outputs (input, template, output) are
-        specified as directories."""
+        """Test the fully recursive case where all inputs and outputs (input,
+        template, output) are specified as directories.
+        """
         self.given_html_test_file("template/file1.html")
         self.given_html_test_file("template/file2.html")
         self.given_po_test_file("translation/file1.po")
@@ -187,19 +194,25 @@ class TestPO2HtmlCommand(test_convert.TestConvertCommand, TestPO2Html):
         assert not os.path.isfile(self.get_testfilename("translated/file2.html"))
 
     def test_no_input_specified(self):
-        """Test the case where no input file or directory is specified. Expect failure with exit."""
+        """Test the case where no input file or directory is specified.
+        Expect failure with exit.
+        """
         self.given_html_test_file("template/file1.html")
         with pytest.raises(SystemExit):
             self.run_command(output="translated", template="template")
 
     def test_no_template_specified(self, caplog):
-        """Test the case where no template file or directory is specified. Expect failure with log message."""
+        """Test the case where no template file or directory is specified.
+        Expect failure with log message.
+        """
         self.given_po_test_file("translation/file1.po")
         self.run_command("translation", "translated")
         assert "Error processing:" in caplog.text
 
     def test_no_output_specified(self, capsys):
-        """Test the case where there is a single input file and no output file or directory is specified. Defaults to stdout."""
+        """Test the case where there is a single input file and no output file
+        or directory is specified. Defaults to stdout.
+        """
         self.given_html_test_file("file1.html")
         self.given_po_test_file("file1.po")
 
@@ -210,8 +223,12 @@ class TestPO2HtmlCommand(test_convert.TestConvertCommand, TestPO2Html):
         assert err == ""
 
     def test_recursive_templates_with_single_po_file(self):
-        """Test the case where templates and outputs are directories, and the input is specified as an
-        individual po file. This indicates that the po file should be applied to all template files."""
+        """Test the case where templates and outputs are directories, and the
+        input is specified as an individual po file.
+
+        This indicates that the po file should be applied to all
+        template files.
+        """
         self.given_html_test_file("template/file1.html")
         self.given_html_test_file("template/subdir/file2.html")
         self.given_po_test_file("translation/file1.po")
@@ -222,8 +239,12 @@ class TestPO2HtmlCommand(test_convert.TestConvertCommand, TestPO2Html):
         self.then_html_file_is_translated("translated/subdir/file2.html")
 
     def test_recursive_templates_with_single_po_file_and_templates_overwritten(self):
-        """Test the case where templates and outputs are in the same directory, and the input is specified as an
-        individual po file. This indicates that the po file should be applied to all template files."""
+        """Test the case where templates and outputs are in the same directory,
+        and the input is specified as an individual po file.
+
+        This indicates that the po file should be applied to all
+        template files.
+        """
         self.given_html_test_file("html/file1.html")
         self.given_html_test_file("html/subdir/file2.html")
         self.given_po_test_file("translation/file1.po")

--- a/translate/convert/test_po2html.py
+++ b/translate/convert/test_po2html.py
@@ -156,12 +156,13 @@ sin.
 
 
 class TestPO2HtmlCommand(test_convert.TestConvertCommand, TestPO2Html):
-    """Tests running actual po2oo commands on files"""
+    """Tests running actual po2html commands on files"""
 
     convertmodule = po2html
 
+
     def test_help(self, capsys):
-        """tests getting help"""
+        """Test getting help."""
         options = test_convert.TestConvertCommand.test_help(self, capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")

--- a/translate/convert/test_po2html.py
+++ b/translate/convert/test_po2html.py
@@ -209,6 +209,30 @@ class TestPO2HtmlCommand(test_convert.TestConvertCommand, TestPO2Html):
         assert "<div>target1</div>" in content
         assert err == ""
 
+    def test_recursive_templates_with_single_po_file(self):
+        """Test the case where templates and outputs are directories, and the input is specified as an
+        individual po file. This indicates that the po file should be applied to all template files."""
+        self.given_html_test_file("template/file1.html")
+        self.given_html_test_file("template/subdir/file2.html")
+        self.given_po_test_file("translation/file1.po")
+
+        self.run_command("translation/file1.po", "translated", template="template")
+
+        self.then_html_file_is_translated("translated/file1.html")
+        self.then_html_file_is_translated("translated/subdir/file2.html")
+
+    def test_recursive_templates_with_single_po_file_and_templates_overwritten(self):
+        """Test the case where templates and outputs are in the same directory, and the input is specified as an
+        individual po file. This indicates that the po file should be applied to all template files."""
+        self.given_html_test_file("html/file1.html")
+        self.given_html_test_file("html/subdir/file2.html")
+        self.given_po_test_file("translation/file1.po")
+
+        self.run_command("translation/file1.po", "html", template="html")
+
+        self.then_html_file_is_translated("html/file1.html")
+        self.then_html_file_is_translated("html/subdir/file2.html")
+
     def test_help(self, capsys):
         """Test getting help."""
         options = test_convert.TestConvertCommand.test_help(self, capsys)


### PR DESCRIPTION
Sometimes it can be more convenient to work with a single pot/po file for an entire web site, or part of a web site, instead of one per html file. For example, this is a workflow familiar to authors of WordPress plugins. The option to extract translatable content from an entire web site into a single po file was added to html2po in #4179. This pull request adds the inverse operation to po2html.

The function is activated when a single PO file is given as input, and a directory of HTML files given as template. Instead of iterating over the input files, the converter will iterate over the template files and produce one output file per template file.

The pr also includes a little cleanup of the documentation: the entries on the Converters page are sorted alphabetically to make them easier to find.