### PR TITLE
feat: avoid xml self-closing tags

### DIFF
--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -362,7 +362,7 @@ class LISAfile(base.TranslationStore):
             )
         else:
             if self.XMLdoctype:
-                out.write(b"" + self.XMLdoctype + "\n")
+                out.write(f"{self.XMLdoctype}\n".encode(self.encoding))
             stream = io.BytesIO()
             ElementTree(root).write(
                 stream,

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -333,11 +333,29 @@ class LISAfile(base.TranslationStore):
     def serialize(self, out=None):
         """Converts to a string containing the file's XML"""
         root = self.document.getroot()
+        xml_declaration = ""
+
         if self.XMLdoublequotes:
             if self.XMLuppercaseEncoding:
-                out.write(b'<?xml version="1.0" encoding="UTF-8"?>\n')
+                xml_declaration = (
+                    '<?xml version="1.0" encoding="' + self.encoding.upper() + '"?>\n'
+                )
             else:
-                out.write(b'<?xml version="1.0" encoding="utf-8"?>\n')
+                xml_declaration = (
+                    '<?xml version="1.0" encoding="' + self.encoding.lower() + '"?>\n'
+                )
+        else:
+            if self.XMLuppercaseEncoding:
+                xml_declaration = (
+                    "<?xml version='1.0' encoding='" + self.encoding.upper() + "'?>\n"
+                )
+            else:
+                xml_declaration = (
+                    "<?xml version='1.0' encoding='" + self.encoding.lower() + "'?>\n"
+                )
+
+        out.write(xml_declaration.encode(self.encoding))
+
         if self.XMLindent:
             reindent(root, **self.XMLindent)
         # When XMLSelfClosingTags flag is active, relay
@@ -347,18 +365,16 @@ class LISAfile(base.TranslationStore):
             treestring = etree.tostring(
                 self.document,
                 pretty_print=not self.XMLindent,
-                xml_declaration=not self.XMLdoublequotes,
                 encoding=self.encoding,
                 doctype=self.XMLdoctype,
             )
         else:
             if self.XMLdoctype:
-                out.write(b'' + self.XMLdoctype + '\n')
+                out.write(b"" + self.XMLdoctype + "\n")
             ElementTree.register_namespace("", self.namespace)
             treestring = ElementTree.tostring(
                 root,
                 encoding=self.encoding,
-                xml_declaration=not self.XMLdoublequotes,
                 short_empty_elements=False,
             )
         treestring = self.serialize_hook(treestring)

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -333,26 +333,16 @@ class LISAfile(base.TranslationStore):
     def serialize(self, out=None):
         """Converts to a string containing the file's XML"""
         root = self.document.getroot()
-        xml_declaration = ""
+        xml_quote_format = "'"
+        xml_encoding = self.encoding.lower()
 
         if self.XMLdoublequotes:
-            if self.XMLuppercaseEncoding:
-                xml_declaration = (
-                    '<?xml version="1.0" encoding="' + self.encoding.upper() + '"?>\n'
-                )
-            else:
-                xml_declaration = (
-                    '<?xml version="1.0" encoding="' + self.encoding.lower() + '"?>\n'
-                )
-        else:
-            if self.XMLuppercaseEncoding:
-                xml_declaration = (
-                    "<?xml version='1.0' encoding='" + self.encoding.upper() + "'?>\n"
-                )
-            else:
-                xml_declaration = (
-                    "<?xml version='1.0' encoding='" + self.encoding.lower() + "'?>\n"
-                )
+            xml_quote_format = '"'
+
+        if self.XMLuppercaseEncoding:
+            xml_encoding = self.encoding.upper()
+
+        xml_declaration = f"<?xml version={xml_quote_format}1.0{xml_quote_format} encoding={xml_quote_format}{xml_encoding}{xml_quote_format}?>\n"
 
         out.write(xml_declaration.encode(self.encoding))
 

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -18,6 +18,7 @@
 
 """Parent class for LISA standards (TMX, TBX, XLIFF)"""
 
+import io
 from xml.etree import ElementTree
 
 from lxml import etree
@@ -362,12 +363,9 @@ class LISAfile(base.TranslationStore):
         else:
             if self.XMLdoctype:
                 out.write(b"" + self.XMLdoctype + "\n")
-            ElementTree.register_namespace("", self.namespace)
-            treestring = ElementTree.tostring(
-                root,
-                encoding=self.encoding,
-                short_empty_elements=False,
-            )
+            stream = io.BytesIO()
+            ElementTree(root).write(stream, self.encoding, short_empty_elements=False)
+            treestring = stream.getvalue()
         treestring = self.serialize_hook(treestring)
         out.write(treestring)
 

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -364,7 +364,12 @@ class LISAfile(base.TranslationStore):
             if self.XMLdoctype:
                 out.write(b"" + self.XMLdoctype + "\n")
             stream = io.BytesIO()
-            ElementTree(root).write(stream, self.encoding, short_empty_elements=False)
+            ElementTree(root).write(
+                stream,
+                self.encoding,
+                short_empty_elements=False,
+                default_namespace=self.namespace,
+            )
             treestring = stream.getvalue()
         treestring = self.serialize_hook(treestring)
         out.write(treestring)

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -355,6 +355,7 @@ class LISAfile(base.TranslationStore):
             treestring = etree.tostring(
                 self.document,
                 pretty_print=not self.XMLindent,
+                xml_declaration=False,
                 encoding=self.encoding,
                 doctype=self.XMLdoctype,
             )

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -364,13 +364,15 @@ class LISAfile(base.TranslationStore):
             if self.XMLdoctype:
                 out.write(f"{self.XMLdoctype}\n".encode(self.encoding))
             stream = io.BytesIO()
-            ElementTree(root).write(
+
+            ElementTree.register_namespace("", self.namespace)
+            ElementTree.ElementTree(root).write(
                 stream,
                 self.encoding,
                 short_empty_elements=False,
-                default_namespace=self.namespace,
             )
             treestring = stream.getvalue()
+
         treestring = self.serialize_hook(treestring)
         out.write(treestring)
 

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -670,4 +670,4 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 
         a = BytesIO()
         xlifffile.serialize(a)
-        assert a.getvalue().decode('utf-8') == f"{xlfsource}"
+        assert a.getvalue().decode("utf-8") == f"{xlfsource}"

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -668,6 +668,4 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         xlifffile.XMLSelfClosingTags = False
         xlifffile.XMLuppercaseEncoding = False
 
-        a = BytesIO()
-        xlifffile.serialize(a)
-        assert a.getvalue().decode("utf-8") == f"{xlfsource}"
+        assert bytes(xlifffile).decode("utf-8") == xlfsource

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+
 from lxml import etree
 
 from translate.misc.xml_helpers import setXMLspace
@@ -643,3 +645,29 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         xfile.units[0].target = "H  E"
         newfile = xliff.xlifffile.parsestring(bytes(xfile))
         assert newfile.units[0].target == "H  E"
+
+    @staticmethod
+    def test_closing_tags():
+        xlfsource = """<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="en-US" original="Email - SMTP API">
+    <body>
+      <group id="body">
+        <trans-unit id="Codeunit 270637162 - NamedType 3430817766" maxwidth="0" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Please connect to a server first.</source>
+          <target state="translated">Please connect to a server first.</target>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Codeunit MailKit Client - NamedType ServerNotConnectedErr</note>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>
+"""
+        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile.XMLSelfClosingTags = False
+        xlifffile.XMLuppercaseEncoding = False
+
+        a = BytesIO()
+        xlifffile.serialize(a)
+        assert a.getvalue().decode('utf-8') == f"{xlfsource}"


### PR DESCRIPTION
Business Central is not using self-closing tags while generating and maintaining XLIFF files.

As a result, when used together with Weblate, there are huge diff which are generated after captions beeing translated - often leading to invalid merge conflict. In order to avoid this case, we swap serialize library from LXML to standard Xml which allow us to skip self-closing tag when an element is empty using `short_empty_elements` parameter from the ToString helper.

Example :
- https://github.com/StefanMaron/MSDyn365BC.Code.History/tree/fr-20/Email%20-%20Current%20User%20Connector/Source/Email%20-%20Current%20User%20Connector/Translations (especially with `note` tag)

Related to rvanbekkum/vsc-xliff-sync#97
Related to WeblateOrg/weblate#8352