### PR TITLE
stringsdict: Fix crash on adding new string

### DIFF
--- a/translate/storage/stringsdict.py
+++ b/translate/storage/stringsdict.py
@@ -49,14 +49,18 @@ class StringsDictUnit(base.DictUnit):
 
     @property
     def outerkey(self):
-        if self._unitid is None or len(self._unitid.parts) < 1:
+        self.get_unitid()
+
+        if len(self._unitid.parts) < 1:
             return None
 
         return self._unitid.parts[0][1]
 
     @property
     def innerkey(self):
-        if self._unitid is None or len(self._unitid.parts) < 2:
+        self.get_unitid()
+
+        if len(self._unitid.parts) < 2:
             return None
 
         return self._unitid.parts[1][1]

--- a/translate/storage/test_stringsdict.py
+++ b/translate/storage/test_stringsdict.py
@@ -163,9 +163,23 @@ class TestStringsDictFile(test_monolingual.TestMonolingualStore):
         unit.target = multistring(lang[1])
         store.addunit(unit)
 
-        bytes = BytesIO()
-        store.serialize(bytes)
-        bytes.seek(0)
+        bytes_io = BytesIO()
+        store.serialize(bytes_io)
+        bytes_io.seek(0)
 
-        plist = plistlib.load(bytes)
+        plist = plistlib.load(bytes_io)
         assert plist["item"]["p"]["zero"]
+
+    def test_add_unit(self):
+        store = self.StoreClass()
+
+        unit = store.UnitClass("item")
+        unit.setid("item")
+        unit.target = "test target"
+        store.addunit(unit)
+
+        content = bytes(store)
+
+        store2 = self.StoreClass()
+        store2.parse(content)
+        assert store2.units[0].target == "test target"


### PR DESCRIPTION
This is caused by setid not updateing _unitid (what is desired). The caller needs to call get_unitid prior that.