### PR TITLE
json: Allow overwriting integer with a string

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -125,10 +125,10 @@ class BaseJsonUnit(base.DictUnit):
         )
 
     def converttarget(self):
-        if issubclass(self._type, str):
-            return self.target
-        else:
+        try:
             return self._type(self.target)
+        except ValueError:
+            return str(self.target)
 
     def storevalues(self, output):
         self.storevalue(output, self.converttarget())

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -282,6 +282,29 @@ class TestJSONResourceStore(test_monolingual.TestMonolingualStore):
         assert str(unit) == expected.strip()
         assert bytes(store).decode() == expected
 
+    def test_types(self):
+        store = self.StoreClass()
+        store.parse('{"key": 1}')
+        assert store.units[0].target == 1
+        store.units[0].target = 2
+
+        assert (
+            bytes(store).decode()
+            == """{
+    "key": 2
+}
+"""
+        )
+        store.units[0].target = "two"
+
+        assert (
+            bytes(store).decode()
+            == """{
+    "key": "two"
+}
+"""
+        )
+
 
 class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):
     StoreClass = jsonl10n.JsonNestedFile


### PR DESCRIPTION
Sometimes number is intended to be a string in the JSON file and it is reasonable to translate it.