### PR TITLE
rc: Fixed parsing of UCS-2 RC files

### DIFF
--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -336,6 +336,9 @@ class rcfile(base.TranslationStore):
         self.encoding = encoding
         if encoding != "auto":
             decoded = rcsrc.decode(encoding)
+        elif b"\000" in rcsrc[:2]:
+            self.encoding = "utf-16-le"
+            decoded = rcsrc.decode(self.encoding)
         else:
             decoded, self.encoding = self.detect_encoding(
                 rcsrc, default_encodings=[self.default_encoding]

--- a/translate/storage/test_rc.py
+++ b/translate/storage/test_rc.py
@@ -32,9 +32,9 @@ second line"""
 class TestRcFile:
     StoreClass = rc.rcfile
 
-    def source_parse(self, source):
+    def source_parse(self, source, encoding="utf-8"):
         """Helper that parses source without requiring files."""
-        dummy_file = BytesIO(source.encode())
+        dummy_file = BytesIO(source.encode(encoding))
         return self.StoreClass(dummy_file)
 
     def source_regenerate(self, source):
@@ -446,5 +446,16 @@ BEGIN
 END
 """
         rc_file = self.source_parse(rc_source)
+        assert len(rc_file.units) == 1
+        assert rc_file.units[0].source == "✔ Copied"
+
+    def test_utf_16(self):
+        rc_source = """
+STRINGTABLE
+BEGIN
+    IDS_COPIED              "✔ Copied"
+END
+"""
+        rc_file = self.source_parse(rc_source, "utf-16-le")
         assert len(rc_file.units) == 1
         assert rc_file.units[0].source == "✔ Copied"


### PR DESCRIPTION
The chardet is really bad in detecting these and having nul char inside
the string is a good indication for this case.