### PR TITLE
tests: Avoid manually handling warnings

### DIFF
--- a/translate/convert/test_po2dtd.py
+++ b/translate/convert/test_po2dtd.py
@@ -8,12 +8,6 @@ from translate.storage import dtd, po
 
 
 class TestPO2DTD:
-    def setup_method(self, method):
-        warnings.resetwarnings()
-
-    def teardown_method(self, method):
-        warnings.resetwarnings()
-
     def po2dtd(self, posource, remove_untranslated=False):
         """helper that converts po source to dtd source without requiring files"""
         inputfile = BytesIO(posource.encode())
@@ -547,18 +541,6 @@ class TestPO2DTDCommand(test_convert.TestConvertCommand, TestPO2DTD):
 
     convertmodule = po2dtd
     defaultoptions = {"progress": "none"}
-    # TODO: because of having 2 base classes, we need to call all their setup and teardown methods
-    # (otherwise we won't reset the warnings etc)
-
-    def setup_method(self, method):
-        """call both base classes setup_methods"""
-        super().setup_method(method)
-        TestPO2DTD.setup_method(self, method)
-
-    def teardown_method(self, method):
-        """call both base classes teardown_methods"""
-        super().teardown_method(method)
-        TestPO2DTD.teardown_method(self, method)
 
     def test_help(self, capsys):
         """tests getting help"""

--- a/translate/convert/test_po2oo.py
+++ b/translate/convert/test_po2oo.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 from io import BytesIO
 
 from pytest import mark
@@ -9,12 +8,6 @@ from translate.storage import po
 
 
 class TestPO2OO:
-    def setup_method(self, method):
-        warnings.resetwarnings()
-
-    def teardown_method(self, method):
-        warnings.resetwarnings()
-
     def convertoo(self, posource, ootemplate, language="en-US"):
         """helper to exercise the command line function"""
         inputfile = BytesIO(posource.encode())

--- a/translate/convert/test_pot2po.py
+++ b/translate/convert/test_pot2po.py
@@ -1,4 +1,3 @@
-import warnings
 from io import BytesIO
 
 from pytest import mark
@@ -8,12 +7,6 @@ from translate.storage import po
 
 
 class TestPOT2PO:
-    def setup_method(self, method):
-        warnings.resetwarnings()
-
-    def teardown_method(self, method):
-        warnings.resetwarnings()
-
     def convertpot(self, potsource, posource=None):
         """helper that converts pot source to po source without requiring files"""
         potfile = BytesIO(potsource.encode())

--- a/translate/storage/test_base.py
+++ b/translate/storage/test_base.py
@@ -20,7 +20,6 @@
 
 
 import os
-import warnings
 from io import BytesIO
 
 from translate.misc.multistring import multistring
@@ -243,13 +242,11 @@ class TestTranslationStore:
         self.filename = f"{self.__class__.__name__}_{method.__name__}.test"
         if os.path.exists(self.filename):
             os.remove(self.filename)
-        warnings.resetwarnings()
 
     def teardown_method(self, method):
         """Makes sure that if self.filename was created by the method, it is cleaned up"""
         if os.path.exists(self.filename):
             os.remove(self.filename)
-        warnings.resetwarnings()
 
     def test_create_blank(self):
         """Tests creating a new blank store"""

--- a/translate/storage/test_oo.py
+++ b/translate/storage/test_oo.py
@@ -108,12 +108,6 @@ def test_escape_help_text():
 
 
 class TestOO:
-    def setup_method(self, method):
-        warnings.resetwarnings()
-
-    def teardown_method(self, method):
-        warnings.resetwarnings()
-
     def ooparse(self, oosource):
         """helper that parses oo source without requiring files"""
         dummyfile = BytesIO(oosource.encode())

--- a/translate/tools/test_pretranslate.py
+++ b/translate/tools/test_pretranslate.py
@@ -1,4 +1,3 @@
-import warnings
 from io import BytesIO
 
 from pytest import mark
@@ -17,12 +16,6 @@ class TestPretranslate:
                 </body>
         </file>
 </xliff>"""
-
-    def setup_method(self, method):
-        warnings.resetwarnings()
-
-    def teardown_method(self, method):
-        warnings.resetwarnings()
 
     def pretranslatepo(self, input_source, template_source=None):
         """helper that converts strings to po source without requiring files"""


### PR DESCRIPTION
pytest captures them since the 3.1 release.