### PR TITLE
json: Fix setid behavior for plural JSON units

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -111,6 +111,8 @@ class BaseJsonUnit(base.DictUnit):
     def setid(self, value):
         self._id = value
         self._unitid = None
+        self.get_unitid()
+        self._item = self._unitid.parts[-1][1]
 
     def getid(self):
         return self._id
@@ -297,12 +299,7 @@ class I18NextUnit(JsonNestedUnit):
     See https://www.i18next.com/
     """
 
-    @property
-    def target(self):
-        return self._target
-
-    @target.setter
-    def target(self, target):
+    def _fixup_item(self):
         def get_base(item):
             """Return base name for plurals"""
             if "_0" in item[0]:
@@ -315,8 +312,8 @@ class I18NextUnit(JsonNestedUnit):
                 return [base, base + "_plural"][:count]
             return [f"{base}_{i}" for i in range(count)]
 
-        if isinstance(target, multistring):
-            count = len(target.strings)
+        if isinstance(self._target, multistring):
+            count = len(self._target.strings)
             if not isinstance(self._item, list):
                 self._item = [self._item]
             if count != len(self._item):
@@ -326,8 +323,19 @@ class I18NextUnit(JsonNestedUnit):
             # Changing plural to singular
             self._item = get_base(self._item)
 
+    def setid(self, value):
+        super().setid(value)
+        self._fixup_item()
+
+    @property
+    def target(self):
+        return self._target
+
+    @target.setter
+    def target(self, target):
         self._rich_target = None
         self._target = target
+        self._fixup_item()
 
     def storevalues(self, output):
         if not isinstance(self.target, multistring):

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -6,7 +6,7 @@ from translate.misc.multistring import multistring
 from translate.storage import base, jsonl10n, test_monolingual
 
 
-JSON_I18NEXT = b"""{
+JSON_I18NEXT = """{
     "key": "value",
     "keyDeep": {
         "inner": "value"
@@ -557,7 +557,7 @@ class TestI18NextStore(test_monolingual.TestMonolingualStore):
         out = BytesIO()
         store.serialize(out)
 
-        assert out.getvalue() == JSON_I18NEXT
+        assert out.getvalue().decode() == JSON_I18NEXT
 
     def test_units(self):
         store = self.StoreClass()
@@ -596,7 +596,7 @@ class TestI18NextStore(test_monolingual.TestMonolingualStore):
         out = BytesIO()
         store.serialize(out)
 
-        assert out.getvalue() == JSON_I18NEXT
+        assert out.getvalue().decode() == JSON_I18NEXT
 
     def test_nested_array(self):
         store = self.StoreClass()
@@ -611,9 +611,11 @@ class TestI18NextStore(test_monolingual.TestMonolingualStore):
         assert bytes(store).decode() == JSON_I18NEXT_NESTED_ARRAY
 
     def test_new_plural(self):
-        EXPECTED = b"""{
+        EXPECTED = """{
     "simple": "the singular",
     "simple_plural": "the plural",
+    "simple2": "the singular",
+    "simple2_plural": "the plural",
     "complex_0": "the plural form 0",
     "complex_1": "the plural form 1",
     "complex_2": "the plural form 2",
@@ -638,6 +640,17 @@ class TestI18NextStore(test_monolingual.TestMonolingualStore):
         unit = self.StoreClass.UnitClass(
             multistring(
                 [
+                    "the singular",
+                    "the plural",
+                ]
+            ),
+        )
+        unit.setid("simple2")
+        store.addunit(unit)
+
+        unit = self.StoreClass.UnitClass(
+            multistring(
+                [
                     "the plural form 0",
                     "the plural form 1",
                     "the plural form 2",
@@ -653,7 +666,7 @@ class TestI18NextStore(test_monolingual.TestMonolingualStore):
         out = BytesIO()
         store.serialize(out)
 
-        assert out.getvalue() == EXPECTED
+        assert out.getvalue().decode() == EXPECTED
 
 
 class TestGoI18NJsonFile(test_monolingual.TestMonolingualStore):


### PR DESCRIPTION
The random identifier was not overwritten in this case, causing the files having keys like 0x15986331a172306b instead of the actual value.