### PR TITLE
ci: Use native pre-commit modules

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -54,31 +54,6 @@ jobs:
           pre-commit run --all pydocstyle
           echo "::remove-matcher owner=flake8::"
 
-  pycodestyle:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/cache@v2.1.6
-        with:
-          path: |
-            ~/.cache/pip
-            ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('requirements/*.txt') }}-${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Setup Python
-        uses: actions/setup-python@v2.2.2
-        with:
-          python-version: 3.9
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip wheel
-          pip install -r requirements/dev.txt
-      - name: Run pycodestyle
-        run: |
-          echo "::add-matcher::.github/matchers/flake8.json"
-          pre-commit run --all pycodestyle
-          echo "::remove-matcher owner=flake8::"
-
   flake8:
     runs-on: ubuntu-latest
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.0.1
     hooks:
       - id: check-yaml
       - id: check-merge-conflict
@@ -14,35 +14,28 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
-  - repo: local
+  - repo: https://github.com/pycqa/isort
+    rev: 5.9.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.21.2
+    hooks:
+      - id: pyupgrade
+        args: [--py36-plus]
+  - repo: https://github.com/psf/black
+    rev: 21.7b0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-breakpoint
+          - flake8-mutable
+          - flake8-polyfill
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
-        name: pydocstyle
-        entry: pydocstyle
-        language: system
-        types: [python]
-      - id: pycodestyle
-        name: pycodestyle
-        entry: pycodestyle
-        language: system
-        types: [python]
-      - id: isort
-        name: isort
-        entry: isort
-        language: system
-        types: [python]
-      - id: pyupgrade
-        name: pyupgrade
-        entry: pyupgrade --py36-plus
-        language: system
-        types: [python]
-      - id: black
-        name: black
-        entry: black
-        language: system
-        types: [python]
-      - id: flake8
-        name: flake8
-        entry: flake8
-        language: system
-        types: [python]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,21 +1,9 @@
 -r optional.txt
 
-black==21.7b0
-flake8==3.9.2
-flake8-black==0.2.3
-flake8-breakpoint==1.1.0
-flake8-isort==4.0.0
-flake8-mutable==1.2.0
-flake8-no-u-prefixed-strings==0.2
-flake8-polyfill==1.0.2
-isort==5.9.2
 pre-commit==2.13.0
-pycodestyle==2.7.0
-pydocstyle==6.1.1
 pytest==6.2.4
 pytest-cov==2.12.1
 pytest-xdist==2.3.0
-pyupgrade==2.21.2
 Sphinx==4.1.1
 twine==3.4.2
 virtualenv==20.6.0


### PR DESCRIPTION
This makes it more self-contained and allows to use pre-commit.ci service.