### PR TITLE
Make 'rc2po --charset' do something

### DIFF
--- a/translate/convert/rc2po.py
+++ b/translate/convert/rc2po.py
@@ -138,7 +138,7 @@ def main(argv=None):
     parser = convert.ConvertOptionParser(
         formats, usetemplates=True, usepots=True, description=__doc__
     )
-    DEFAULTCHARSET = "cp1252"
+    DEFAULTCHARSET = "auto"
     parser.add_option(
         "",
         "--charset",

--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -308,7 +308,7 @@ class rcfile(base.TranslationStore):
     """This class represents a .rc file, made up of rcunits."""
 
     UnitClass = rcunit
-    default_encoding = "cp1252"
+    default_encoding = "auto"
 
     def __init__(self, inputfile=None, lang=None, sublang=None, **kwargs):
         """Construct an rcfile, optionally reading in from inputfile."""
@@ -319,7 +319,7 @@ class rcfile(base.TranslationStore):
         if inputfile is not None:
             rcsrc = inputfile.read()
             inputfile.close()
-            self.parse(rcsrc)
+            self.parse(rcsrc, self.encoding)
 
     def add_popup_units(self, pre_name, popup):
         """Transverses the popup tree making new units as needed."""
@@ -361,7 +361,7 @@ class rcfile(base.TranslationStore):
             decoded = rcsrc.decode(self.encoding)
         else:
             decoded, self.encoding = self.detect_encoding(
-                rcsrc, default_encodings=[self.default_encoding]
+                rcsrc, default_encodings=["cp1252"]
             )
 
         decoded = decoded.replace("\r", "")


### PR DESCRIPTION
At the moment, the specified encoding gets passed down via the kwargs of rcfile.__init__(), but that then ignores it when calling rcfile.parse(), which goes off and does it's autodetection based on `#pragma code_page`, or (if that is absent) utf-16-le or cp1252,