### PR TITLE
docs: Fix a few typos

### DIFF
--- a/translate/convert/convert.py
+++ b/translate/convert/convert.py
@@ -489,7 +489,7 @@ class ArchiveConvertOptionParser(ConvertOptionParser):
     def processfile(
         self, fileprocessor, options, fullinputpath, fulloutputpath, fulltemplatepath
     ):
-        """Run an invidividual conversion."""
+        """Run an individual conversion."""
         if options.timestamp and _output_is_newer(fullinputpath, fulloutputpath):
             return False
 

--- a/translate/convert/test_po2dtd.py
+++ b/translate/convert/test_po2dtd.py
@@ -478,7 +478,7 @@ msgstr "Simple string 3"
         assert bytes(dtdfile).decode("utf-8") == dtdexpected
 
     def test_preserving_spaces(self):
-        """ensure that we preseve spaces between entity and value. Bug 1662"""
+        """ensure that we preserve spaces between entity and value. Bug 1662"""
         posource = """#: simple.label\nmsgid "One"\nmsgstr "Een"\n"""
         dtdtemplate = '<!ENTITY     simple.label         "One">\n'
         dtdexpected = '<!ENTITY     simple.label         "Een">\n'
@@ -487,7 +487,7 @@ msgstr "Simple string 3"
         assert bytes(dtdfile).decode("utf-8") == dtdexpected
 
     def test_preserving_spaces_after_value(self):
-        """Preseve spaces after value. Bug 1662"""
+        """Preserve spaces after value. Bug 1662"""
         # Space between value and >
         posource = """#: simple.label\nmsgid "One"\nmsgstr "Een"\n"""
         dtdtemplate = '<!ENTITY simple.label "One" >\n'

--- a/translate/filters/test_checks.py
+++ b/translate/filters/test_checks.py
@@ -1071,7 +1071,7 @@ def test_printf():
 
 
 def test_pythonbraceformat():
-    """Tests python brace format placeholds"""
+    """Tests python brace format placeholder"""
     stdchecker = checks.StandardChecker()
     # anonymous formats
     assert passes(

--- a/translate/search/test_match.py
+++ b/translate/search/test_match.py
@@ -94,7 +94,7 @@ class TestMatch:
         candidates = self.candidatestrings(matcher.matches("Open File"))
         assert candidates == ["file"]
         candidates = self.candidatestrings(matcher.matches("Contact your ISP"))
-        # we lowercase everything - that is why we get it back differerntly.
+        # we lowercase everything - that is why we get it back differently.
         # we don't change the target text, though
         assert candidates == ["isp"]
 

--- a/translate/storage/test_dtd.py
+++ b/translate/storage/test_dtd.py
@@ -363,7 +363,7 @@ certificate.">
         assert bytes(dtdfile) == b'<!ENTITY test.me "bananas for sale">\n'
 
     def test_missing_quotes(self, recwarn):
-        """test that we fail graacefully when a message without quotes is found (bug #161)"""
+        """test that we fail gracefully when a message without quotes is found (bug #161)"""
         dtdsource = '<!ENTITY bad no quotes">\n<!ENTITY good "correct quotes">\n'
         dtdfile = self.dtdparse(dtdsource)
         assert len(dtdfile.units) == 1


### PR DESCRIPTION
There are small typos in:
- translate/convert/convert.py
- translate/convert/test_po2dtd.py
- translate/filters/test_checks.py
- translate/search/test_match.py
- translate/storage/test_dtd.py

Fixes:
- Should read `preserve` rather than `preseve`.
- Should read `placeholder` rather than `placeholds`.
- Should read `individual` rather than `invidividual`.
- Should read `gracefully` rather than `graacefully`.
- Should read `differently` rather than `differerntly`.

Closes #4382 