### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,9 @@ on:
     - deepsource**
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   docs:
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
     - docs/**
 
+permissions:
+  contents: read
+
 jobs:
   test:
 

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
     - docs/**
 
+permissions:
+  contents: read
+
 jobs:
   test-osx:
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,9 @@ on:
     - deepsource**
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -7,6 +7,9 @@ on:
     - deepsource**
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   setup:
 

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
     - docs/**
 
+permissions:
+  contents: read
+
 jobs:
   test-win:
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
