### PR TITLE
Add new rewriter to spot easily what is not part of the translation file 

### DIFF
--- a/docs/commands/option_rewrite.rst
+++ b/docs/commands/option_rewrite.rst
@@ -143,3 +143,19 @@ messages are still readable.
    Run :doc:`pofilter` as a quick method to fix up incorrect changes, or
    upgrade to version 1.4.
 
+.. _option_rewrite#nsa:
+
+nsa
+=======
+
+.. versionadded:: dev
+
+Rewrites the source text with black square that looks like NSA folder.
+
+.. code-block:: po
+
+  msgid "English"
+  msgstr "▮▮▮▮▮▮▮"
+
+This allows a translator or programmer to check what is not part of the translation. 
+This way it's easy to spot what is not translated yet.

--- a/docs/commands/option_rewrite.rst
+++ b/docs/commands/option_rewrite.rst
@@ -143,19 +143,21 @@ messages are still readable.
    Run :doc:`pofilter` as a quick method to fix up incorrect changes, or
    upgrade to version 1.4.
 
-.. _option_rewrite#nsa:
+.. _option_rewrite#classified:
 
-nsa
-=======
+classified
+==========
 
-.. versionadded:: dev
+.. versionadded:: 3.7.3
 
-Rewrites the source text with black square that looks like NSA folder.
+Rewrites the source text with black square (▮) that looks like NSA classified 
+files.
 
 .. code-block:: po
 
   msgid "English"
   msgstr "▮▮▮▮▮▮▮"
 
-This allows a translator or programmer to check what is not part of the translation. 
-This way it's easy to spot what is not translated yet.
+This allows a translator or programmer to visually distinguish what is not
+part of the translation yet.
+This way it's really easy to spot what strings are missing.

--- a/docs/commands/podebug.rst
+++ b/docs/commands/podebug.rst
@@ -58,7 +58,7 @@ Options:
 -S, --timestamp       skip conversion if the output file has newer timestamp
 -f FORMAT, --format=FORMAT     specify format string
 --rewrite=STYLE        the translation rewrite style: :doc:`xxx, en, blank,
-                       chef  (v1.2), unicode (v1.2) <option_rewrite>`
+                       chef  (v1.2), unicode (v1.2), nsa (dev) <option_rewrite>`
 --ignore=APPLICATION   apply tagging ignore rules for the given application:
                        kde, gtk, openoffice, libreoffice, mozilla
 --preserveplaceholders

--- a/docs/commands/podebug.rst
+++ b/docs/commands/podebug.rst
@@ -58,7 +58,7 @@ Options:
 -S, --timestamp       skip conversion if the output file has newer timestamp
 -f FORMAT, --format=FORMAT     specify format string
 --rewrite=STYLE        the translation rewrite style: :doc:`xxx, en, blank,
-                       chef  (v1.2), unicode (v1.2), nsa (dev) <option_rewrite>`
+                       chef  (v1.2), unicode (v1.2), classified (dev) <option_rewrite>`
 --ignore=APPLICATION   apply tagging ignore rules for the given application:
                        kde, gtk, openoffice, libreoffice, mozilla
 --preserveplaceholders

--- a/translate/tools/podebug.py
+++ b/translate/tools/podebug.py
@@ -242,7 +242,7 @@ class podebug:
         self.apply_to_translatables(string, transformer)
         return string
 
-    def rewrite_nsa(self, string):
+    def rewrite_classified(self, string):
         if not isinstance(string, StringElem):
             string = StringElem(string)
 

--- a/translate/tools/podebug.py
+++ b/translate/tools/podebug.py
@@ -242,6 +242,24 @@ class podebug:
         self.apply_to_translatables(string, transformer)
         return string
 
+    def rewrite_nsa(self, string):
+        if not isinstance(string, StringElem):
+            string = StringElem(string)
+
+        def transpose(char):
+            if char.isalnum():
+                return "▮"
+            return char
+
+        def transformer(s):
+            if self.preserveplaceholders:
+                return self.transform_characters_preserving_placeholders(s, transpose)
+            else:
+                return "".join(transpose(c) for c in s)
+
+        self.apply_to_translatables(string, transformer)
+        return string
+
     @classmethod
     def ignorelist(cls):
         return [

--- a/translate/tools/test_podebug.py
+++ b/translate/tools/test_podebug.py
@@ -156,47 +156,48 @@ class TestPODebug:
             == "\u202e<b>{{ph}}⊥ǝsʇ{ph}@@ph@@⊥ǝsʇ</b>"
         )
 
-    def test_rewrite_nsa(self):
+    def test_rewrite_classified(self):
         """Test the unicode rewrite function"""
-        assert str(self.debug.rewrite_nsa("Test")) == "▮▮▮▮"
+        assert str(self.debug.rewrite_classified("Test")) == "▮▮▮▮"
         # alternative with reversed string and no RTL override:
-        # assert unicode(self.debug.rewrite_nsa("Test")) == "ʇsǝ⊥"
+        # assert unicode(self.debug.rewrite_classified("Test")) == "ʇsǝ⊥"
         # Chars < ! and > z are returned as is
-        assert str(self.debug.rewrite_nsa(" ")) == " "
-        assert str(self.debug.rewrite_nsa("©")) == "©"
+        assert str(self.debug.rewrite_classified(" ")) == " "
+        assert str(self.debug.rewrite_classified("©")) == "©"
 
     @staticmethod
-    def test_rewrite_nsa_preserves_at_placeholders():
+    def test_rewrite_classified_preserves_at_placeholders():
         """Test the unicode rewrite function"""
         debug = podebug.podebug(preserveplaceholders=True)
-        assert str(debug.rewrite_nsa("@@ph@@Test @@ph@@")) == "@@ph@@▮▮▮▮ @@ph@@"
+        assert str(debug.rewrite_classified("@@ph@@Test @@ph@@")) == "@@ph@@▮▮▮▮ @@ph@@"
 
     @staticmethod
-    def test_rewrite_nsa_preserves_single_brace_placeholders():
+    def test_rewrite_classified_preserves_single_brace_placeholders():
         """Test the unicode rewrite function"""
         debug = podebug.podebug(preserveplaceholders=True)
-        assert str(debug.rewrite_nsa("{ph}Test {ph}")) == "{ph}▮▮▮▮ {ph}"
+        assert str(debug.rewrite_classified("{ph}Test {ph}")) == "{ph}▮▮▮▮ {ph}"
 
     @staticmethod
-    def test_rewrite_nsa_preserves_double_brace_placeholders():
+    def test_rewrite_classified_preserves_double_brace_placeholders():
         """Test the unicode rewrite function"""
         debug = podebug.podebug(preserveplaceholders=True)
-        assert str(debug.rewrite_nsa("{{ph}}Test {{ph}}")) == "{{ph}}▮▮▮▮ {{ph}}"
+        assert str(debug.rewrite_classified("{{ph}}Test {{ph}}")) == "{{ph}}▮▮▮▮ {{ph}}"
 
     @staticmethod
-    def test_rewrite_nsa_preserves_html():
+    def test_rewrite_classified_preserves_html():
         """Test the unicode rewrite function"""
         debug = podebug.podebug(preserveplaceholders=True)
         assert (
-            str(debug.rewrite_nsa("<style0>Test </style0>")) == "<style0>▮▮▮▮ </style0>"
+            str(debug.rewrite_classified("<style0>Test </style0>"))
+            == "<style0>▮▮▮▮ </style0>"
         )
 
     @staticmethod
-    def test_rewrite_nsa_multiple_styles_of_placeholder():
+    def test_rewrite_classified_multiple_styles_of_placeholder():
         """Test the unicode rewrite function"""
         debug = podebug.podebug(preserveplaceholders=True)
         assert (
-            str(debug.rewrite_nsa("<b>{{ph}}Test{ph}@@ph@@Test</b>"))
+            str(debug.rewrite_classified("<b>{{ph}}Test{ph}@@ph@@Test</b>"))
             == "<b>{{ph}}▮▮▮▮{ph}@@ph@@▮▮▮▮</b>"
         )
 

--- a/translate/tools/test_podebug.py
+++ b/translate/tools/test_podebug.py
@@ -156,6 +156,50 @@ class TestPODebug:
             == "\u202e<b>{{ph}}⊥ǝsʇ{ph}@@ph@@⊥ǝsʇ</b>"
         )
 
+    def test_rewrite_nsa(self):
+        """Test the unicode rewrite function"""
+        assert str(self.debug.rewrite_nsa("Test")) == "▮▮▮▮"
+        # alternative with reversed string and no RTL override:
+        # assert unicode(self.debug.rewrite_nsa("Test")) == "ʇsǝ⊥"
+        # Chars < ! and > z are returned as is
+        assert str(self.debug.rewrite_nsa(" ")) == " "
+        assert str(self.debug.rewrite_nsa("©")) == "©"
+
+    @staticmethod
+    def test_rewrite_nsa_preserves_at_placeholders():
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert str(debug.rewrite_nsa("@@ph@@Test @@ph@@")) == "@@ph@@▮▮▮▮ @@ph@@"
+
+    @staticmethod
+    def test_rewrite_nsa_preserves_single_brace_placeholders():
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert str(debug.rewrite_nsa("{ph}Test {ph}")) == "{ph}▮▮▮▮ {ph}"
+
+    @staticmethod
+    def test_rewrite_nsa_preserves_double_brace_placeholders():
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert str(debug.rewrite_nsa("{{ph}}Test {{ph}}")) == "{{ph}}▮▮▮▮ {{ph}}"
+
+    @staticmethod
+    def test_rewrite_nsa_preserves_html():
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert (
+            str(debug.rewrite_nsa("<style0>Test </style0>")) == "<style0>▮▮▮▮ </style0>"
+        )
+
+    @staticmethod
+    def test_rewrite_nsa_multiple_styles_of_placeholder():
+        """Test the unicode rewrite function"""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert (
+            str(debug.rewrite_nsa("<b>{{ph}}Test{ph}@@ph@@Test</b>"))
+            == "<b>{{ph}}▮▮▮▮{ph}@@ph@@▮▮▮▮</b>"
+        )
+
     def test_rewrite_chef(self):
         """Test the chef rewrite function
 


### PR DESCRIPTION
Looking for a tool to test my translation I found (remind) podebug with rewriter was a really good tool.
But It was missing an option to spot strings that have not been integrated yet.
I tried with Chef and Flipped, but it was still not enough obvious.

That's why I created the NSA rewriters 

Based on flipped it keeps variables but obfuscates all alphanumeric characters with a black square 

Perhaps it can serve the community, so I made this PR...