### PR TITLE
formats: Switch to charset-normalizer from chardet

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -5,7 +5,7 @@ aeidon==1.10.1        # Subtitles
 # Format support
 BeautifulSoup4>=4.3  # Trados
 # Encoding detection
-chardet==4.0.0              # chardet
+charset-normalizer==2.0.11   # chardet
 # Tmserver backend
 cheroot==8.6.0       # tmserver
 # Format support

--- a/translate/storage/test_csvl10n.py
+++ b/translate/storage/test_csvl10n.py
@@ -103,3 +103,15 @@ GENERAL@2|Notes,"cable, motor, switch"
         assert store.units[0].source == "te\\nst"
         assert store.units[0].target == "ot\\nher"
         assert bytes(store) == content
+
+    def test_utf_8_detection(self):
+        content = (
+            """"location","source","target","id","fuzzy","context","translator_comments","developer_comments"\r\n"""
+            """"","Second","秒","","False","00029.00002","","# Filter Order|IDE_2ND_ORDER_FILTER"\r\n"""
+        )
+        store = self.StoreClass()
+        store.parse(content.encode())
+        assert len(store.units) == 1
+        assert store.units[0].source == "Second"
+        assert store.units[0].target == "秒"
+        assert bytes(store).decode() == content


### PR DESCRIPTION
This is better maintained and more reliable detection.
    
This avoids issues with chardet mistakenly reporting utf-8 content as    windows-1252, see https://github.com/chardet/chardet/issues/185

