### PR TITLE
po2json: Make sure that --fuzzy and --removeuntranslated can be used together.

### DIFF
--- a/translate/convert/po2json.py
+++ b/translate/convert/po2json.py
@@ -39,9 +39,8 @@ class rejson:
         self.inputstore.makeindex()
         for unit in self.templatestore.units:
             inputunit = self.inputstore.locationindex.get(unit.getid())
-            skip_unit = self.remove_untranslated and (
-                inputunit is None or inputunit.isfuzzy() or not inputunit.istranslated()
-            )
+            skip_unit = (self.remove_untranslated and (inputunit is None or not inputunit.istranslated())) or (
+                    not self.includefuzzy and inputunit.isfuzzy())
             if skip_unit:
                 continue
             if inputunit is not None:


### PR DESCRIPTION
Currently when you combine the options --fuzzy and --removeuntranslated together, the fuzzy translations are also removed.
Both of these options work fine on their own, the problem lies in the check itself, that currently ignores the fuzzy parameter and will skip any fuzzy strings when --removeuntranslated is passed on.

The following PR will improve the logic in the "skip" check, to make sure that:
- When --removeuntranslated is passed, the string must be empty or missing to be skipped
or
- When --fuzzy is passed, the string will be included