### PR TITLE
storage: Remove filename arg from getids method

### DIFF
--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -717,7 +717,7 @@ class TranslationStore:
         if not self.id_index:
             self.makeindex()
 
-    def getids(self, filename=None):
+    def getids(self):
         """return a list of unit ids"""
         self.require_index()
         return self.id_index.keys()

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -719,17 +719,6 @@ class xlifffile(lisa.LISAfile):
             return self.createfilenode(filename)
         return None
 
-    def getids(self, filename=None):
-        if not filename:
-            return super().getids()
-
-        self.id_index = {}
-        prefix = filename + ID_SEPARATOR
-        units = (unit for unit in self.units if unit.getid().startswith(prefix))
-        for index, unit in enumerate(units):
-            self.id_index[unit.getid()[len(prefix) :]] = unit
-        return self.id_index.keys()
-
     def setsourcelanguage(self, language):
         if not language:
             return


### PR DESCRIPTION
- it is not useed anywhere in the translate-toolkit
- the variant with filename has weird side effect of changing id_index
- the only external user seems Pootle and it does not use filename