### PR TITLE
Android: Improve XML handling

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -313,6 +313,8 @@ class AndroidResourceUnit(base.TranslationUnit):
                 cloned_doc = copy.deepcopy(self._store.document)
                 cloned_root = cloned_doc.getroot()
                 cloned_root.clear()
+                # Add content to the element so that we get a real closing tag
+                cloned_root.text = " "
                 template = etree.tostring(
                     cloned_doc,
                     encoding="unicode",
@@ -320,14 +322,8 @@ class AndroidResourceUnit(base.TranslationUnit):
                 )
             else:
                 template = "<resources></resources>"
-            if "</resources>" in template:
-                match = "</resources>"
-                prefix = ""
-            else:
-                match = "<resources/>"
-                prefix = "<resources>"
             newstring = template.replace(
-                match, f"{prefix}<string>{target}</string></resources>"
+                "</resources>", f"<string>{target}</string></resources>"
             )
             try:
                 newstring = etree.fromstring(newstring, parser)[0]

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -746,3 +746,21 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
             0
         ].target = """Other: <xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">%s</xliff:g>"""
         assert bytes(store).decode() == expected
+
+    def test_xliff_namespace(self):
+        original = """<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="id">Test</string>
+</resources>"""
+        expected = """<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="id">Test: <xliff:g>%s</xliff:g></string>
+</resources>"""
+        store = self.StoreClass()
+        store.parse(original.encode())
+        assert bytes(store).decode() == original
+        store.units[
+            0
+        ].target = """Test: <xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">%s</xliff:g>"""
+        # The namespace should be flattened as it is defined in the toplevel element
+        assert bytes(store).decode() == expected


### PR DESCRIPTION
The root element can have a namespace and that broke the string
replacements. Instead of detecting the content, force the XML to include
proper closing tag (instead of self-closing one). This way the text
replacement is safe and does not break on additional attributes defined
on the root element.

Fixes https://github.com/WeblateOrg/weblate/discussions/5657