### PR TITLE
Better handling of translations of concatenated string in dialog controls in po2rc

### DIFF
--- a/translate/convert/po2rc.py
+++ b/translate/convert/po2rc.py
@@ -112,21 +112,28 @@ class rerc:
 
             tmp = []
 
+            # collect initial quoted items to form msgid
+            i = 1
+            while isinstance(c[i], str) and c[i].startswith(("'", '"')):
+                i = i + 1
+            msgid = "".join(cn[1:-1] for cn in c[1:i])
+
             name = rc.generate_dialog_control_name(
-                toks.block_type, toks.block_id[0], c.id_control[0], c.values_[1]
+                toks.block_type, toks.block_id[0], c.id_control[0], c[i]
             )
-            msgid = c[1][1:-1]
-            if c[1].startswith(("'", '"')) and msgid in self.inputdict:
+
+            # append translation if available, otherwise use as is
+            if msgid in self.inputdict:
                 if name in self.inputdict[msgid]:
                     tmp.append('"' + self.inputdict[msgid][name] + '"')
                 elif EMPTY_LOCATION in self.inputdict[msgid]:
                     tmp.append('"' + self.inputdict[msgid][EMPTY_LOCATION] + '"')
-            elif is_iterable_but_not_string(c[1]):
-                tmp.append(" | ".join(c[1]))
             else:
-                tmp.append(c[1])
+                if i > 1:
+                    tmp.append(" ".join(c[1:i]))
 
-            for a in c[2:]:
+            # and the remaining items, comma separated
+            for a in c[i:]:
                 if is_iterable_but_not_string(a):
                     tmp.append(" | ".join(a))
                 else:

--- a/translate/convert/test_po2rc.py
+++ b/translate/convert/test_po2rc.py
@@ -21,7 +21,7 @@ BEGIN
     PUSHBUTTON      "Help",ID_HELP,99,162,48,15
     PUSHBUTTON      "Close",IDCANCEL,151,162,48,15
     PUSHBUTTON      "Activate instalation",IDC_BUTTON1,74,76,76,18
-    CTEXT           "My very good program",IDC_STATIC1,56,21,109,19,SS_SUNKEN
+    CTEXT           "My very" " good program",IDC_STATIC1,56,21,109,19,SS_SUNKEN
     CTEXT           "You can use it without registering it",IDC_STATIC,35,131,128,19,SS_SUNKEN
     PUSHBUTTON      "Offline",IDC_OFFLINE,149,108,42,13
     PUSHBUTTON      "See license",IDC_LICENCIA,10,162,85,15
@@ -54,6 +54,10 @@ POFILE = """
 #: DIALOGEX.IDD_REGGHC_DIALOG.CAPTION
 msgid "License dialog"
 msgstr "Licenční dialog"
+
+#: DIALOGEX.IDD_REGGHC_DIALOG.CTEXT.IDC_STATIC1
+msgid "My very good program"
+msgstr "Mój bardzo dobry program"
 """
 
 
@@ -80,6 +84,7 @@ class TestPO2RCCommand(test_convert.TestConvertCommand):
             rc_result = rcfile(handle)
         assert len(rc_result.units) == 14
         assert rc_result.units[0].target == "Licenční dialog"
+        assert rc_result.units[4].target == "Mój bardzo dobry program"
 
     def test_convert_comment(self):
         self.create_testfile(


### PR DESCRIPTION
This is the same change as  #4481, for dialog controls rather than stringtable entries.

