### PR TITLE
i18next: Improve plural handling

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -322,16 +322,17 @@ class I18NextUnit(JsonNestedUnit):
 
     def _get_plural_labels(self, count):
         base_name = self._get_base_name()
-        if count <= 2:
+        if count == 2:
             return [base_name, base_name + "_plural"][:count]
         return [f"{base_name}_{i}" for i in range(count)]
 
     def _fixup_item(self):
         if isinstance(self._target, multistring):
             count = len(self._target.strings)
-            if not isinstance(self._item, list):
-                self._item = [self._item]
-            if count != len(self._item):
+            is_list = isinstance(self._item, list)
+            if not is_list or count != len(self._item):
+                if not is_list:
+                    self._item = [self._item]
                 # Generate new plural labels
                 self._item = self._get_plural_labels(count)
         elif isinstance(self._item, list):
@@ -442,8 +443,6 @@ class I18NextV4Unit(I18NextUnit):
 
     def _get_plural_labels(self, count):
         base_name = self._get_base_name()
-        if count <= 2:
-            return [base_name + "_one", base_name + "_other"][:count]
         return [f"{base_name}_{self._store.plural_tags[i]}" for i in range(count)]
 
 
@@ -490,10 +489,8 @@ class I18NextV4File(JsonNestedFile):
                     sources = []
                     items = []
                     for key in plurals:
-                        if key not in data:
-                            continue
                         processed.add(key)
-                        sources.append(data[key])
+                        sources.append(data.get(key, ""))
                         items.append(key)
 
                     unit = self.UnitClass(multistring(sources), items)

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -38,6 +38,25 @@ JSON_I18NEXT_V4 = """{
 }
 """
 
+JSON_I18NEXT_V4_FIXED = """{
+    "key": "value",
+    "keyDeep": {
+        "inner": "value"
+    },
+    "keyPluralSimple_zero": "",
+    "keyPluralSimple_one": "the singular",
+    "keyPluralSimple_two": "",
+    "keyPluralSimple_few": "",
+    "keyPluralSimple_many": "",
+    "keyPluralSimple_other": "the plural",
+    "keyPluralMultipleEgArabic_zero": "the plural form 0",
+    "keyPluralMultipleEgArabic_one": "the plural form 1",
+    "keyPluralMultipleEgArabic_two": "the plural form 2",
+    "keyPluralMultipleEgArabic_few": "the plural form 3",
+    "keyPluralMultipleEgArabic_many": "the plural form 4",
+    "keyPluralMultipleEgArabic_other": "the plural form 5"
+}
+"""
 
 JSON_I18NEXT_PLURAL = b"""{
     "key": "value",
@@ -747,6 +766,26 @@ class TestI18NextStore(test_monolingual.TestMonolingualStore):
 
         assert out.getvalue().decode() == EXPECTED
 
+    def test_new_plural_id(self):
+        EXPECTED = """{
+    "simple_0": "the singular"
+}
+"""
+        store = self.StoreClass()
+        store.settargetlanguage("id")
+
+        unit = self.StoreClass.UnitClass(
+            multistring(
+                [
+                    "the singular",
+                ]
+            ),
+            "simple",
+        )
+        store.addunit(unit)
+
+        assert bytes(store).decode() == EXPECTED
+
 
 class TestGoTextJsonFile(test_monolingual.TestMonolingualStore):
     StoreClass = jsonl10n.GoTextJsonFile
@@ -782,7 +821,8 @@ class TestI18NextV4Store(test_monolingual.TestMonolingualStore):
         out = BytesIO()
         store.serialize(out)
 
-        assert out.getvalue().decode() == JSON_I18NEXT_V4
+        # This will add missing plurals
+        assert out.getvalue().decode() == JSON_I18NEXT_V4_FIXED
 
     def test_units(self):
         store = self.StoreClass()
@@ -807,7 +847,11 @@ class TestI18NextV4Store(test_monolingual.TestMonolingualStore):
         store.settargetlanguage("ar")
         store.units[2].target = multistring(
             [
+                "",
                 "the singular",
+                "",
+                "",
+                "",
                 "the plural",
             ]
         )
@@ -825,7 +869,7 @@ class TestI18NextV4Store(test_monolingual.TestMonolingualStore):
         out = BytesIO()
         store.serialize(out)
 
-        assert out.getvalue().decode() == JSON_I18NEXT_V4
+        assert out.getvalue().decode() == JSON_I18NEXT_V4_FIXED
 
     def test_nested_array(self):
         store = self.StoreClass()
@@ -841,8 +885,8 @@ class TestI18NextV4Store(test_monolingual.TestMonolingualStore):
 
     def test_new_plural(self):
         EXPECTED = """{
-    "simple_one": "the singular",
-    "simple_other": "the plural",
+    "simple_zero": "the singular",
+    "simple_one": "the plural",
     "complex_zero": "the plural form 0",
     "complex_one": "the plural form 1",
     "complex_two": "the plural form 2",


### PR DESCRIPTION
- v3 stores with _0 suffix in the one plural case
- v4 parses missing plurals correctly (keeps the string positions)