### PR TITLE
tests: Properly encode unicode strings

### DIFF
--- a/translate/storage/test_cpo.py
+++ b/translate/storage/test_cpo.py
@@ -159,7 +159,7 @@ class TestCPOFile(test_po.TestPOFile):
 
     def test_output_str_unicode(self):
         """checks that we can serialize pofile, unit content is in unicode"""
-        posource = """#: nb\nmsgid "Norwegian Bokm\xe5l"\nmsgstr ""\n"""
+        posource = """#: nb\nmsgid "Norwegian Bokmål"\nmsgstr ""\n"""
         pofile = self.StoreClass(BytesIO(posource.encode("UTF-8")), encoding="UTF-8")
         assert len(pofile.units) == 1
         print(bytes(pofile))

--- a/translate/storage/test_pypo.py
+++ b/translate/storage/test_pypo.py
@@ -269,7 +269,7 @@ class TestPYPOFile(test_po.TestPOFile):
 
     def test_output_str_unicode(self):
         """checks that we can str(element) which is in unicode"""
-        posource = """#: nb\nmsgid "Norwegian Bokm\xe5l"\nmsgstr ""\n"""
+        posource = """#: nb\nmsgid "Norwegian Bokmål"\nmsgstr ""\n"""
         pofile = self.StoreClass(BytesIO(posource.encode("UTF-8")), encoding="UTF-8")
         assert len(pofile.units) == 1
         print(bytes(pofile))


### PR DESCRIPTION
Those were iso-8859-1, but Python reads the files as utf-8 now.