### PR TITLE
misc: Use super() when applicable

### DIFF
--- a/translate/convert/test_csv2po.py
+++ b/translate/convert/test_csv2po.py
@@ -143,7 +143,7 @@ class TestCSV2POCommand(test_convert.TestConvertCommand, TestCSV2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--charset=CHARSET")

--- a/translate/convert/test_dtd2po.py
+++ b/translate/convert/test_dtd2po.py
@@ -397,7 +397,7 @@ class TestDTD2POCommand(test_convert.TestConvertCommand, TestDTD2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE", last=True)

--- a/translate/convert/test_flatxml2po.py
+++ b/translate/convert/test_flatxml2po.py
@@ -132,7 +132,7 @@ class TestFlatXML2POCommand(test_convert.TestConvertCommand):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-r ROOT, --root=ROOT")
         options = self.help_check(options, "-v VALUE, --value=VALUE")
         options = self.help_check(options, "-k KEY, --key=KEY")

--- a/translate/convert/test_html2po.py
+++ b/translate/convert/test_html2po.py
@@ -689,7 +689,7 @@ class TestHTML2POCommand(test_convert.TestConvertCommand, TestHTML2PO):
 
     def test_help(self, capsys):
         """Test getting help."""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")
         options = self.help_check(options, "--keepcomments")

--- a/translate/convert/test_ical2po.py
+++ b/translate/convert/test_ical2po.py
@@ -456,6 +456,6 @@ class TestIcal2POCommand(test_convert.TestConvertCommand, TestIcal2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")

--- a/translate/convert/test_ini2po.py
+++ b/translate/convert/test_ini2po.py
@@ -150,7 +150,7 @@ class TestIni2POCommand(test_convert.TestConvertCommand, TestIni2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")

--- a/translate/convert/test_json2po.py
+++ b/translate/convert/test_json2po.py
@@ -80,7 +80,7 @@ class TestJson2POCommand(test_convert.TestConvertCommand, TestJson2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")

--- a/translate/convert/test_moz2po.py
+++ b/translate/convert/test_moz2po.py
@@ -13,7 +13,7 @@ class TestMoz2POCommand(test_convert.TestConvertCommand, TestMoz2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(

--- a/translate/convert/test_mozlang2po.py
+++ b/translate/convert/test_mozlang2po.py
@@ -147,7 +147,7 @@ class TestLang2POCommand(test_convert.TestConvertCommand, TestLang2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--encoding=ENCODING")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE", last=True)

--- a/translate/convert/test_oo2po.py
+++ b/translate/convert/test_oo2po.py
@@ -208,7 +208,7 @@ class TestOO2POCommand(test_convert.TestConvertCommand, TestOO2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "--source-language=LANG")
         options = self.help_check(options, "--language=LANG")
         options = self.help_check(options, "-P, --pot")

--- a/translate/convert/test_oo2xliff.py
+++ b/translate/convert/test_oo2xliff.py
@@ -20,7 +20,7 @@ class TestOO2POCommand(test_convert.TestConvertCommand, TestOO2XLIFF):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "--source-language=LANG")
         options = self.help_check(options, "--language=LANG")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")

--- a/translate/convert/test_php2po.py
+++ b/translate/convert/test_php2po.py
@@ -275,7 +275,7 @@ class TestPhp2POCommand(test_convert.TestConvertCommand, TestPhp2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE", last=True)

--- a/translate/convert/test_po2csv.py
+++ b/translate/convert/test_po2csv.py
@@ -139,5 +139,5 @@ class TestPO2CSVCommand(test_convert.TestConvertCommand, TestPO2CSV):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "--columnorder=COLUMNORDER", last=True)

--- a/translate/convert/test_po2dtd.py
+++ b/translate/convert/test_po2dtd.py
@@ -552,17 +552,17 @@ class TestPO2DTDCommand(test_convert.TestConvertCommand, TestPO2DTD):
 
     def setup_method(self, method):
         """call both base classes setup_methods"""
-        test_convert.TestConvertCommand.setup_method(self, method)
+        super().setup_method(method)
         TestPO2DTD.setup_method(self, method)
 
     def teardown_method(self, method):
         """call both base classes teardown_methods"""
-        test_convert.TestConvertCommand.teardown_method(self, method)
+        super().teardown_method(method)
         TestPO2DTD.teardown_method(self, method)
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--fuzzy")
         options = self.help_check(options, "--threshold=PERCENT")

--- a/translate/convert/test_po2flatxml.py
+++ b/translate/convert/test_po2flatxml.py
@@ -135,7 +135,7 @@ class TestPO2FlatXMLCommand(test_convert.TestConvertCommand):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "-r ROOT, --root=ROOT")
         options = self.help_check(options, "-v VALUE, --value=VALUE")

--- a/translate/convert/test_po2html.py
+++ b/translate/convert/test_po2html.py
@@ -256,7 +256,7 @@ class TestPO2HtmlCommand(test_convert.TestConvertCommand, TestPO2Html):
 
     def test_help(self, capsys):
         """Test getting help."""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2ical.py
+++ b/translate/convert/test_po2ical.py
@@ -367,7 +367,7 @@ class TestPO2IcalCommand(test_convert.TestConvertCommand, TestPO2Ical):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2ini.py
+++ b/translate/convert/test_po2ini.py
@@ -283,7 +283,7 @@ class TestPO2IniCommand(test_convert.TestConvertCommand, TestPO2Ini):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2moz.py
+++ b/translate/convert/test_po2moz.py
@@ -13,7 +13,7 @@ class TestPO2MozCommand(test_convert.TestConvertCommand, TestPO2Moz):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "-l LOCALE, --locale=LOCALE")
         options = self.help_check(options, "--removeuntranslated")

--- a/translate/convert/test_po2mozlang.py
+++ b/translate/convert/test_po2mozlang.py
@@ -198,7 +198,7 @@ class TestPO2LangCommand(test_convert.TestConvertCommand, TestPO2Lang):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2oo.py
+++ b/translate/convert/test_po2oo.py
@@ -202,7 +202,7 @@ class TestPO2OOCommand(test_convert.TestConvertCommand, TestPO2OO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "--source-language=LANG")
         options = self.help_check(options, "--language=LANG")
         options = self.help_check(options, "-T, --keeptimestamp")

--- a/translate/convert/test_po2php.py
+++ b/translate/convert/test_po2php.py
@@ -308,7 +308,7 @@ class TestPO2PhpCommand(test_convert.TestConvertCommand, TestPO2Php):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2prop.py
+++ b/translate/convert/test_po2prop.py
@@ -518,7 +518,7 @@ class TestPO2PropCommand(test_convert.TestConvertCommand, TestPO2Prop):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--fuzzy")
         options = self.help_check(options, "--threshold=PERCENT")

--- a/translate/convert/test_po2resx.py
+++ b/translate/convert/test_po2resx.py
@@ -566,5 +566,5 @@ class TestPO2RESXCommand(test_convert.TestConvertCommand, TestPO2RESX):
 
     def test_help(self, capsys):
         """Tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")

--- a/translate/convert/test_po2sub.py
+++ b/translate/convert/test_po2sub.py
@@ -68,7 +68,7 @@ class TestPO2SubCommand(test_convert.TestConvertCommand, TestPO2Sub):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2tiki.py
+++ b/translate/convert/test_po2tiki.py
@@ -64,5 +64,5 @@ class TestPo2TikiCommand(test_convert.TestConvertCommand, TestPo2Tiki):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         self.help_check(options, "", last=True)

--- a/translate/convert/test_po2tmx.py
+++ b/translate/convert/test_po2tmx.py
@@ -198,7 +198,7 @@ class TestPO2TMXCommand(test_convert.TestConvertCommand, TestPO2TMX):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-l LANG, --language=LANG")
         options = self.help_check(options, "--source-language=LANG")
         options = self.help_check(options, "--comments", last=True)

--- a/translate/convert/test_po2ts.py
+++ b/translate/convert/test_po2ts.py
@@ -147,7 +147,7 @@ class TestPO2TSCommand(test_convert.TestConvertCommand, TestPO2TS):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-c CONTEXT, --context=CONTEXT")
         options = self.help_check(
             options, "-t TEMPLATE, --template=TEMPLATE", last=True

--- a/translate/convert/test_po2txt.py
+++ b/translate/convert/test_po2txt.py
@@ -185,7 +185,7 @@ class TestPO2TxtCommand(test_convert.TestConvertCommand, TestPO2Txt):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_po2yaml.py
+++ b/translate/convert/test_po2yaml.py
@@ -205,7 +205,7 @@ class TestPO2YAMLCommand(test_convert.TestConvertCommand, TestPO2YAML):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--threshold=PERCENT")
         options = self.help_check(options, "--fuzzy")

--- a/translate/convert/test_pot2po.py
+++ b/translate/convert/test_pot2po.py
@@ -835,7 +835,7 @@ class TestPOT2POCommand(test_convert.TestConvertCommand, TestPOT2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--tm")

--- a/translate/convert/test_prop2po.py
+++ b/translate/convert/test_prop2po.py
@@ -358,7 +358,7 @@ class TestProp2POCommand(test_convert.TestConvertCommand, TestProp2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--personality=TYPE")

--- a/translate/convert/test_resx2po.py
+++ b/translate/convert/test_resx2po.py
@@ -196,7 +196,7 @@ class TestRESX2POCommand(test_convert.TestConvertCommand, TestRESX2PO):
 
     def test_help(self, capsys):
         """Tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")

--- a/translate/convert/test_tiki2po.py
+++ b/translate/convert/test_tiki2po.py
@@ -73,5 +73,5 @@ class TestTiki2PoCommand(test_convert.TestConvertCommand, TestTiki2Po):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "--include-unused")

--- a/translate/convert/test_ts2po.py
+++ b/translate/convert/test_ts2po.py
@@ -149,6 +149,6 @@ class TestTS2POCommand(test_convert.TestConvertCommand, TestTS2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")
         options = self.help_check(options, "-P, --pot", last=True)

--- a/translate/convert/test_txt2po.py
+++ b/translate/convert/test_txt2po.py
@@ -235,7 +235,7 @@ class TestTxt2POCommand(test_convert.TestConvertCommand, TestTxt2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates")
         options = self.help_check(options, "--encoding")

--- a/translate/convert/test_xliff2po.py
+++ b/translate/convert/test_xliff2po.py
@@ -287,7 +287,7 @@ class TestXLIFF2POCommand(test_convert.TestConvertCommand, TestXLIFF2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "--duplicates=DUPLICATESTYLE")
 

--- a/translate/convert/test_yaml2po.py
+++ b/translate/convert/test_yaml2po.py
@@ -136,6 +136,6 @@ class TestYAML2POCommand(test_convert.TestConvertCommand, TestYAML2PO):
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-P, --pot")
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -135,7 +135,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
     )
 
     def __init__(self, inputfile=None, callback=None):
-        html.parser.HTMLParser.__init__(self, convert_charrefs=False)
+        super().__init__(convert_charrefs=False)
         base.TranslationStore.__init__(self)
 
         # store parameters

--- a/translate/storage/test_mo.py
+++ b/translate/storage/test_mo.py
@@ -467,11 +467,11 @@ class TestMOFile(test_base.TestTranslationStore):
                 os.remove(file)
 
     def setup_method(self, method):
-        test_base.TestTranslationStore.setup_method(self, method)
+        super().setup_method(method)
         self.remove_po_and_mo()
 
     def teardown_method(self, method):
-        test_base.TestTranslationStore.teardown_method(self, method)
+        super().teardown_method(method)
         self.remove_po_and_mo()
 
     def test_language(self):

--- a/translate/tools/test_pretranslate.py
+++ b/translate/tools/test_pretranslate.py
@@ -369,7 +369,7 @@ class TestPretranslateCommand(test_convert.TestConvertCommand, TestPretranslate)
 
     def test_help(self, capsys):
         """tests getting help"""
-        options = test_convert.TestConvertCommand.test_help(self, capsys)
+        options = super().test_help(capsys)
         options = self.help_check(options, "-t TEMPLATE, --template=TEMPLATE")
         options = self.help_check(options, "--tm")
         options = self.help_check(


### PR DESCRIPTION
Call parent class method using super() instead of specifying actual class.