### PR TITLE
dictunit: Improve serializing of out of order items

### DIFF
--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -980,6 +980,9 @@ class DictUnit(TranslationUnit):
             if not use_list and isinstance(target[key], list):
                 # Convert list to dict if needed
                 target[key] = dict(enumerate(target[key]))
+            # Handle placeholders
+            if target[key] is None:
+                target[key] = default.copy()
             target = target[key]
         if override_key:
             element, key = "key", override_key
@@ -993,6 +996,9 @@ class DictUnit(TranslationUnit):
         elif element == "index":
             if len(target) <= key:
                 if not unset:
+                    # Add placeholders to the list
+                    while len(target) < key:
+                        target.append(None)
                     target.append(value)
             else:
                 if unset:

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -349,6 +349,41 @@ class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):
 """
         assert bytes(store).decode() == expected
 
+    def test_nested_list_mixed(self):
+        data = """{
+    "story_9795": {
+        "tsr_0": [
+            [
+                "‥",
+                "Combinato Carcer Tullianum & parco"
+            ],
+            "Archeologico del Colosseo"
+        ]
+    }
+}
+"""
+        store = self.StoreClass()
+        store.parse(data)
+        assert len(store.units) == 3
+        assert store.units[0].getid() == ".story_9795.tsr_0[0][0]"
+        assert store.units[1].getid() == ".story_9795.tsr_0[0][1]"
+        assert store.units[2].getid() == ".story_9795.tsr_0[1]"
+
+        assert bytes(store).decode() == data
+
+        store = self.StoreClass()
+        unit = self.StoreClass.UnitClass("Archeologico del Colosseo")
+        unit.setid(".story_9795.tsr_0[1]")
+        store.addunit(unit)
+        unit = self.StoreClass.UnitClass("Combinato Carcer Tullianum & parco")
+        unit.setid(".story_9795.tsr_0[0][1]")
+        store.addunit(unit)
+        unit = self.StoreClass.UnitClass("‥")
+        unit.setid(".story_9795.tsr_0[0][0]")
+        store.addunit(unit)
+
+        assert bytes(store).decode() == data
+
     def test_list_to_dict(self):
         data = """{
     "userInfoPage": [


### PR DESCRIPTION
When the units are not added in the order of serializing, the lists can
have blank space which needs to be filled in with None.

This fixes list ordering for newly added strings.

Fixes https://github.com/WeblateOrg/weblate/issues/7294