### PR TITLE
cpo: Fix raising exceptions from ctypes

### DIFF
--- a/translate/convert/test_po2dtd.py
+++ b/translate/convert/test_po2dtd.py
@@ -518,7 +518,7 @@ msgid "&Bookmarks"
 msgstr "Dipu&kutshwayo1"
 
 #: bookmarksItem.title
-msgctxt "bookmarksItem.title
+msgctxt "bookmarksItem.title"
 msgid "Bookmarks"
 msgstr "Dipukutshwayo2"
 

--- a/translate/storage/poparser.py
+++ b/translate/storage/poparser.py
@@ -195,9 +195,7 @@ def parse_quoted(parse_state, start_pos=0):
         right = rfind(line, '"')
         if left != right:
             return parse_state.read_line()[left : right + 1]
-        # There is no terminating quote, so we append an extra quote, but
-        # we also ignore the newline at the end (therefore the -1)
-        return parse_state.read_line()[left:-1] + '"'
+        raise ValueError("end-of-line within string")
     return None
 
 

--- a/translate/storage/test_cpo.py
+++ b/translate/storage/test_cpo.py
@@ -207,7 +207,3 @@ class TestCPOFile(test_po.TestPOFile):
     @mark.xfail(reason="removal not working in cPO")
     def test_remove(self):
         super().test_remove()
-
-    @mark.xfail(reason="exception raising not working in cPO")
-    def test_syntax_error(self):
-        super().test_syntax_error()

--- a/translate/storage/test_po.py
+++ b/translate/storage/test_po.py
@@ -460,14 +460,12 @@ msgstr "POT-Creation-Date: 2006-03-08 17:30+0200\n"
         posource = (
             'msgid "thing\nmsgstr "ding"\nmsgid "Second thing"\nmsgstr "Tweede ding"\n'
         )
-        pofile = self.poparse(posource)
-        assert len(pofile.units) == 2
-        print(repr(pofile.units[0].source))
-        assert pofile.units[0].source == "thing"
+        with raises(ValueError):
+            self.poparse(posource)
 
     def test_malformed_obsolete_units(self):
         """Test that we handle malformed obsolete units reasonably."""
-        posource = """msgid "thing
+        posource = """msgid "thing"
 msgstr "ding"
 
 #~ msgid "Second thing"
@@ -545,7 +543,7 @@ msgstr "een"
 #~ msgstr ""
 #~ "Mit diesem Modul können leider ausschließlich Webseiten vorgelesen werden."
 """
-        pofile = self.poparse(posource)
+        pofile = self.poparse(posource.encode())
         assert len(pofile.units) == 3
         unit = pofile.units[2]
         print(str(unit))
@@ -908,13 +906,8 @@ msgstr "start thing dingis fish"
 "
 "
 """
-        pofile1 = self.poparse(posource)
-        print(repr(pofile1.units[1].target))
-        assert pofile1.units[1].target == "start thing dingis fish"
-        pofile2 = self.poparse(bytes(pofile1))
-        assert pofile2.units[1].target == "start thing dingis fish"
-        print(bytes(pofile2))
-        assert bytes(pofile1) == bytes(pofile2)
+        with raises(ValueError):
+            self.poparse(posource)
 
     def test_encoding_change(self):
         posource = r"""
@@ -1123,6 +1116,13 @@ msgstr ""
 #|raise an infinite loop bug!
 msgid "text"
 msgstr "texte"
+"""
+        with raises(ValueError):
+            self.poparse(posource)
+
+    def test_invalid(self):
+        posource = b"""
+msg
 """
         with raises(ValueError):
             self.poparse(posource)


### PR DESCRIPTION
It is not possible to raise an exception from ctype callback this way.

Store the exception in (thread local) variable and raise it when leaving the call.

Discovered when working on https://github.com/translate/translate/pull/4235, see https://stackoverflow.com/a/42443453/225718 for more details.

This causes tests to fail, I'd like to get feedback first whether such change looks okay.