### PR TITLE
Better handling of multiline stringtable translations in po2rc

### DIFF
--- a/translate/convert/po2rc.py
+++ b/translate/convert/po2rc.py
@@ -164,14 +164,21 @@ class rerc:
                 out.append(c0[0].ljust(24))
 
             name = rc.generate_stringtable_name(c0[0])
-            msgid = c[1][1:-1]
+            msgid = "".join(cn[1:-1] for cn in c[1:])
+
             if msgid in self.inputdict:
                 if name in self.inputdict[msgid]:
-                    c[1] = '"' + self.inputdict[msgid][name] + '"'
+                    tmp = ['"' + self.inputdict[msgid][name] + '"']
                 elif EMPTY_LOCATION in self.inputdict[msgid]:
-                    c[1] = '"' + self.inputdict[msgid][EMPTY_LOCATION] + '"'
+                    tmp = ['"' + self.inputdict[msgid][EMPTY_LOCATION] + '"']
+            else:
+                tmp = c[1:]
 
-            out.append(",".join(c[1:]))
+            for part in tmp[:-1]:
+                out.append(part)
+                out.append(NL + " " * (24 + 4))
+            out.append(tmp[-1])
+
             out.append(NL)
 
         out.append(BLOCK_END)

--- a/translate/convert/test_po2rc.py
+++ b/translate/convert/test_po2rc.py
@@ -89,6 +89,10 @@ STRINGTABLE
 BEGIN
     // IDS_COMMENTED        "Comment"
     IDS_COPIED              "Copied"
+    IDS_ADJACENT_STRINGS    "Line1 "
+                            "Line2"
+    IDS_UNTRANSLATED_STRING "This string has no translation. "
+                            "It will appear verbatim in the output"
 END
 """,
         )
@@ -98,6 +102,13 @@ END
 #: STRINGTABLE.IDS_COPIED
 msgid "Copied"
 msgstr "Zkopirovano"
+#: STRINGTABLE.IDS_ADJACENT_STRINGS
+msgid ""
+"Line1 "
+"Line2"
+msgstr ""
+"Čára1 "
+"Čára2"
 """,
         )
         self.run_command(
@@ -105,8 +116,13 @@ msgstr "Zkopirovano"
         )
         with self.open_testfile("output.rc") as handle:
             rc_result = rcfile(handle)
-        assert len(rc_result.units) == 1
+        assert len(rc_result.units) == 3
         assert rc_result.units[0].target == "Zkopirovano"
+        assert rc_result.units[1].target == "Čára1 Čára2"
+        assert (
+            rc_result.units[2].target
+            == "This string has no translation. It will appear verbatim in the output"
+        )
 
     def test_convert_comment_dos_eol(self):
         self.create_testfile(


### PR DESCRIPTION
When outputting a STRINGTABLE:
- Construct msgid correctly when it's multiline
- If a translation isn't available, output the continuation lines indented (not separated by ',')
- If a translation is available, it's output on a single line (since we don't know where to break lines)

Fixes #4115