### PR TITLE
fluent: Raise error on parse error

### DIFF
--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -98,13 +98,6 @@ class FluentUnit(base.TranslationUnit):
         return self._placeables
 
     def parse(self, entry):
-        # Handle this unit separately if it is invalid.
-        if isinstance(entry, ast.Junk):
-            for annotation in entry.annotations:
-                self.adderror(annotation.code, annotation.message)
-            self._set_value(entry.content)
-            return
-
         this = self
 
         class Parser(visitor.Visitor):
@@ -202,6 +195,13 @@ class FluentFile(base.TranslationStore):
     def parse(self, fluentsrc):
         resource = parse(fluentsrc.decode("utf-8"))
         for entry in resource.body:
+            # Handle this unit separately if it is invalid.
+            if isinstance(entry, ast.Junk):
+                for annotation in entry.annotations:
+                    raise ValueError(
+                        f"{annotation.code}: {annotation.message} [offset {annotation.span.start}]"
+                    )
+
             self.addunit(FluentUnit(entry=entry))
 
     def serialize(self, out):

--- a/translate/storage/test_fluent.py
+++ b/translate/storage/test_fluent.py
@@ -18,6 +18,8 @@
 
 from io import BytesIO
 
+from pytest import raises
+
 from translate.storage import fluent, test_monolingual
 
 
@@ -181,20 +183,8 @@ creating-page-wait-message = Saving your shot…
         fluent_source = """valid-unit = I'm great!
 = I'm not.
 """
-        fluent_file = self.fluent_parse(fluent_source)
-        assert len(fluent_file.units) == 2
-
-        fluent_valid_unit = fluent_file.units[0]
-        assert fluent_valid_unit.getid() == "valid-unit"
-        assert fluent_valid_unit.source == "I'm great!"
-        assert fluent_valid_unit.geterrors() == {}
-
-        fluent_invalid_unit = fluent_file.units[1]
-        assert fluent_invalid_unit.getid() is None
-        assert fluent_invalid_unit.source == "= I'm not.\n"
-        assert fluent_invalid_unit.geterrors() == {
-            "E0002": "Expected an entry start",
-        }
+        with raises(ValueError):
+            self.fluent_parse(fluent_source)
 
     def test_attributes(self):
         """Checks that we handle attributes."""


### PR DESCRIPTION
This is consistent with other formats - if file can not be parsed, an error is raised instead of working on incomplete data.

Fixes #4615