### PR TITLE
lint: Update ignore for flake 5.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -214,11 +214,12 @@ exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,conf.py,_build,.tox,selector.py,mozil
 # N - naming plugin
 #  E203 - see https://github.com/psf/black/issues/315
 ignore=E203,E129,E226,E402,E731,W503,N,E265,E501,E266,E741,W504
+# /end [pycodestyle] duplication
 statistics=True
 per-file-ignores =
   translate/storage/placeables/__init__.py:F401,F403
   translate/storage/po.py:F401,F403
-# /end [pycodestyle] duplication
+  translate/storage/wordfast.py:155:27:E262
 
 [isort]
 # Settings:


### PR DESCRIPTION
It introduced check for inline comments what fails on
listing non breakable space in the escape map.