### PR TITLE
Allow numeric resource IDs in RC files

### DIFF
--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -206,6 +206,7 @@ def rc_statement():
     undefined_control = (
         Group(
             name_id.set_results_name("id_control")
+            + Optional(",")
             + delimited_list(
                 concatenated_string ^ constant ^ numbers ^ Group(combined_constants)
             ).set_results_name("values_")

--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -181,14 +181,14 @@ def rc_statement():
     block_start = (Keyword("{") | Keyword("BEGIN")).set_name("block_start")
     block_end = (Keyword("}") | Keyword("END")).set_name("block_end")
 
-    name_id = Group(Word(alphas, alphanums + "_")).set_name("name_id")
-
     numbers = Word(nums)
 
     integerconstant = numbers ^ Combine("0x" + numbers)
 
+    name_id = Group(Word(alphas, alphanums + "_") | integerconstant)
+
     constant = Combine(
-        Optional(Keyword("NOT")) + (name_id | integerconstant),
+        Optional(Keyword("NOT")) + Group(name_id),
         adjacent=False,
         join_string=" ",
     )

--- a/translate/storage/test_rc.py
+++ b/translate/storage/test_rc.py
@@ -568,3 +568,30 @@ END
         assert rc_file.units[1].name == "MENU.IDR_MAINFRAME.MENUITEM.ID_COPIED"
         assert rc_file.units[2].source == "Delete"
         assert rc_file.units[2].name == "MENU.IDR_MAINFRAME.MENUITEM.ID_DELETE"
+
+    def test_decompiled(self):
+        rc_source = """
+1 MENU
+{
+  POPUP "This is a menu."
+  {
+    MENUITEM "This is a menu item.",  2
+  }
+}
+
+3 DIALOGEX 0, 0, 156, 50
+CAPTION "This is a dialog."
+{
+   CONTROL "This is a button.", 4, BUTTON, BS_DEFPUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 99, 7, 50, 14
+}
+"""
+        rc_file = self.source_parse(rc_source)
+        assert len(rc_file.units) == 4
+        assert rc_file.units[0].source == "This is a menu."
+        assert rc_file.units[0].name == "MENU.1.POPUP.CAPTION"
+        assert rc_file.units[1].source == "This is a menu item."
+        assert rc_file.units[1].name == "MENU.1.MENUITEM.2"
+        assert rc_file.units[2].source == "This is a dialog."
+        assert rc_file.units[2].name == "DIALOGEX.3.CAPTION"
+        assert rc_file.units[3].source == "This is a button."
+        assert rc_file.units[3].name == "DIALOGEX.3.CONTROL.4"

--- a/translate/storage/test_rc.py
+++ b/translate/storage/test_rc.py
@@ -584,9 +584,14 @@ CAPTION "This is a dialog."
 {
    CONTROL "This is a button.", 4, BUTTON, BS_DEFPUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 99, 7, 50, 14
 }
+
+STRINGTABLE
+{
+  5 	"This is a string."
+}
 """
         rc_file = self.source_parse(rc_source)
-        assert len(rc_file.units) == 4
+        assert len(rc_file.units) == 5
         assert rc_file.units[0].source == "This is a menu."
         assert rc_file.units[0].name == "MENU.1.POPUP.CAPTION"
         assert rc_file.units[1].source == "This is a menu item."
@@ -595,3 +600,5 @@ CAPTION "This is a dialog."
         assert rc_file.units[2].name == "DIALOGEX.3.CAPTION"
         assert rc_file.units[3].source == "This is a button."
         assert rc_file.units[3].name == "DIALOGEX.3.CONTROL.4"
+        assert rc_file.units[4].source == "This is a string."
+        assert rc_file.units[4].name == "STRINGTABLE.5"


### PR DESCRIPTION
# Background

When using tools like Resource Hacker to extract an RC file from a compiled binary EXE, resource identifiers are not `#define`d because the name cannot be reproduced from the binary. Instead, the numeric IDs are used directly. Furthermore, in the case of string tables, there is a comma after the resource ID. Running `rc2po` on such files produces an empty result.

# The fix

Simply allow numeric IDs, and an optional comma after `id_control`. Everything else seems to fall into place nicely.

A comma after the resource ID seems to be a documented feature for string tables: https://docs.microsoft.com/en-us/windows/win32/menurc/stringtable-resource#examples
Whether this causes any issues with other resource types, I cannot say. Tests all pass, however.

# Not covered

Converting such PO files back to RC was not tested, as it's out of scope for me. I am mostly interested in the RC file parsing aspect. However, if that's an issue, I could look at that as well.