### PR TITLE
po: Fail on syntactically invalid PO files

### DIFF
--- a/translate/storage/poparser.py
+++ b/translate/storage/poparser.py
@@ -292,8 +292,7 @@ def parse_msgstr_array(parse_state, unit):
 
 def parse_plural(parse_state, unit):
     return bool(
-        parse_msgid_plural(parse_state, unit)
-        and (parse_msgstr_array(parse_state, unit) or parse_msgstr(parse_state, unit))
+        parse_msgid_plural(parse_state, unit) and parse_msgstr_array(parse_state, unit)
     )
 
 

--- a/translate/storage/test_po.py
+++ b/translate/storage/test_po.py
@@ -1140,3 +1140,12 @@ msgstr "texte"
         if not hasattr(pofile, "_gpo_memory_file"):
             assert unit.prev_source == "someold text"
         assert unit.source == "text"
+
+    def test_missing_plural(self):
+        posource = b"""
+msgid "text"
+msgid_plural "texts"
+msgstr "texte"
+"""
+        with raises(ValueError):
+            self.poparse(posource)


### PR DESCRIPTION
The original gettext parser fails on these and translate-toolkit
should be consistent with it.