### PR TITLE
stringsdict: Add support for stringsdict storage

### DIFF
--- a/translate/storage/stringsdict.py
+++ b/translate/storage/stringsdict.py
@@ -68,7 +68,7 @@ class StringsDictFile(base.TranslationStore):
             return data.cldr_plural_categories
 
         locale = target_lang.replace("_", "-").split("-")[0]
-        tags = data.plural_tags.get(locale, data.cldr_plural_categories)
+        tags = data.plural_tags.get(locale, data.cldr_plural_categories).copy()
         if "zero" not in tags:
             tags.insert(0, "zero")
         return tags

--- a/translate/storage/stringsdict.py
+++ b/translate/storage/stringsdict.py
@@ -13,19 +13,18 @@ class StringsDictId(base.UnitId):
 
     def __str__(self):
         s = super().__str__()
-        if s[0] == ":":
+        if s.startswith(":"):
             return s[1:]
         return s
 
 
 class StringsDictUnit(base.DictUnit):
-    IdClass = StringsDictId
-
     """A single entry in a .stringsdict file.
     One entry represents either a localized format string, or a variable used
     within another string.
     """
 
+    IdClass = StringsDictId
     format_value_type = ""
 
     def __init__(self, source=None):

--- a/translate/storage/stringsdict.py
+++ b/translate/storage/stringsdict.py
@@ -1,0 +1,154 @@
+import os
+import plistlib
+import re
+from collections import OrderedDict
+
+from translate.lang import data
+from translate.misc.multistring import multistring
+from translate.storage import base
+
+
+class StringsDictUnit(base.TranslationUnit):
+    """A single entry in a .stringsdict file.
+    One entry represents either a localized format string, or a variable used
+    within another string.
+    """
+
+    format_value_type = ""
+
+    def __eq__(self, other):
+        return (
+            super().__eq__(other) and self.format_value_type == other.format_value_type
+        )
+
+
+class StringsDictFile(base.TranslationStore):
+    """Class representing a .stringsdict file.
+
+    One entry in a .stringsdict file consists of a format string, and any
+    number of variables with plural strings.
+
+    Each entry is split up into multiple translation units, containing either
+    the format string or one of the variables.
+    """
+
+    UnitClass = StringsDictUnit
+    Name = "iOS Stringsdict"
+    Mimetypes = ["application/x-plist"]
+    Extensions = ["stringsdict"]
+
+    def __init__(self, inputfile=None, **kwargs):
+        super().__init__(**kwargs)
+        self.parse(inputfile)
+
+    def gettargetlanguage(self):
+        target_lang = super().gettargetlanguage()
+
+        # If targetlanguage isn't set, we try to extract it from the filename path (if any).
+        if target_lang is None and hasattr(self, "filename") and self.filename:
+            parent_dir = os.path.split(os.path.dirname(self.filename))[1]
+            match = re.search(r"^(\w*).lproj", parent_dir)
+            if match is not None:
+                target_lang = match.group(1)
+            else:
+                target_lang = self.sourcelanguage
+
+            # Cache it
+            self.settargetlanguage(target_lang)
+
+        return target_lang
+
+    @property
+    def target_plural_tags(self):
+        """Get all supported plural tags for the target language.
+        Note that 'zero' is always supported.
+        """
+        target_lang = self.gettargetlanguage()
+        if target_lang is None:
+            return data.cldr_plural_categories
+
+        locale = target_lang.replace("_", "-").split("-")[0]
+        tags = data.plural_tags.get(locale, data.cldr_plural_categories)
+        if "zero" not in tags:
+            tags.insert(0, "zero")
+        return tags
+
+    def parse(self, input):
+        """Read a .stringsdict file into a dictionary, and convert it to translation units."""
+
+        if isinstance(input, bytes) or isinstance(input, str):
+            plist = plistlib.loads(input, dict_type=OrderedDict)
+        elif input is not None:
+            plist = plistlib.load(input, dict_type=OrderedDict)
+        else:
+            plist = {}
+
+        for key, outer in plist.items():
+            if not isinstance(outer, dict):
+                raise ValueError(f"{key} is not a dict")
+            for innerkey, value in outer.items():
+                if innerkey == "NSStringLocalizedFormatKey":
+                    u = self.UnitClass(key)
+                    u.target = str(value)
+                    self.addunit(u)
+                elif isinstance(value, dict):
+                    spec_type = value.get("NSStringFormatSpecTypeKey", "")
+                    if spec_type and spec_type != "NSStringPluralRuleType":
+                        raise ValueError(
+                            f"{innerkey} in {key} is not of NSStringPluralRuleType"
+                        )
+
+                    plural_tags = self.target_plural_tags
+                    plural_strings = [value.get(tag, "") for tag in plural_tags]
+
+                    u = self.UnitClass(f"{key}[{innerkey}]")
+                    u.target = multistring(plural_strings)
+                    u.format_value_type = value.get("NSStringFormatValueTypeKey", "")
+                    self.addunit(u)
+                else:
+                    raise ValueError(f"Unexpected key {innerkey} in {key}")
+
+    def serialize(self, out):
+        plist = OrderedDict()
+
+        for u in self.units:
+            loc = str(u.getid()) or ""
+            subkey = None
+
+            # Check if this unit is a format string or a variable
+            opener = loc.rfind("[")
+            if opener > 0 and loc[-1] == "]":
+                subkey = loc[(opener + 1) : (len(loc) - 1)]
+                loc = loc[:opener]
+
+            if loc not in plist:
+                plist[loc] = OrderedDict()
+
+            if subkey is not None:
+                plurals = OrderedDict()
+                plurals["NSStringFormatSpecTypeKey"] = "NSStringPluralRuleType"
+                plurals["NSStringFormatValueTypeKey"] = u.format_value_type
+
+                plural_tags = self.target_plural_tags
+
+                if isinstance(u.target, multistring):
+                    plural_strings = u.target.strings
+                elif isinstance(u.target, list):
+                    plural_strings = u.target
+                else:
+                    plural_strings = [u.target]
+
+                # Sync plural_strings elements to plural_tags count.
+                if len(plural_strings) < len(plural_tags):
+                    plural_strings += [""] * (len(plural_tags) - len(plural_strings))
+                plural_strings = plural_strings[: len(plural_tags)]
+
+                for plural_tag, plural_string in zip(plural_tags, plural_strings):
+                    if plural_string:
+                        plurals[plural_tag] = plural_string
+
+                plist[loc][subkey] = plurals
+            else:
+                plist[loc]["NSStringLocalizedFormatKey"] = u.target or u.source
+
+        out.write(plistlib.dumps(plist, sort_keys=False))

--- a/translate/storage/test_stringsdict.py
+++ b/translate/storage/test_stringsdict.py
@@ -65,12 +65,21 @@ class TestStringsDictFile(test_monolingual.TestMonolingualStore):
     </dict>
 </plist>"""
         store = self.StoreClass()
+        store.settargetlanguage("en")
         store.parse(content)
 
         assert store.units[0].source == "shopping-list"
+        assert store.units[0].target == "%1$#@apple@ and %2$#@orange@."
         assert store.units[1].source == "shopping-list[apple]"
+        assert store.units[1].target.strings == ["", "One apple", "%d apples"]
         assert store.units[2].source == "shopping-list[orange]"
+        assert store.units[2].target.strings == [
+            "no oranges",
+            "one orange",
+            "%d oranges",
+        ]
         assert store.units[3].source == "other-string"
+        assert store.units[3].target == "Other string"
 
         newstore = self.reparse(store)
         self.check_equality(store, newstore)

--- a/translate/storage/test_stringsdict.py
+++ b/translate/storage/test_stringsdict.py
@@ -1,0 +1,138 @@
+import plistlib
+from io import BytesIO
+
+from translate.lang import data
+from translate.misc.multistring import multistring
+from translate.storage import stringsdict, test_monolingual
+
+
+class TestStringsDictUnit(test_monolingual.TestMonolingualUnit):
+    UnitClass = stringsdict.StringsDictUnit
+
+    def test_eq_formatvaluetype(self):
+        unit = self.UnitClass("Test String[p]")
+        unit2 = self.UnitClass("Test String[p]")
+
+        assert unit == unit2
+        unit2.format_value_type = "d"
+        assert unit != unit2
+        unit.format_value_type = "d"
+        assert unit == unit2
+
+
+class TestStringsDictFile(test_monolingual.TestMonolingualStore):
+    StoreClass = stringsdict.StringsDictFile
+
+    def test_serialize(self):
+        content = b"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>shopping-list</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%1$#@apple@ and %2$#@orange@.</string>
+            <key>apple</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>One apple</string>
+                <key>other</key>
+                <string>%d apples</string>
+            </dict>
+            <key>orange</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>zero</key>
+                <string>no oranges</string>
+                <key>one</key>
+                <string>one orange</string>
+                <key>other</key>
+                <string>%d oranges</string>
+            </dict>
+        </dict>
+        <key>other-string</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>Other string</string>
+        </dict>
+    </dict>
+</plist>"""
+        store = self.StoreClass()
+        store.parse(content)
+
+        assert store.units[0].source == "shopping-list"
+        assert store.units[1].source == "shopping-list[apple]"
+        assert store.units[2].source == "shopping-list[orange]"
+        assert store.units[3].source == "other-string"
+
+        newstore = self.reparse(store)
+        self.check_equality(store, newstore)
+
+    def test_targetlanguage_default_handlings(self):
+        store = self.StoreClass()
+
+        # Initial value is None
+        assert store.gettargetlanguage() is None
+
+        # sourcelanguage shouldn't change the targetlanguage
+        store.setsourcelanguage("en")
+        assert store.gettargetlanguage() is None
+
+        # targetlanguage setter works correctly
+        store.settargetlanguage("de")
+        assert store.gettargetlanguage() == "de"
+
+        # explicit targetlanguage wins over filename
+        store.filename = "Project/it.lproj/Localizable.stringsdict"
+        assert store.gettargetlanguage() == "de"
+
+    def test_targetlanguage_auto_detection_filename(self):
+        store = self.StoreClass()
+
+        # Check language auto_detection
+        store.filename = "Project/it.lproj/Localizable.stringsdict"
+        assert store.gettargetlanguage() == "it"
+
+    def test_targetlanguage_auto_detection_filename_default_language(self):
+        store = self.StoreClass()
+
+        store.setsourcelanguage("nl")
+
+        # Check language auto_detection
+        store.filename = "Project/Localizable.stringsdict"
+        assert store.gettargetlanguage() == "nl"
+
+        # Clear cache
+        store.settargetlanguage(None)
+
+        store.filename = "invalid_filename"
+        assert store.gettargetlanguage() == "nl"
+
+    def test_plural_zero_always_set(self):
+        def lang_without_zero(tuple):
+            return len(tuple[1]) > 3 and "zero" not in tuple[1]
+
+        lang = next(filter(lang_without_zero, data.plural_tags.items()))
+
+        store = self.StoreClass()
+        store.settargetlanguage(lang[0])
+
+        store.addsourceunit("item")
+
+        unit = store.UnitClass("item[p]")
+        unit.target = multistring(lang[1])
+        store.addunit(unit)
+
+        bytes = BytesIO()
+        store.serialize(bytes)
+        bytes.seek(0)
+
+        plist = plistlib.load(bytes)
+        assert plist["item"]["p"]["zero"]

--- a/translate/storage/test_stringsdict.py
+++ b/translate/storage/test_stringsdict.py
@@ -9,15 +9,32 @@ from translate.storage import stringsdict, test_monolingual
 class TestStringsDictUnit(test_monolingual.TestMonolingualUnit):
     UnitClass = stringsdict.StringsDictUnit
 
+    def test_source(self):
+        unit = self.UnitClass()
+        unit.set_unitid(unit.IdClass([("key", "Test String"), ("key", "p")]))
+        unit2 = self.UnitClass("Test String:p")
+        unit3 = self.UnitClass("Test String 2:p")
+        unit4 = self.UnitClass("Test String:q")
+
+        assert unit == unit2
+        assert unit != unit3
+        assert unit != unit4
+
     def test_eq_formatvaluetype(self):
-        unit = self.UnitClass("Test String[p]")
-        unit2 = self.UnitClass("Test String[p]")
+        unit = self.UnitClass("Test String:p")
+        unit2 = self.UnitClass("Test String:p")
 
         assert unit == unit2
         unit2.format_value_type = "d"
         assert unit != unit2
         unit.format_value_type = "d"
         assert unit == unit2
+
+    def test_innerkey(self):
+        unit = self.UnitClass()
+        unit.set_unitid(unit.IdClass([("key", "Test String"), ("key", "p")]))
+        assert unit.outerkey == "Test String"
+        assert unit.innerkey == "p"
 
 
 class TestStringsDictFile(test_monolingual.TestMonolingualStore):
@@ -70,9 +87,9 @@ class TestStringsDictFile(test_monolingual.TestMonolingualStore):
 
         assert store.units[0].source == "shopping-list"
         assert store.units[0].target == "%1$#@apple@ and %2$#@orange@."
-        assert store.units[1].source == "shopping-list[apple]"
+        assert store.units[1].source == "shopping-list:apple"
         assert store.units[1].target.strings == ["", "One apple", "%d apples"]
-        assert store.units[2].source == "shopping-list[orange]"
+        assert store.units[2].source == "shopping-list:orange"
         assert store.units[2].target.strings == [
             "no oranges",
             "one orange",
@@ -135,7 +152,7 @@ class TestStringsDictFile(test_monolingual.TestMonolingualStore):
 
         store.addsourceunit("item")
 
-        unit = store.UnitClass("item[p]")
+        unit = store.UnitClass("item:p")
         unit.target = multistring(lang[1])
         store.addunit(unit)
 


### PR DESCRIPTION
#3238 

This implements Stringsdict as defined by Apple. While it can be used for regular strings, it's recommended to only use this format to store plurals.

Apple deviates from the CLDR Language Plural Rules standard in the following ways:
* All languages support the 'zero' category. This implementation prepends the 'zero' category in every language that doesn't define it already.
* The 'other' category is always used when a category has a missing string, including in languages that doesn't have 'other' defined in the list of tags. This is currently unsupported by this implementation, and the 'other' string is not preserved when parsing a file in a language that doesn't define it.

