### PR TITLE
aresource: Fixed plural handling for b+ language codes

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -371,7 +371,11 @@ class AndroidResourceUnit(base.TranslationUnit):
                 self.xmlelement = etree.Element("plurals")
                 self.setid(old_id)
 
-            locale = self.gettargetlanguage().replace("_", "-").split("-")[0]
+            locale = self.gettargetlanguage()
+            # Handle b+ style language codes
+            if locale.startswith("b+"):
+                locale = locale[2:]
+            locale = locale.replace("_", "-").replace("+", "-").split("-")[0]
             plural_tags = data.plural_tags.get(locale, data.plural_tags["en"])
 
             # Get string list to handle, wrapping non multistring/list targets into a list.

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -786,3 +786,25 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
     </plurals>
 </resources>"""
         )
+
+    def test_edit_plural_b_zh_hk(self):
+        content = """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="vms_num_visitors">
+        <item quantity="one">%d visitor</item>
+        <item quantity="other">%d visitors</item>
+    </plurals>
+</resources>"""
+        store = self.StoreClass()
+        store.targetlanguage = "b+zh+Hant+HK"
+        store.parse(content.encode())
+        store.units[0].target = "%d 訪客"
+        assert (
+            bytes(store).decode()
+            == """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="vms_num_visitors">
+        <item quantity="other">%d 訪客</item>
+    </plurals>
+</resources>"""
+        )


### PR DESCRIPTION
This is Android way of coding complex language codes, we need to strip
this out to get actual language code.

Fixes https://github.com/WeblateOrg/weblate/issues/7816