### PR TITLE
properties: Handle single quote escaping in GWT

### DIFF
--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -435,10 +435,9 @@ class DialectGaia(DialectMozilla):
 
 
 @register_dialect
-class DialectGwt(DialectJava):
+class DialectGwt(DialectJavaUtf8):
     plural_regex = re.compile(r"([^\[\]]*)(?:\[(.*)\])?")
     name = "gwt"
-    default_encoding = "utf-8"
     delimiters = ["="]
 
     gwt_plural_categories = [
@@ -482,7 +481,13 @@ class DialectGwt(DialectJava):
 
     @classmethod
     def encode(cls, string, encoding=None):
-        return quote.java_utf8_properties_encode(string or "")
+        result = super().encode(string, encoding)
+        return result.replace("'", "''")
+
+    @classmethod
+    def decode(cls, string):
+        result = super().decode(string)
+        return result.replace("''", "'")
 
 
 @register_dialect

--- a/translate/storage/test_properties.py
+++ b/translate/storage/test_properties.py
@@ -129,6 +129,17 @@ class TestGwtProp(test_monolingual.TestMonolingualStore):
         """helper that converts properties source to propfile object and back"""
         return self.propparse(propsource).__bytes__()
 
+    def test_quotes(self):
+        """checks that quotes are parsed and saved correctly"""
+        propsource = "test_me=I can ''code''!"
+        propfile = self.propparse(propsource)
+        assert len(propfile.units) == 1
+        propunit = propfile.units[0]
+        assert propunit.name == "test_me"
+        assert propunit.source == "I can 'code'!"
+        propunit.value = "I 'can' code!"
+        assert bytes(propfile).decode() == "test_me=I ''can'' code!\n"
+
     def test_simpledefinition(self):
         """checks that a simple properties definition is parsed correctly"""
         propsource = "test_me=I can code!"


### PR DESCRIPTION
The GWT format is supposed to use Java MessageFormat formatting which
doubles single quotes, see http://www.gwtproject.org/doc/latest/tutorial/i18n.html