### PR TITLE
rc: Fix how identifiers are found after concatenated string

### DIFF
--- a/tests/cli/data/test_rc2po/one.rc
+++ b/tests/cli/data/test_rc2po/one.rc
@@ -77,7 +77,7 @@ BEGIN
     PUSHBUTTON      "See license",IDC_LICENCIA,10,162,85,15
     RTEXT           "If you don't have internet, please use magic.",IDC_STATIC,23,105,120,18
     ICON            IDR_MAINFRAME,IDC_STATIC,44,74,20,20
-    CTEXT           "Use your finger to activate the program.",IDC_ACTIVADA,17,50,175,17
+    CTEXT           "Use your finger to" " activate the program.",IDC_ACTIVADA,17,50,175,17
     ICON            IDR_MAINFRAME1,IDC_STATIC6,18,19,20,20
 END
 

--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -75,6 +75,18 @@ def extract_text(values):
     return "".join(result)
 
 
+def extract_id(values):
+    for value in values:
+        if isinstance(value, str) and value.startswith('"'):
+            continue
+        else:
+            if isinstance(value, str):
+                return value
+            break
+
+    return "UNKNOWN_ID"
+
+
 def escape_to_rc(string):
     """Escape a given Python string into a valid .rc string."""
     rcstring = re.sub("\\\\", "\\\\\\\\", string)
@@ -325,7 +337,7 @@ class rcfile(base.TranslationStore):
                     if newtext:
                         newunit = rcunit(newtext)
                         newunit.name = generate_menuitem_name(
-                            pre_name, element.block_type, element.values_[1]
+                            pre_name, element.block_type, extract_id(element.values_)
                         )
                         newunit.match = element
                         self.addunit(newunit)
@@ -420,7 +432,7 @@ class rcfile(base.TranslationStore):
                                     statement.block_type,
                                     statement.block_id[0],
                                     control.id_control[0],
-                                    control.values_[1],
+                                    extract_id(control.values_),
                                 )
                                 newunit.match = control
                                 self.addunit(newunit)

--- a/translate/storage/test_rc.py
+++ b/translate/storage/test_rc.py
@@ -170,7 +170,7 @@ BEGIN
     PUSHBUTTON      "See license",IDC_LICENCIA,10,162,85,15
     RTEXT           "If you don't have internet, please use magic.",IDC_STATIC,23,105,120,18
     ICON            IDR_MAINFRAME,IDC_STATIC,44,74,20,20
-    CTEXT           "Use your finger to activate the program.",IDC_ACTIVADA,17,50,175,17
+    CTEXT           "Use your finger to" " activate the program.",IDC_ACTIVADA,17,50,175,17
     ICON            IDR_MAINFRAME1,IDC_STATIC6,18,19,20,20
 END
 """


### PR DESCRIPTION
Fix how identifiers are found after a concatenated string in MENU and
DIALOG resources.

After extract_test() has consumed one or more adjacent quoted string
tokens to concatenate, the following token is the identifier.

This fixes an oversight in 2c581f31.