### PR TITLE
html parser improvements

### DIFF
--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -218,22 +218,19 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
         tagstack = []
         tagmap = {}
         tag = None
-        for pos in range(len(self.tu_content)):
-            if (
-                self.tu_content[pos]["type"] != "endtag"
-                and tag in self.EMPTY_HTML_ELEMENTS
-            ):
+        for pos, content in enumerate(self.tu_content):
+            if content["type"] != "endtag" and tag in self.EMPTY_HTML_ELEMENTS:
                 match = tagstack.pop()
                 tag = None
 
-            if self.has_translatable_content(self.tu_content[pos]):
+            if self.has_translatable_content(content):
                 if end == 0:
                     start = pos
                 end = pos + 1
-            elif self.tu_content[pos]["type"] == "starttag":
+            elif content["type"] == "starttag":
                 tagstack.append(pos)
-                tag = self.tu_content[pos]["tag"]
-            elif self.tu_content[pos]["type"] == "endtag":
+                tag = content["tag"]
+            elif content["type"] == "endtag":
                 if tagstack:
                     match = tagstack.pop()
                     tagmap[match] = pos

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -218,6 +218,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
         tagstack = []
         tagmap = {}
         tag = None
+        do_normalize = True
         for pos, content in enumerate(self.tu_content):
             if content["type"] != "endtag" and tag in self.EMPTY_HTML_ELEMENTS:
                 match = tagstack.pop()
@@ -230,6 +231,8 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
             elif content["type"] == "starttag":
                 tagstack.append(pos)
                 tag = content["tag"]
+                if tag == "pre":
+                    do_normalize = False
             elif content["type"] == "endtag":
                 if tagstack:
                     match = tagstack.pop()
@@ -272,7 +275,10 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
                     else:
                         html_content.append(markup["html_content"])
             html_content = "".join(html_content)
-            normalized_content = self.WHITESPACE_RE.sub(" ", html_content.strip())
+            if do_normalize:
+                normalized_content = self.WHITESPACE_RE.sub(" ", html_content.strip())
+            else:
+                normalized_content = html_content.strip()
             assert normalized_content  # shouldn't be here otherwise
 
             unit = self.addsourceunit(normalized_content)

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -264,13 +264,14 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
 
         # emit captured markup elements
         if start < end:
-            html_content = ""
+            html_content = []
             for markup in self.tu_content[start:end]:
                 if markup["type"] != "comment":
                     if "untranslated_html" in markup:
-                        html_content += markup["untranslated_html"]
+                        html_content.append(markup["untranslated_html"])
                     else:
-                        html_content += markup["html_content"]
+                        html_content.append(markup["html_content"])
+            html_content = "".join(html_content)
             normalized_content = self.WHITESPACE_RE.sub(" ", html_content.strip())
             assert normalized_content  # shouldn't be here otherwise
 

--- a/translate/storage/test_html.py
+++ b/translate/storage/test_html.py
@@ -222,3 +222,33 @@ class TestHTMLExtraction:
         )
         assert len(store.units) == 1
         assert store.units[0].source == "Henry Jacobs camper application"
+
+    def test_extraction_pre(self):
+        """Check that we can preserve lines in the <pre> tag"""
+        h = html.htmlfile()
+        store = h.parsestring(
+            """
+<pre>
+this is
+a multiline
+pre tag
+</pre>
+        """
+        )
+        assert len(store.units) == 1
+        assert store.units[0].source == "this is\na multiline\npre tag"
+
+    def test_extraction_pre_code(self):
+        """Check that we can preserve lines in the <pre> tag"""
+        h = html.htmlfile()
+        store = h.parsestring(
+            """
+<pre><code>
+this is
+a multiline
+pre tag
+</code></pre>
+        """
+        )
+        assert len(store.units) == 1
+        assert store.units[0].source == "this is\na multiline\npre tag"


### PR DESCRIPTION
This makes the parser preserve whitespace in `<pre>`, fixes #3265.

While looking into the code, I've made some other minor cleanups.