### PR TITLE
xliff: Refactor element clear

### DIFF
--- a/translate/misc/xml_helpers.py
+++ b/translate/misc/xml_helpers.py
@@ -198,3 +198,14 @@ def valid_chars_only(text: str) -> str:
     prevent to crash libxml with unexpected chars
     """
     return "".join(char for char in text if validate_char(char))
+
+
+def clear_content(node):
+    """
+    Removes XML node content.
+
+    Unlike clear() this is not removing attributes.
+    """
+    for child in node:
+        node.remove(child)
+    node.text = None

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -190,6 +190,11 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert x_placeable.tail == "baz"
 
         # Test 2
+        xliffunit.target = "test plain target"
+        xliffunit.set_rich_target(
+            [StringElem(["foo", G(id="eek", sub=[G(id="ook", sub=["bar", "rab"])])])],
+            "fr",
+        )
         xliffunit.set_rich_target(
             [
                 StringElem(
@@ -219,6 +224,21 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert xliffunit.rich_target == [
             StringElem(["foobaz", G(id="oof", sub=[G(id="zab", sub=["barrab"])])])
         ]
+        print(bytes(xlifffile).decode())
+        assert (
+            bytes(xlifffile).decode()
+            == """<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.1" version="1.1">
+  <file original="NoName" source-language="en" datatype="plaintext">
+    <body>
+      <trans-unit xml:space="preserve" id="2" approved="yes"><source></source>
+        <target state="translated">foobaz<g id="oof"><g id="zab">barrab</g></g></target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+"""
+        )
 
     @staticmethod
     def test_source():

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -24,7 +24,12 @@ The official recommendation is to use the extention .xlf for XLIFF files.
 from lxml import etree
 
 from translate.misc.multistring import multistring
-from translate.misc.xml_helpers import getXMLspace, setXMLlang, setXMLspace
+from translate.misc.xml_helpers import (
+    clear_content,
+    getXMLspace,
+    setXMLlang,
+    setXMLspace,
+)
 from translate.storage import base, lisa
 from translate.storage.placeables.lisa import strelem_to_xml, xml_to_strelem
 from translate.storage.workflow import StateEnum as state
@@ -182,8 +187,7 @@ class xliffunit(lisa.LISAunit):
             self.set_source_dom(sourcelanguageNode)
 
         # Clear sourcelanguageNode first
-        sourcelanguageNode.clear()
-        sourcelanguageNode.text = None
+        clear_content(sourcelanguageNode)
 
         strelem_to_xml(sourcelanguageNode, value[0])
 
@@ -215,8 +219,7 @@ class xliffunit(lisa.LISAunit):
             self.set_target_dom(languageNode, append)
 
         # Clear languageNode first
-        languageNode.clear()
-        languageNode.text = None
+        clear_content(languageNode)
 
         strelem_to_xml(languageNode, value[0])
         ### currently giving some issues in Virtaal: self._rich_target = value


### PR DESCRIPTION
- add tests that clearing works
- move the code to the xml helpers
- document why clear() is not a choice (and caused unnoticed regression
  in bb7d23bb09ba3c8d0d557821d3c8b8662dabc05f)