### PR TITLE
pypo: Remove unused, untested and broken pounit.parse

### DIFF
--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -653,11 +653,6 @@ class pounit(pocommon.pounit):
         """returns whether this pounit contains plural strings..."""
         return len(self.msgid_plural) > 0
 
-    def parse(self, src):
-        return poparser.parse_unit(
-            poparser.ParseState(splitlines(src)[0], pounit), self
-        )
-
     def _getmsgpartstr(self, partname, partlines, partcomments=""):
         if isinstance(partlines, dict):
             partkeys = sorted(partlines.keys())


### PR DESCRIPTION
This code is broken for years without anybody noticing, so
it should be safe to remove.