### PR TITLE
rc: Avoid duplicating \r in po2rc

### DIFF
--- a/translate/convert/po2rc.py
+++ b/translate/convert/po2rc.py
@@ -53,6 +53,14 @@ class rerc:
         self.lang = lang
         self.sublang = sublang
 
+    def convert_comment(self, out, addnl, comment):
+        if not addnl:
+            out.append("    ")
+        # Strip extra \r from \r\n which is left in the comment by the parser
+        if comment.endswith("\r"):
+            comment = comment[:-1]
+        out.append(comment)
+
     def convert_dialog(self, s, loc, toks):
         out = []
         out.append(toks.block_id)
@@ -87,9 +95,7 @@ class rerc:
         for c in toks.controls:
 
             if isinstance(c, str):
-                if not addnl:
-                    out.append("    ")
-                out.append(c)
+                self.convert_comment(out, addnl, c)
                 addnl = True
                 continue
             if addnl:
@@ -142,9 +148,7 @@ class rerc:
         addnl = False
         for c in toks.controls:
             if isinstance(c, str):
-                if not addnl:
-                    out.append("    ")
-                out.append(c)
+                self.convert_comment(out, addnl, c)
                 addnl = True
                 continue
             if addnl:
@@ -212,6 +216,9 @@ class rerc:
         out.append(NL)
 
         for element in popup.elements:
+            if isinstance(element, str):
+                self.convert_comment(out, True, element)
+                continue
 
             if element.block_type and element.block_type == "MENUITEM":
                 out.append(identation)

--- a/translate/convert/test_po2rc.py
+++ b/translate/convert/test_po2rc.py
@@ -107,3 +107,30 @@ msgstr "Zkopirovano"
             rc_result = rcfile(handle)
         assert len(rc_result.units) == 1
         assert rc_result.units[0].target == "Zkopirovano"
+
+    def test_convert_comment_dos_eol(self):
+        self.create_testfile(
+            "simple.rc",
+            b"""\r\nSTRINGTABLE\r\nBEGIN\r\n// Comment\r\nIDS_1 "Copied"\r\nEND\r\n""",
+        )
+        self.create_testfile(
+            "simple.po",
+            """
+#: STRINGTABLE.IDS_1
+msgid "Copied"
+msgstr "Zkopirovano"
+""",
+        )
+        self.run_command(
+            template="simple.rc", i="simple.po", o="output.rc", l="LANG_CZECH"
+        )
+        with self.open_testfile("output.rc", "rb") as handle:
+            content = handle.read()
+            assert (
+                content
+                == b"""\r\nSTRINGTABLE\r\nBEGIN\r\n    // Comment\r\n    IDS_1                   "Zkopirovano"\r\nEND\r\n"""
+            )
+        with self.open_testfile("output.rc") as handle:
+            rc_result = rcfile(handle)
+        assert len(rc_result.units) == 1
+        assert rc_result.units[0].target == "Zkopirovano"


### PR DESCRIPTION
The parser operates based on \n, but the RC file is typically using \r\n.