### PR TITLE
deps: Increase lxml dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ feature set. This cal be easily specified during pip installation::
 
 The Toolkit requires Python 3.6 or newer.
 
-The package lxml is required. You should install version 4.0.0 or later.
+The package lxml is required. You should install version 4.6.3 or later.
 <http://lxml.de/> Depending on your platform, the easiest way to install might
 be through your system's package management. Alternatively you can try ::
 

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -1,2 +1,2 @@
 # lxml - for XML processing (XLIFF, TMX, TBX, ts, Android)
-lxml>=4.0,!=4.3.1
+lxml>=4.6.3


### PR DESCRIPTION
To address  Cross-Site Scripting in lxml (CVE-2021-28957)