### PR TITLE
json: Gracefully migrate lists to hashes

### DIFF
--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -950,7 +950,8 @@ class DictUnit(TranslationUnit):
         parts = self._unitid.parts
         for pos, part in enumerate(parts[:-1]):
             element, key = part
-            default = [] if parts[pos + 1][0] == "index" else self.DefaultDict()
+            use_list = parts[pos + 1][0] == "index"
+            default = [] if use_list else self.DefaultDict()
             if element == "index":
                 while len(target) <= key and not unset:
                     target.append(default.copy())
@@ -959,6 +960,9 @@ class DictUnit(TranslationUnit):
                     target[key] = default
             else:
                 raise ValueError(f"Unsupported element: {element}")
+            if not use_list and isinstance(target[key], list):
+                # Convert list to dict if needed
+                target[key] = dict(enumerate(target[key]))
             target = target[key]
         if override_key:
             element, key = "key", override_key

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -312,6 +312,32 @@ class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):
 """
         assert bytes(store).decode() == expected
 
+    def test_list_to_dict(self):
+        data = """{
+    "userInfoPage": [
+        "Name"
+    ]
+}
+"""
+        store = self.StoreClass()
+        store.parse(data)
+        assert len(store.units) == 1
+        assert bytes(store).decode() == data
+
+        unit = self.StoreClass.UnitClass("Test")
+        unit.setid("userInfoPage.nesting")
+        store.addunit(unit)
+        assert (
+            bytes(store).decode()
+            == """{
+    "userInfoPage": {
+        "0": "Name",
+        "nesting": "Test"
+    }
+}
+"""
+        )
+
 
 class TestWebExtensionUnit(test_monolingual.TestMonolingualUnit):
     UnitClass = jsonl10n.WebExtensionJsonUnit


### PR DESCRIPTION
This avoids problems when changing the file structure and new units
being not compatible with old ones.