### PR TITLE
feat: drop Python 3.6

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,14 +19,13 @@ jobs:
       matrix:
         requirements: [latest]
         python-version:
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
         include:
         - requirements: minimal
-          python-version: '3.6'
+          python-version: '3.7'
 
     steps:
     - uses: actions/checkout@v2.4.0

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         requirements: [latest]
         python-version:
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         requirements: [latest]
         python-version:
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ feature set. This cal be easily specified during pip installation::
    Will install all optional dependencies convering support for many other
    formats.
 
-The Toolkit requires Python 3.6 or newer.
+The Toolkit requires Python 3.7 or newer.
 
 The package lxml is required. You should install version 4.6.3 or later.
 <http://lxml.de/> Depending on your platform, the easiest way to install might

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,6 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -596,7 +595,7 @@ def dosetup(name, version, packages, datafiles, scripts, ext_modules=[]):
     setup(
         name=name,
         version=version,
-        python_requires=">=3.6",
+        python_requires=">=3.7",
         license="GNU General Public License (GPL)",
         description=description,
         long_description=long_description,


### PR DESCRIPTION
Maybe you want to keep it for a bit, but it hit EOL at the end of December https://devguide.python.org/devcycle/#end-of-life-branches