### PR TITLE
ci: Avoid running CI on pushes to deepsource branches

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
+      - "deepsource**"
   pull_request:
 
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,7 @@ on:
     - "docs/**"
     branches-ignore:
       - "dependabot/**"
+      - "deepsource**"
   pull_request:
     paths-ignore:
     - "docs/**"

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -6,6 +6,7 @@ on:
     - "docs/**"
     branches-ignore:
       - "dependabot/**"
+      - "deepsource**"
   pull_request:
     paths-ignore:
     - "docs/**"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
+      - "deepsource**"
   pull_request:
 
 jobs:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
+      - "deepsource**"
   pull_request:
 
 jobs:

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -6,6 +6,7 @@ on:
     - "docs/**"
     branches-ignore:
       - "dependabot/**"
+      - "deepsource**"
   pull_request:
     paths-ignore:
     - "docs/**"


### PR DESCRIPTION
These end up in the pull requests, so there is no good reason to run
everything twice.