### PR TITLE
chore: Update submodule URL to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/translate/sphinx-themes.git
+	url = https://github.com/translate/sphinx-themes.git


### PR DESCRIPTION
It should have been done years ago, but nobody noticed that. It is now being switched off by GitHub, see https://github.blog/2021-09-01-improving-git-protocol-security-github/