### PR TITLE
dist: Include doc theme in dist manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@
 /build/
 /dist/
 MANIFEST
-MANIFEST.in
 
 
 # Requirements generation

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+# Needs manual listing until setuptools_scm support submodules
+# See https://github.com/pypa/setuptools_scm/issues/206
+include docs/_themes/README.rst
+include docs/_themes/sphinx-bootstrap/*.html
+include docs/_themes/sphinx-bootstrap/theme.conf
+recursive-include docs/_themes/sphinx-bootstrap/static/ *.*


### PR DESCRIPTION
The setuptools_scm does not automatically include submodules, so we have to do that manually for now.

See https://github.com/pypa/setuptools_scm/issues/206

Fixes #4744