### PR TITLE
po: Raise ValueError on invalid syntax

### DIFF
--- a/translate/storage/poparser.py
+++ b/translate/storage/poparser.py
@@ -121,16 +121,20 @@ def parse_comment(parse_state, unit):
         if next_char == ".":
             append(unit.automaticcomments, next_line)
         elif next_line[0] == "|" or next_char == "|":
+            parsed = False
             # Read all the lines starting with #|
             prevmsgid_lines = read_prevmsgid_lines(parse_state)
             # Create a parse state object that holds these lines
             ps = parse_state.new_input(iter(prevmsgid_lines))
             # Parse the msgctxt if any
-            parse_prev_msgctxt(ps, unit)
+            parsed |= parse_prev_msgctxt(ps, unit)
             # Parse the msgid if any
-            parse_prev_msgid(ps, unit)
+            parsed |= parse_prev_msgid(ps, unit)
             # Parse the msgid_plural if any
-            parse_prev_msgid_plural(ps, unit)
+            parsed |= parse_prev_msgid_plural(ps, unit)
+            # Fail with error in csae nothing was parsed
+            if not parsed:
+                raise ValueError(f"Syntax error on line {parse_state.lineno}")
             return parse_state.next_line
         elif next_char == ":":
             append(unit.sourcecomments, next_line)

--- a/translate/storage/test_cpo.py
+++ b/translate/storage/test_cpo.py
@@ -207,3 +207,7 @@ class TestCPOFile(test_po.TestPOFile):
     @mark.xfail(reason="removal not working in cPO")
     def test_remove(self):
         super().test_remove()
+
+    @mark.xfail(reason="exception raising not working in cPO")
+    def test_syntax_error(self):
+        super().test_syntax_error()

--- a/translate/storage/test_po.py
+++ b/translate/storage/test_po.py
@@ -1116,3 +1116,13 @@ msgstr ""
         assert unit.source == "Raphaël2"
         unit = pofile.units[1]
         assert unit.source == "Raphaël"
+
+    def test_syntax_error(self):
+        posource = b"""
+#| identified as a comment
+#|raise an infinite loop bug!
+msgid "text"
+msgstr "texte"
+"""
+        with raises(ValueError):
+            self.poparse(posource)


### PR DESCRIPTION
The invalid syntax of comments could lead to infinite recurision in case
none of the parsers matches on them. Raise a ValueError in that case.

Fixes #4232