### PR TITLE
json: Improve handling of mixed indices

### DIFF
--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -960,11 +960,14 @@ class DictUnit(TranslationUnit):
         super().__init__(source)
         self._unitid = None
 
-    def storevalue(self, output, value, override_key=None, unset=False):
-        parent = target = output
+    def get_unitid(self):
         if self._unitid is None:
             self._unitid = self.IdClass.from_string(self._id)
-        parts = self._unitid.parts
+        return self._unitid
+
+    def storevalue(self, output, value, override_key=None, unset=False):
+        parent = target = output
+        parts = self.get_unitid().parts
         key = None
         for pos, part in enumerate(parts[:-1]):
             element, key = part
@@ -1029,7 +1032,9 @@ class DictUnit(TranslationUnit):
 
 class DictStore(TranslationStore):
     def get_root_node(self):
-        if self.units and self.units[0].getid().startswith("["):
+        if self.units and all(
+            unit.get_unitid().parts[0][0] == "index" for unit in self.units
+        ):
             return []
         return OrderedDict()
 

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -235,6 +235,35 @@ class TestJSONResourceStore(test_monolingual.TestMonolingualStore):
         assert str(unit) == expected.strip()
         assert bytes(store).decode() == expected
 
+    def test_add_list_like(self):
+        store = self.StoreClass()
+
+        unit = self.StoreClass.UnitClass("source")
+        unit.setid("[0]")
+        store.addunit(unit)
+
+        unit = self.StoreClass.UnitClass("source2")
+        unit.setid("key")
+        store.addunit(unit)
+
+        assert (
+            bytes(store).decode()
+            == """{
+    "[0]": "source",
+    "key": "source2"
+}
+"""
+        )
+        unit.setid("[1]")
+        assert (
+            bytes(store).decode()
+            == """{
+    "[0]": "source",
+    "[1]": "source2"
+}
+"""
+        )
+
     def test_add_blank(self):
         expected = """{
     "simple.key": "source"
@@ -295,6 +324,10 @@ class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):
     def test_array(self):
         store = self.StoreClass()
         store.parse(JSON_ARRAY)
+
+        assert store.units[0].source == "One"
+        assert store.units[0].getid() == ".key[0]"
+        assert store.units[1].getid() == ".key[1]"
 
         out = BytesIO()
         store.serialize(out)


### PR DESCRIPTION
- Improve detection of the root node to look at actual parsed unitis instead of examining strings ids. This makes the behavior consistent with behavior possibly overridden UnitId subclasses.
- Extend JSON tests to cover more complex adding behavior.
- Include unitid parsing in the DictUnit API to make it reusable.