### PR TITLE
json: Handle crash when can not detect encoding

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -230,6 +230,8 @@ class JsonFile(base.DictStore):
             # that parse JSON texts MAY ignore the presence of a byte order mark
             # rather than treating it as an error, see RFC7159
             input, self.encoding = self.detect_encoding(input)
+            if input is None:
+                raise base.ParseError(ValueError("Failed to decode JSON string."))
         try:
             self._file = json.loads(input, object_pairs_hook=OrderedDict)
         except ValueError as e:

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -136,6 +136,13 @@ class TestJSONResourceStore(test_monolingual.TestMonolingualStore):
 
         assert out.getvalue() == b'{\n    "key": "value"\n}\n'
 
+    def test_can_not_detect(self):
+        store = self.StoreClass()
+        with raises(base.ParseError):
+            store.parse(
+                b"PK\x03\x04\x14\x00\x06\x00\x08\x00\x00\x00!\x00b\xee\x9dh^\x01\x00\x00\x90\x04\x00\x00\x13\x00\x08\x02"
+            )
+
     def test_error(self):
         store = self.StoreClass()
         with raises(base.ParseError):


### PR DESCRIPTION
If not handled here, the json complains on passing None which does
not really tell what went wrong.