### PR TITLE
ci: Fix pip upgrade

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -36,9 +36,9 @@ jobs:
         cache: pip
         cache-dependency-path: requirements/*.txt
     - name: Update pip
-      run: pip install --user --upgrade pip wheel
+      run: python -m pip install --upgrade pip wheel
     - name: Install pip dependencies
-      run: pip install -r requirements/dev.txt
+      run: python -m pip install -r requirements/dev.txt
     - name: Install
       run: pip install .
     - name: pytest


### PR DESCRIPTION
pip on Windows can be upgraded only via `python -m pip` to avoid having
pip binary open while it is upgrading.