### PR TITLE
chore: unpin core GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         submodules: recursive
     - name: Setup Python
-      uses: actions/setup-python@v2.3.2
+      uses: actions/setup-python@v2
       with:
         python-version: '3.10'
         cache: pip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
     - name: Setup Python

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.6'
 
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2.3.2
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2.3.2
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -26,7 +26,7 @@ jobs:
         - '3.10'
 
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2.3.2
       with:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2.3.2
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v2
     - name: Setup Python
       uses: actions/setup-python@v2.3.2
       with:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v2
     - name: Setup Python
       uses: actions/setup-python@v2.3.2
       with:
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v2
     - name: Setup Python
       uses: actions/setup-python@v2.3.2
       with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v2.3.2
+      uses: actions/setup-python@v2
       with:
         python-version: '3.10'
         cache: pip
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v2.3.2
+      uses: actions/setup-python@v2
       with:
         python-version: '3.10'
         cache: pip
@@ -53,7 +53,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v2.3.2
+      uses: actions/setup-python@v2
       with:
         python-version: '3.10'
         cache: pip

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         submodules: recursive
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2.3.2
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
         cache: pip

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
     - name: Set up Python 3.7

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -26,7 +26,7 @@ jobs:
         - '3.10'
 
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2.3.2
       with:

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2.3.2
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip


### PR DESCRIPTION
Pointin to v2 will reduce some Dependabot noise, till there is a v3 release