### PR TITLE
Add basic Fluent storage support

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -9,6 +9,8 @@ chardet==4.0.0              # chardet
 # Tmserver backend
 cheroot==8.5.2       # tmserver
 # Format support
+fluent.syntax==0.18.1 # Fluent
+# Format support
 iniparse==0.5        # INI
 # Format support
 phply==1.2.5         # PHP

--- a/translate/storage/factory.py
+++ b/translate/storage/factory.py
@@ -55,6 +55,7 @@ _classes_str = {
     "xliff": ("xliff", "xlifffile"),
     "xlf": ("xliff", "xlifffile"),
     "sdlxliff": ("xliff", "xlifffile"),
+    "ftl": ("fluent", "FluentFile"),
 }
 ###  XXX:  if you add anything here, you must also add it to translate.storage.
 
@@ -269,6 +270,7 @@ supported = [
     ("OmegaT Glossary", ["utf8", "tab"], ["application/x-omegat-glossary"]),
     ("UTX Dictionary", ["utx"], ["text/x-utx"]),
     ("Haiku catkeys file", ["catkeys"], ["application/x-catkeys"]),
+    ("Fluent file", ["ftl"], []),
 ]
 
 

--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -138,6 +138,11 @@ class FluentUnit(base.TranslationUnit):
                 this._type = ast.Message
                 this._set_value(source_from_entry(node))
                 self.generic_visit(node)
+
+            def visit_Term(self, node):
+                this._type = ast.Term
+                this._set_value(source_from_entry(node))
+                self.generic_visit(node)
         Parser().visit(entry)
 
     def to_entry(self):

--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -61,6 +61,7 @@ class FluentUnit(base.TranslationUnit):
     def __init__(self, source=None, entry=None):
         super().__init__(source)
         self._id = None
+        self._errors = {}
         # The source and target are equivalent for monolingual units.
         self.target = source
         if source is not None:
@@ -75,7 +76,22 @@ class FluentUnit(base.TranslationUnit):
     def setid(self, value):
         self._id = value
 
+    def adderror(self, errorname, errortext):
+        self._errors[errorname] = errortext
+
+    def geterrors(self):
+        return self._errors
+
     def parse(self, entry):
+        # Handle this unit separately if it is invalid.
+        if isinstance(entry, ast.Junk):
+            for annotation in entry.annotations:
+                self.adderror(annotation.code, annotation.message)
+            self.source = entry.content
+            # The source and target are equivalent for monolingual units.
+            self.target = self.source
+            return
+
         this = self
 
         class Parser(visitor.Visitor):

--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -63,13 +63,17 @@ class FluentUnit(base.TranslationUnit):
         self._id = None
         self._errors = {}
         self._attributes = {}
-        # The source and target are equivalent for monolingual units.
-        self.target = source
         if source is not None:
+            self._set_value(source)
             # Default to source string
             self._id = id_from_source(self.source)
         if entry is not None:
             self.parse(entry)
+
+    def _set_value(self, value):
+        self.source = value
+        # The source and target are equivalent for monolingual units.
+        self.target = self.source
 
     def getid(self):
         return self._id
@@ -91,9 +95,7 @@ class FluentUnit(base.TranslationUnit):
         if isinstance(entry, ast.Junk):
             for annotation in entry.annotations:
                 self.adderror(annotation.code, annotation.message)
-            self.source = entry.content
-            # The source and target are equivalent for monolingual units.
-            self.target = self.source
+            self._set_value(entry.content)
             return
 
         this = self
@@ -115,9 +117,7 @@ class FluentUnit(base.TranslationUnit):
                     self._found_id = True
         Parser().visit(entry)
 
-        self.source = source_from_entry(entry)
-        # The source and target are equivalent for monolingual units.
-        self.target = self.source
+        self._set_value(source_from_entry(entry))
 
     def to_entry(self):
         fp = FluentParser(False)

--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -1,0 +1,135 @@
+#
+# Copyright 2021 Jack Grigg
+#
+# This file is part of the Translate Toolkit.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+r"""Manage the Fluent translation format.
+
+It is a monolingual base class derived format with :class:`FluentFile`
+and :class:`FluentUnit` providing file and unit level access.
+"""
+
+from fluent.syntax import (
+    FluentParser,
+    ast,
+    parse,
+    serialize,
+    visitor,
+)
+from fluent.syntax.stream import FluentParserStream
+from fluent.syntax.serializer import serialize_pattern
+
+from translate.storage import base
+
+
+def id_from_source(source):
+    # If the caller does not provide a unit ID, we need to generate one
+    # ourselves. A valid Fluent identifier has the following EBNF grammar:
+    #     Identifier          ::= [a-zA-Z] [a-zA-Z0-9_-]*
+    #
+    # This means we can't simply use the source string itself as the identifier
+    # (as e.g. PO files do). Instead, we hash the source string with a
+    # collision-resistant hash function.
+    import hashlib
+    return 'gen-' + hashlib.sha256(source.encode()).hexdigest()
+
+
+def source_from_entry(entry):
+    # Serialized patterns come in two forms:
+    # - Single-line patterns, which have a leading space we need to strip (for
+    #   consistency with the expectations of what callers will set).
+    # - Multiline patterns, which have a leading newline we need to preserve.
+    return serialize_pattern(entry.value).lstrip(' ')
+
+
+class FluentUnit(base.TranslationUnit):
+    """A Fluent message."""
+
+    def __init__(self, source=None, entry=None):
+        super().__init__(source)
+        self._id = None
+        # The source and target are equivalent for monolingual units.
+        self.target = source
+        if source is not None:
+            # Default to source string
+            self._id = id_from_source(self.source)
+        if entry is not None:
+            self.parse(entry)
+
+    def getid(self):
+        return self._id
+
+    def setid(self, value):
+        self._id = value
+
+    def parse(self, entry):
+        this = self
+
+        class Parser(visitor.Visitor):
+            _found_id = False
+
+            def visit_Comment(self, node):
+                this.addnote(node.content)
+
+            def visit_Identifier(self, node):
+                if not self._found_id:
+                    # Only save the first identifier we encounter (the entry's
+                    # value will also contain identifiers if it has selectors).
+                    this._id = node.name
+                    self._found_id = True
+        Parser().visit(entry)
+
+        self.source = source_from_entry(entry)
+        # The source and target are equivalent for monolingual units.
+        self.target = self.source
+
+    def to_entry(self):
+        value = FluentParser(False).maybe_get_pattern(
+            FluentParserStream(self.source))
+
+        comment = None
+        if self.getnotes():
+            comment = ast.Comment(self.getnotes())
+
+        return ast.Message(
+            ast.Identifier(self.getid()),
+            value=value,
+            comment=comment)
+
+
+class FluentFile(base.TranslationStore):
+    """A Fluent file."""
+
+    Name = "Fluent file"
+    Mimetypes = []
+    Extensions = ["ftl"]
+    UnitClass = FluentUnit
+
+    def __init__(self, inputfile=None, **kwargs):
+        super().__init__(**kwargs)
+        self.filename = getattr(inputfile, "name", "")
+        if inputfile is not None:
+            fluentsrc = inputfile.read()
+            self.parse(fluentsrc)
+
+    def parse(self, fluentsrc):
+        resource = parse(fluentsrc.decode('utf-8'))
+        for entry in resource.body:
+            self.addunit(FluentUnit(entry=entry))
+
+    def serialize(self, out):
+        body = [unit.to_entry() for unit in self.units]
+        out.write(serialize(ast.Resource(body)).encode(self.encoding))

--- a/translate/storage/test_fluent.py
+++ b/translate/storage/test_fluent.py
@@ -74,6 +74,56 @@ key = value
         fluent_unit = fluent_file.units[0]
         assert fluent_unit.getnotes() == 'A comment\nwith a second line!'
 
+    def test_standalone_comments(self):
+        """Checks that we handle standalone comments."""
+        # Example from https://projectfluent.org/fluent/guide/comments.html
+        fluent_source = '''# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### Localization for Server-side strings of Firefox Screenshots
+
+## Global phrases shared across pages
+
+my-shots = My Shots
+home-link = Home
+screenshots-description =
+    Screenshots made simple. Take, save, and
+    share screenshots without leaving Firefox.
+
+## Creating page
+
+# Note: { $title } is a placeholder for the title of the web page
+# captured in the screenshot. The default, for pages without titles, is
+# creating-page-title-default.
+creating-page-title = Creating { $title }
+creating-page-title-default = page
+creating-page-wait-message = Saving your shot…
+'''
+        fluent_file = self.fluent_parse(fluent_source)
+
+        # ((istranslatable, isheader), comment.startswith)
+        expected_units = [
+            ((False, False), 'This Source Code'),
+            ((False, True), 'Localization for Server-side'),
+            ((False, True), 'Global phrases shared across pages'),
+            ((True, False), ''),
+            ((True, False), ''),
+            ((True, False), ''),
+            ((False, True), 'Creating page'),
+            ((True, False), 'Note: { $title } is a placeholder'),
+            ((True, False), ''),
+            ((True, False), ''),
+        ]
+        assert len(fluent_file.units) == len(expected_units)
+
+        for (expected, actual) in zip(expected_units, fluent_file.units):
+            assert (
+                actual.istranslatable(),
+                actual.isheader(),
+            ) == expected[0]
+            assert actual.getnotes().startswith(expected[1])
+
     def test_source_with_selectors(self):
         """Checks that we handle selectors."""
         fluent_source = '''emails =

--- a/translate/storage/test_fluent.py
+++ b/translate/storage/test_fluent.py
@@ -1,0 +1,86 @@
+#
+# Copyright 2021 Jack Grigg
+#
+# This file is part of the Translate Toolkit.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+from io import BytesIO
+
+from translate.storage import fluent, test_monolingual
+
+
+class TestFluentUnit(test_monolingual.TestMonolingualUnit):
+    UnitClass = fluent.FluentUnit
+
+
+class TestFluentFile(test_monolingual.TestMonolingualStore):
+    StoreClass = fluent.FluentFile
+
+    def fluent_parse(self, fluent_source):
+        """Helper that parses Fluent source without requiring files."""
+        dummyfile = BytesIO(fluent_source.encode())
+        fluent_file = fluent.FluentFile(dummyfile)
+        return fluent_file
+
+    def fluent_regen(self, fluent_source):
+        """Helper that converts Fluent source to a FluentFile object and back."""
+        return bytes(self.fluent_parse(fluent_source)).decode('utf-8')
+
+    def test_simpledefinition(self):
+        """Checks that a simple Fluent definition is parsed correctly."""
+        fluent_source = 'test_me = I can code!'
+        fluent_file = self.fluent_parse(fluent_source)
+        assert len(fluent_file.units) == 1
+        fluent_unit = fluent_file.units[0]
+        assert fluent_unit.getid() == "test_me"
+        assert fluent_unit.source == "I can code!"
+
+    def test_simpledefinition_source(self):
+        """Checks that a simple Fluent definition can be regenerated as source."""
+        fluent_source = 'test_me = I can code!'
+        fluent_regen = self.fluent_regen(fluent_source)
+        assert fluent_source + '\n' == fluent_regen
+
+    def test_comments(self):
+        """Checks that we handle # comments."""
+        fluent_source = '''# A comment
+key = value
+'''
+        fluent_file = self.fluent_parse(fluent_source)
+        assert len(fluent_file.units) == 1
+        fluent_unit = fluent_file.units[0]
+        assert fluent_unit.getnotes() == 'A comment'
+
+    def test_multiline_comments(self):
+        """Checks that we handle # comments across several lines."""
+        fluent_source = '''# A comment
+# with a second line!
+key = value
+'''
+        fluent_file = self.fluent_parse(fluent_source)
+        assert len(fluent_file.units) == 1
+        fluent_unit = fluent_file.units[0]
+        assert fluent_unit.getnotes() == 'A comment\nwith a second line!'
+
+    def test_source_with_selectors(self):
+        """Checks that we handle selectors."""
+        fluent_source = '''emails =
+    { $unreadEmails ->
+        [one] You have one unread email.
+       *[other] You have { $unreadEmails } unread emails.
+    }
+'''
+        fluent_regen = self.fluent_regen(fluent_source)
+        assert fluent_source == fluent_regen

--- a/translate/storage/test_fluent.py
+++ b/translate/storage/test_fluent.py
@@ -84,3 +84,23 @@ key = value
 '''
         fluent_regen = self.fluent_regen(fluent_source)
         assert fluent_source == fluent_regen
+
+    def test_errors(self):
+        """Checks that errors are extracted."""
+        fluent_source = '''valid-unit = I'm great!
+= I'm not.
+'''
+        fluent_file = self.fluent_parse(fluent_source)
+        assert len(fluent_file.units) == 2
+
+        fluent_valid_unit = fluent_file.units[0]
+        assert fluent_valid_unit.getid() == "valid-unit"
+        assert fluent_valid_unit.source == "I'm great!"
+        assert fluent_valid_unit.geterrors() == {}
+
+        fluent_invalid_unit = fluent_file.units[1]
+        assert fluent_invalid_unit.getid() == None
+        assert fluent_invalid_unit.source == "= I'm not.\n"
+        assert fluent_invalid_unit.geterrors() == {
+            "E0002": "Expected an entry start",
+        }

--- a/translate/storage/test_fluent.py
+++ b/translate/storage/test_fluent.py
@@ -104,3 +104,31 @@ key = value
         assert fluent_invalid_unit.geterrors() == {
             "E0002": "Expected an entry start",
         }
+
+    def test_attributes(self):
+        """Checks that we handle attributes."""
+        fluent_source = '''login-input = Predefined value
+    .placeholder = email@example.com
+    .aria-label = Login input value
+    .title = Type your login email
+'''
+        fluent_file = self.fluent_parse(fluent_source)
+        assert len(fluent_file.units) == 1
+        fluent_unit = fluent_file.units[0]
+        assert fluent_unit.getid() == "login-input"
+        assert fluent_unit.source == "Predefined value"
+        assert fluent_unit.getattributes() == {
+            "placeholder": "email@example.com",
+            "aria-label": "Login input value",
+            "title": "Type your login email",
+        }
+
+    def test_attributes_source(self):
+        """Checks that attributes can be regenerated as source."""
+        fluent_source = '''login-input = Predefined value
+    .placeholder = email@example.com
+    .aria-label = Login input value
+    .title = Type your login email
+'''
+        fluent_regen = self.fluent_regen(fluent_source)
+        assert fluent_source == fluent_regen

--- a/translate/storage/test_fluent.py
+++ b/translate/storage/test_fluent.py
@@ -53,6 +53,30 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
         fluent_regen = self.fluent_regen(fluent_source)
         assert fluent_source + '\n' == fluent_regen
 
+    def test_term(self):
+        """Checks that a Fluent definition with a term is parsed correctly."""
+        fluent_source = '''-some-term = Fizz Buzz
+term-usage = I can code { -some-term }!
+'''
+        fluent_file = self.fluent_parse(fluent_source)
+        assert len(fluent_file.units) == 2
+
+        term_unit = fluent_file.units[0]
+        assert term_unit.getid() == "some-term"
+        assert term_unit.source == "Fizz Buzz"
+
+        term_unit = fluent_file.units[1]
+        assert term_unit.getid() == "term-usage"
+        assert term_unit.source == "I can code { -some-term }!"
+
+    def test_term_source(self):
+        """Checks that a Fluent definition with a term can be regenerated as source."""
+        fluent_source = '''-some-term = Fizz Buzz
+term-usage = I can code { -some-term }!
+'''
+        fluent_regen = self.fluent_regen(fluent_source)
+        assert fluent_source == fluent_regen
+
     def test_comments(self):
         """Checks that we handle # comments."""
         fluent_source = '''# A comment


### PR DESCRIPTION
This uses `fluent.syntax` for parsing and serialization.

Implemented:
- Messages and terms.
- Comments (both attached to messages/terms and standalone).
- Errors when parsing Fluent files are recorded.
- Attributes from parsed Fluent files are exposed, and preserved on reserialization.

Part of #3389.