### PR TITLE
po2rc: Fix handling identical source strings with different ID

### DIFF
--- a/translate/convert/po2rc.py
+++ b/translate/convert/po2rc.py
@@ -163,13 +163,12 @@ class rerc:
             name = rc.generate_stringtable_name(c0[0])
             msgid = "".join(cn[1:-1] for cn in c[1:])
 
+            tmp = c[1:]
             if msgid in self.inputdict:
                 if name in self.inputdict[msgid]:
                     tmp = ['"' + self.inputdict[msgid][name] + '"']
                 elif EMPTY_LOCATION in self.inputdict[msgid]:
                     tmp = ['"' + self.inputdict[msgid][EMPTY_LOCATION] + '"']
-            else:
-                tmp = c[1:]
 
             for part in tmp[:-1]:
                 yield part

--- a/translate/convert/test_po2rc.py
+++ b/translate/convert/test_po2rc.py
@@ -150,3 +150,31 @@ msgstr "Zkopirovano"
             rc_result = rcfile(handle)
         assert len(rc_result.units) == 1
         assert rc_result.units[0].target == "Zkopirovano"
+
+    def test_convert_double_string(self):
+        self.create_testfile(
+            "simple.rc",
+            """
+STRINGTABLE
+BEGIN
+    IDS_COPIED              "Copied"
+    IDS_XCOPIED             "Copied"
+END
+""",
+        )
+        self.create_testfile(
+            "simple.po",
+            """
+#: STRINGTABLE.IDS_COPIED
+msgid "Copied"
+msgstr "Zkopirovano"
+""",
+        )
+        self.run_command(
+            template="simple.rc", i="simple.po", o="output.rc", l="LANG_CZECH"
+        )
+        with self.open_testfile("output.rc") as handle:
+            rc_result = rcfile(handle)
+        assert len(rc_result.units) == 2
+        assert rc_result.units[0].target == "Zkopirovano"
+        assert rc_result.units[1].target == "Copied"


### PR DESCRIPTION
The code would either crash on undefined variable or re-use its content
from the previous loop.