### PR TITLE
feat(lisa): avoid xml self-closing tags

### DIFF
--- a/translate/misc/xml_helpers.py
+++ b/translate/misc/xml_helpers.py
@@ -184,6 +184,23 @@ def reindent(
             elem.tail = i
 
 
+def expand_closing_tags(elem):
+    """
+    Changes value of empty XML tags to empty string.
+
+    This changes lxml behavior to render these tags as
+    <tag></tag> instead of <tag />
+    """
+    elements = [elem]
+    while elements:
+        elem = elements.pop()
+        if elem.tag is etree.Entity:
+            continue
+        if elem.text is None:
+            elem.text = ""
+        elements.extend(elem)
+
+
 def validate_char(char: str) -> bool:
     """
     identify valid chars for XML, based on xmlIsChar_ch from

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -643,3 +643,27 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         xfile.units[0].target = "H  E"
         newfile = xliff.xlifffile.parsestring(bytes(xfile))
         assert newfile.units[0].target == "H  E"
+
+    @staticmethod
+    def test_closing_tags():
+        xlfsource = """<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="en-US" original="Email - SMTP API">
+    <body>
+      <group id="body">
+        <trans-unit id="Codeunit 270637162 - NamedType 3430817766" maxwidth="0" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Please connect to a server first.</source>
+          <target state="translated">Please connect to a server first.</target>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Codeunit MailKit Client - NamedType ServerNotConnectedErr</note>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>
+"""
+        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile.XMLSelfClosingTags = False
+        xlifffile.XMLuppercaseEncoding = False
+
+        assert bytes(xlifffile).decode("utf-8") == xlfsource


### PR DESCRIPTION
- ability to override the XML format for XLIFF files
- self-closing tag is set to true by default to prevent conflict with current implementation
- capability will be defer to Weblate as XLIFF Addon like JSON Format (https://docs.weblate.org/en/latest/admin/addons.html#customize-json-output)
- always generate XML declaration in translate-toolkit for consistency

Co-authored-by: Michal Čihař <michal@cihar.com>