### PR TITLE
chore: Remove OrderedDict usage

### DIFF
--- a/translate/lang/el.py
+++ b/translate/lang/el.py
@@ -23,7 +23,6 @@
 
 
 import re
-from collections import OrderedDict
 
 from translate.lang import common
 
@@ -46,12 +45,10 @@ class el(common.Common):
         re.VERBOSE | re.UNICODE,
     )
 
-    puncdict = OrderedDict(
-        [
-            (";", "·"),
-            ("?", ";"),
-        ]
-    )
+    puncdict = {
+        ";": "·",
+        "?": ";",
+    }
 
     # Valid latin characters for use as accelerators
     valid_latin_accel = (

--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -23,7 +23,6 @@ import os.path
 import re
 import sys
 import traceback
-from collections import OrderedDict
 from io import BytesIO
 
 from translate import __version__
@@ -31,15 +30,13 @@ from translate.misc import progressbar
 
 
 class ProgressBar:
-    progress_types = OrderedDict(
-        [
-            ("dots", progressbar.DotsProgressBar),
-            ("none", progressbar.NoProgressBar),
-            ("bar", progressbar.HashProgressBar),
-            ("names", progressbar.MessageProgressBar),
-            ("verbose", progressbar.VerboseProgressBar),
-        ]
-    )
+    progress_types = {
+        "dots": progressbar.DotsProgressBar,
+        "none": progressbar.NoProgressBar,
+        "bar": progressbar.HashProgressBar,
+        "names": progressbar.MessageProgressBar,
+        "verbose": progressbar.VerboseProgressBar,
+    }
 
     def __init__(self, progress_type, allfiles):
         """Set up a progress bar appropriate to the progress_type and files."""

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -21,7 +21,6 @@
 import codecs
 import logging
 import pickle
-from collections import OrderedDict
 from io import BytesIO
 from typing import List, Optional, Tuple
 
@@ -954,7 +953,6 @@ class UnitId:
 
 class DictUnit(TranslationUnit):
     IdClass = UnitId
-    DefaultDict = OrderedDict
 
     def __init__(self, source=None):
         super().__init__(source)
@@ -972,7 +970,7 @@ class DictUnit(TranslationUnit):
         for pos, part in enumerate(parts[:-1]):
             element, key = part
             use_list = parts[pos + 1][0] == "index"
-            default = [] if use_list else self.DefaultDict()
+            default = [] if use_list else {}
             if element == "index":
                 while len(target) <= key and not unset:
                     target.append(default.copy())
@@ -1036,7 +1034,7 @@ class DictStore(TranslationStore):
             unit.get_unitid().parts[0][0] == "index" for unit in self.units
         ):
             return []
-        return OrderedDict()
+        return {}
 
     def serialize_units(self, output):
         for unit in self.unit_iter():

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -68,7 +68,6 @@ TODO:
 
 import json
 import uuid
-from collections import OrderedDict
 
 from translate.lang.data import cldr_plural_categories, plural_tags
 from translate.misc.multistring import multistring
@@ -232,7 +231,7 @@ class JsonFile(base.DictStore):
             if input is None:
                 raise base.ParseError(ValueError("Failed to decode JSON string."))
         try:
-            self._file = json.loads(input, object_pairs_hook=OrderedDict)
+            self._file = json.loads(input)
         except ValueError as e:
             raise base.ParseError(e)
 
@@ -253,7 +252,7 @@ class JsonNestedFile(JsonFile):
 
 class WebExtensionJsonUnit(BaseJsonUnit):
     def storevalues(self, output):
-        value = OrderedDict((("message", self.target),))
+        value = {"message": self.target}
         if self.notes:
             value["description"] = self.notes
         if self.placeholders:
@@ -418,13 +417,11 @@ class GoI18NJsonUnit(BaseJsonUnit):
             strings = list(target.strings)
             if len(self._store.plural_tags) > len(target.strings):
                 strings += [""] * (len(self._store.plural_tags) - len(target.strings))
-            target = OrderedDict(
-                [
-                    (plural, strings[offset])
-                    for offset, plural in enumerate(self._store.plural_tags)
-                ]
-            )
-        value = OrderedDict((("id", self.getid()),))
+            target = {
+                plural: strings[offset]
+                for offset, plural in enumerate(self._store.plural_tags)
+            }
+        value = {"id": self.getid()}
         if self.notes:
             value["description"] = self.notes
         value["translation"] = target
@@ -544,9 +541,7 @@ class ARBJsonFile(JsonFile):
         last_node=None,
     ):
         # Extract metadata as header
-        metadata = OrderedDict(
-            [(key, value) for key, value in data.items() if key.startswith("@@")]
-        )
+        metadata = {key: value for key, value in data.items() if key.startswith("@@")}
         if metadata:
             unit = self.UnitClass(metadata=metadata)
             unit.setid("@")

--- a/translate/storage/poheader.py
+++ b/translate/storage/poheader.py
@@ -20,7 +20,6 @@
 
 import re
 import time
-from collections import OrderedDict
 
 from translate import __version__
 from translate.misc.dictutils import cidict
@@ -41,7 +40,7 @@ def parseheaderstring(input):
     """Parses an input string with the definition of a PO header and returns
     the interpreted values as a dictionary.
     """
-    headervalues = OrderedDict()
+    headervalues = {}
     for line in input.split("\n"):
         if not line or ":" not in line:
             continue
@@ -74,7 +73,7 @@ def update(existing, add=False, **kwargs):
     :return: Updated dictionary of header entries
     :rtype: dict of strings
     """
-    headerargs = OrderedDict()
+    headerargs = {}
     fixedargs = cidict()
     for key, value in kwargs.items():
         key = key.replace("_", "-")
@@ -182,7 +181,7 @@ class poheader:
         if report_msgid_bugs_to is None:
             report_msgid_bugs_to = ""
 
-        defaultargs = OrderedDict()
+        defaultargs = {}
         defaultargs["Project-Id-Version"] = project_id_version
         defaultargs["Report-Msgid-Bugs-To"] = report_msgid_bugs_to
         defaultargs["POT-Creation-Date"] = pot_creation_date

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -126,7 +126,6 @@ Name and Value pairs:
 
 """
 
-import collections
 import re
 from codecs import iterencode
 from copy import deepcopy
@@ -565,7 +564,7 @@ class proppluralunit(base.TranslationUnit):
         """Construct a blank propunit."""
         self.personality = get_dialect(personality)
         super().__init__(source)
-        self.units = collections.OrderedDict()
+        self.units = {}
         self.name = ""
 
     @staticmethod

--- a/translate/storage/stringsdict.py
+++ b/translate/storage/stringsdict.py
@@ -1,7 +1,6 @@
 import os
 import plistlib
 import re
-from collections import OrderedDict
 
 from translate.lang import data
 from translate.misc.multistring import multistring
@@ -126,9 +125,9 @@ class StringsDictFile(base.DictStore):
         """Read a .stringsdict file into a dictionary, and convert it to translation units."""
 
         if isinstance(input, (bytes, str)):
-            plist = plistlib.loads(input, dict_type=OrderedDict)
+            plist = plistlib.loads(input)
         elif input is not None:
-            plist = plistlib.load(input, dict_type=OrderedDict)
+            plist = plistlib.load(input)
         else:
             plist = {}
 
@@ -160,17 +159,17 @@ class StringsDictFile(base.DictStore):
                     raise ValueError(f"Unexpected key {innerkey} in {key}")
 
     def serialize(self, out):
-        plist = OrderedDict()
+        plist = {}
 
         for u in self.units:
             loc = u.outerkey
             subkey = u.innerkey
 
             if loc not in plist:
-                plist[loc] = OrderedDict()
+                plist[loc] = {}
 
             if subkey is not None:
-                plurals = OrderedDict()
+                plurals = {}
                 plurals["NSStringFormatSpecTypeKey"] = "NSStringPluralRuleType"
                 plurals["NSStringFormatValueTypeKey"] = u.format_value_type
 

--- a/translate/storage/test_poheader.py
+++ b/translate/storage/test_poheader.py
@@ -1,6 +1,5 @@
 import os
 import time
-from collections import OrderedDict
 from io import BytesIO
 
 from translate.storage import po, poheader, poxliff
@@ -38,7 +37,7 @@ def test_update():
     d = poheader.update({}, add=True, test_me="hello")
     assert d["Test-Me"] == "hello"
     # is the order correct ?
-    d = OrderedDict()
+    d = {}
     d["Project-Id-Version"] = "abc"
     d["POT-Creation-Date"] = "now"
     d = poheader.update(d, add=True, Test="hello", Report_Msgid_Bugs_To="bugs@list.org")

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -45,7 +45,6 @@ class YAMLUnit(base.DictUnit):
     """A YAML entry"""
 
     IdClass = YAMLUnitId
-    DefaultDict = dict
 
     def __init__(self, source=None, **kwargs):
         # Ensure we have ID (for serialization)


### PR DESCRIPTION
Since Python 3.7 the dict is guaranteed to be ordered as well.