### PR TITLE
Fix columnorder argument for csv2po/po2csv

### DIFF
--- a/translate/convert/csv2po.py
+++ b/translate/convert/csv2po.py
@@ -248,6 +248,10 @@ def convertcsv(
     return 1
 
 
+def columnorder_callback(option, opt, value, parser):
+    setattr(parser.values, option.dest, value.split(','))
+
+
 def main(argv=None):
     from translate.convert import convert
 
@@ -271,6 +275,9 @@ def main(argv=None):
         "",
         "--columnorder",
         dest="columnorder",
+        action="callback",
+        callback=columnorder_callback,
+        type='str',
         default=None,
         help="specify the order and position of columns (location,source,target)",
     )

--- a/translate/convert/po2csv.py
+++ b/translate/convert/po2csv.py
@@ -86,6 +86,10 @@ def convertcsv(inputfile, outputfile, templatefile, columnorder=None):
     return 1
 
 
+def columnorder_callback(option, opt, value, parser):
+    setattr(parser.values, option.dest, value.split(','))
+
+
 def main(argv=None):
     from translate.convert import convert
 
@@ -95,6 +99,9 @@ def main(argv=None):
         "",
         "--columnorder",
         dest="columnorder",
+        action="callback",
+        callback=columnorder_callback,
+        type='str',
         default=None,
         help="specify the order and position of columns (location,source,target)",
     )


### PR DESCRIPTION
Currently the `--columnorder` argument isnot correctly parsed for `csv2po` and `po2csv`. For example `po2csv --columnorder=source,target,location ...` is parsed as columns `['s', 'o', 'u', 'r', 'c', 'e', ',', 't', 'a', 'r', 'g', 'e', 't', ',', 'l', 'o', 'c', 'a', 't', 'i', 'o', 'n']`. The changes in this PR apply the correct parsing so the reulst is `["source", "target", "location"]`.