### PR TITLE
lisa: Share XML indentation code

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -27,7 +27,6 @@ from lxml import etree
 
 from translate.lang import data
 from translate.misc.multistring import multistring
-from translate.misc.xml_helpers import reindent
 from translate.storage import base, lisa
 
 
@@ -317,7 +316,7 @@ class AndroidResourceUnit(base.TranslationUnit):
                 template = etree.tostring(
                     cloned_doc,
                     encoding="unicode",
-                    doctype=copy.copy(self._store._doctype),
+                    doctype=copy.copy(self._store.XMLdoctype),
                 )
             else:
                 template = "<resources></resources>"
@@ -479,7 +478,8 @@ class AndroidResourceFile(lisa.LISAfile):
     bodyNode = "resources"
     XMLskeleton = """<?xml version="1.0" encoding="utf-8"?>
 <resources></resources>"""
-    _doctype = None
+    XMLindent = {"indent": "    ", "leaves": {"string", "item"}}
+    XMLdoublequotes = True
 
     def initbody(self):
         """Initialises self.body so it never needs to be retrieved from the XML
@@ -487,18 +487,6 @@ class AndroidResourceFile(lisa.LISAfile):
         """
         self.namespace = self.document.getroot().nsmap.get(None, None)
         self.body = self.document.getroot()
-
-    def serialize(self, out=None):
-        """Converts to a string containing the file's XML"""
-        out.write(b'<?xml version="1.0" encoding="utf-8"?>\n')
-        reindent(self.document.getroot(), indent="    ", leaves=("string", "item"))
-        self.document.write(
-            out,
-            pretty_print=False,
-            xml_declaration=False,
-            encoding="utf-8",
-            doctype=self._doctype,
-        )
 
     def parse(self, xml):
         """Populates this object from the given xml string"""
@@ -565,7 +553,7 @@ class AndroidResourceFile(lisa.LISAfile):
             if hasentity:
                 cloned_doc = copy.deepcopy(unit._store.document)
                 cloned_doc.getroot().clear()
-                self._doctype = etree.tostring(
+                self.XMLdoctype = etree.tostring(
                     cloned_doc, xml_declaration=False, encoding="unicode"
                 ).rsplit("\n", 1)[0]
 

--- a/translate/storage/resx.py
+++ b/translate/storage/resx.py
@@ -21,7 +21,7 @@
 
 from lxml import etree
 
-from translate.misc.xml_helpers import reindent, setXMLspace
+from translate.misc.xml_helpers import setXMLspace
 from translate.storage import lisa
 from translate.storage.placeables import general
 
@@ -188,6 +188,9 @@ class RESXFile(lisa.LISAfile):
   </resheader>
 </root>
 """
+    XMLindent = {"indent": "  ", "max_level": 4}
+    # Use same header as Visual Studio
+    XMLdoublequotes = True
     namespace = ""
 
     def __init__(self, *args, **kwargs):
@@ -220,13 +223,6 @@ class RESXFile(lisa.LISAfile):
             unit.xmlelement.text = "\n    "
         return unit
 
-    def serialize(self, out=None):
-        root = self.document.getroot()
-        reindent(root, indent="  ", max_level=4)
-        # Use same header as Visual Studio
-        out.write(b'<?xml version="1.0" encoding="utf-8"?>\n')
-        content = etree.tostring(
-            root, pretty_print=False, xml_declaration=False, encoding="utf-8"
-        )
+    def serialize_hook(self, treestring):
         # Additional space on empty tags same as Visual Studio
-        out.write(content.replace(b"/>", b" />"))
+        return treestring.replace(b"/>", b" />")

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -24,7 +24,7 @@ The official recommendation is to use the extention .xlf for XLIFF files.
 from lxml import etree
 
 from translate.misc.multistring import multistring
-from translate.misc.xml_helpers import getXMLspace, reindent, setXMLlang, setXMLspace
+from translate.misc.xml_helpers import getXMLspace, setXMLlang, setXMLspace
 from translate.storage import base, lisa
 from translate.storage.placeables.lisa import strelem_to_xml, xml_to_strelem
 from translate.storage.workflow import StateEnum as state
@@ -626,6 +626,7 @@ class xlifffile(lisa.LISAfile):
 </body>
 </file>
 </xliff>"""
+    XMLindent = {"indent": "  ", "max_level": 4, "toplevel": False}
     namespace = "urn:oasis:names:tc:xliff:document:1.1"
     unversioned_namespace = "urn:oasis:names:tc:xliff:document:"
 
@@ -873,7 +874,6 @@ class xlifffile(lisa.LISAfile):
 
     def serialize(self, out):
         self.removedefaultfile()
-        reindent(self.document.getroot(), indent="  ", max_level=4)
         super().serialize(out)
 
     @classmethod


### PR DESCRIPTION
Reuse same serialize method in all indenting storages. This reduces code
duplication and makes it easy to introduce indenting to other storages.