### PR TITLE
ts2: Consistent using of XML entity for non-breakable space

### DIFF
--- a/translate/storage/test_ts2.py
+++ b/translate/storage/test_ts2.py
@@ -55,7 +55,7 @@ TS_NUMERUS = """<?xml version="1.0" encoding="utf-8"?>
     </message>
     <message>
         <source>&quot;Qt Linguist&apos;s&quot; format ain&apos;t that easy.
-The other line&apos;s translation may have quotes, too (&quot;&apos;&quot;,
+The other line&apos;s&#xa0;translation may have quotes, too (&quot;&apos;&quot;,
 &apos;&quot;&apos;)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -483,6 +483,7 @@ class tsfile(lisa.LISAfile):
                 treestring[pos:nextpos]
                 .replace(b"'", b"&apos;")
                 .replace(b'"', b"&quot;")
+                .replace(b"\xc2\xa0", b"&#xa0;")
             )
             pos = nextpos
             nextpos = treestring.find(b">", pos)


### PR DESCRIPTION
This is how Qt tools do that.

Fixes https://github.com/WeblateOrg/weblate/issues/5917