### PR TITLE
json: Avoid parsing root node

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -205,12 +205,11 @@ class JsonFile(base.DictStore):
                     item, stop, prev + [("index", i)], i, name_node, data
                 )
         # apply filter
-        elif (
+        elif prev.parts and (
             stop is None
             or (isinstance(last_node, dict) and name_node in stop)
             or (isinstance(last_node, list) and name_last_node in stop)
         ):
-
             unit = self.UnitClass(data, name_node)
             unit.set_unitid(prev)
             yield unit

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -235,6 +235,24 @@ class TestJSONResourceStore(test_monolingual.TestMonolingualStore):
         assert str(unit) == expected.strip()
         assert bytes(store).decode() == expected
 
+    def test_add_blank(self):
+        expected = """{
+    "simple.key": "source"
+}
+"""
+        store = self.StoreClass()
+        store.parse("true")
+
+        unit = self.StoreClass.UnitClass(
+            "source",
+        )
+        assert str(unit) != expected.strip()
+        unit.setid("simple.key")
+        store.addunit(unit)
+
+        assert str(unit) == expected.strip()
+        assert bytes(store).decode() == expected
+
 
 class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):
     StoreClass = jsonl10n.JsonNestedFile


### PR DESCRIPTION
This currently can not be represented well and breaks when adding new
units.