### PR TITLE
Refactor Fluent parsing and serializing

### DIFF
--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -22,163 +22,425 @@ It is a monolingual base class derived format with :class:`FluentFile`
 and :class:`FluentUnit` providing file and unit level access.
 """
 
-from fluent.syntax import FluentParser, ast, parse, serialize, visitor
-from fluent.syntax.serializer import serialize_pattern, serialize_placeable
-from fluent.syntax.stream import FluentParserStream
+import re
+import textwrap
+
+from fluent.syntax import FluentSerializer, ast, parse, serialize, visitor
 
 from translate.storage import base
 
 
-def id_from_source(source):
-    # If the caller does not provide a unit ID, we need to generate one
-    # ourselves. A valid Fluent identifier has the following EBNF grammar:
-    #     Identifier          ::= [a-zA-Z] [a-zA-Z0-9_-]*
-    #
-    # This means we can't simply use the source string itself as the identifier
-    # (as e.g. PO files do). Instead, we hash the source string with a
-    # collision-resistant hash function.
-    import hashlib
-
-    return "gen-" + hashlib.sha256(source.encode()).hexdigest()
-
-
-def source_from_entry(entry):
-    # Serialized patterns come in two forms:
-    # - Single-line patterns, which have a leading space we need to strip (for
-    #   consistency with the expectations of what callers will set).
-    # - Multiline patterns, which have a leading newline we need to preserve.
-    return serialize_pattern(entry.value).lstrip(" ")
-
-
 class FluentUnit(base.TranslationUnit):
-    """A Fluent message."""
+    """Represents a single fluent Message, Term, a ResourceComment, a
+    GroupComment or a stand-alone Comment.
+    """
 
-    def __init__(self, source=None, entry=None):
+    def __init__(
+        self,
+        source=None,
+        unit_id=None,
+        comment="",
+        fluent_type="Message",
+        placeholders=None,
+    ):
+        """
+        :param source: The serialized fluent value, or None.
+        :type source: str or None
+        :param unit_id: An optional id to set (see :meth:`~FluentUnit.setid`),
+            otherwise an id is generated from the given `source`.
+        :type unit_id: str or None
+        :param str comment: An optional comment for the unit.
+        :param str fluent_type: The fluent type this unit corresponds to.
+        :param placeholders: An optional list of sub-strings of the source that
+            should be highlighted as placeholders. A translation of this unit
+            would be expected to contain the same sub-strings.
+        :type placeholders: list[str] or None
+        """
+        if fluent_type not in (
+            "Message",
+            "Term",
+            "ResourceComment",
+            "GroupComment",
+            "DetachedComment",
+        ):
+            raise ValueError(f'Unknown value "{fluent_type}" for fluent_type')
         super().__init__(source)
-        self._type = None
-        self._id = None
-        self._attributes = {}
-        self._placeables = []
-        if source is not None:
-            self._type = ast.Message
-            self._set_value(source)
-            # Default to source string
-            self._id = id_from_source(self.source)
-        if entry is not None:
-            self.parse(entry)
+        self._fluent_type = fluent_type
+        self._is_comment = fluent_type.endswith("Comment")
+        self.placeholders = placeholders or []
+        self.target = source
+        if unit_id is None and fluent_type == "Message" and source:
+            unit_id = self._id_from_source(source)
+        self.setid(unit_id)
+        self.addnote(comment)
 
-    def _set_value(self, value):
-        self.source = value
-        # The source and target are equivalent for monolingual units.
-        self.target = self.source
+    @staticmethod
+    def _id_from_source(source):
+        # If the caller does not provide a unit ID, we need to generate one
+        # ourselves.
+        # The set of valid ids is restricted, so we cannot use the source string
+        # as the identifier (as e.g. PO files do). Instead, we hash the source
+        # string with a collision-resistant hash function.
+        # By default, we choose an id that indicates that this represents a
+        # fluent Message.
+        import hashlib
+
+        return "gen-" + hashlib.sha256(source.encode()).hexdigest()
 
     def getid(self):
         return self._id
 
+    # From fluent EBNF.
+    _FLUENT_ID_PATTERN = r"[a-zA-Z][a-zA-Z0-9_-]*"
+    _FLUENT_ID_REGEXES = {
+        "Message": _FLUENT_ID_PATTERN,
+        "Term": r"-" + _FLUENT_ID_PATTERN,
+    }
+
     def setid(self, value):
-        self._id = value
+        """Set the id of the unit.
+        A valid fluent identifier is [a-zA-Z][a-zA-Z0-9_-]*
+        For a FluentUnit that represents a fluent Message, the id must be a
+        valid fluent identifier.
+        For a fluent Term, the id must be a valid fluent identifier prefixed by
+        a "-".
+        For a fluent Comment, GroupComment or ResourceComment, the id is unused.
+        """
+        regex = self._FLUENT_ID_REGEXES.get(self._fluent_type, "")
+        if not re.fullmatch(regex, value or ""):
+            raise ValueError(
+                f"Invalid id for a {self._fluent_type} FluentUnit: {value}"
+            )
+        self._id = value or None
 
     def isheader(self):
-        return self._type in [
-            ast.Comment,
-            ast.GroupComment,
-            ast.ResourceComment,
-        ]
+        return self._is_comment
 
-    def getattributes(self):
-        return self._attributes
+    @property
+    def fluent_type(self):
+        """The fluent type this unit corresponds to."""
+        return self._fluent_type
 
     def getplaceables(self):
-        return self._placeables
+        """Still called in Weblate. Returns :attr:`~FluentUnit.placeholders`."""
+        return self.placeholders
 
-    def parse(self, entry):
-        this = self
+    @classmethod
+    def new_from_entry(cls, fluent_entry, comment=None):
+        """Create a new unit corresponding to the given fluent AST entry.
 
-        class Parser(visitor.Visitor):
-            _found_id = False
+        :param fluent_entry: A fluent Entry to convert.
+        :type fluent_entry: Entry
+        :param comment: A comment to set on the unit. For fluent Comments the
+            comment is taken from the object instead.
+        :type comment: str or None
 
-            @staticmethod
-            def visit_Attribute(node):
-                this._attributes[node.id.name] = source_from_entry(node)
+        :return: A new FluentUnit.
+        :rtype: FluentUnit
+        """
+        if isinstance(fluent_entry, ast.ResourceComment):
+            return cls(comment=fluent_entry.content, fluent_type="ResourceComment")
+        if isinstance(fluent_entry, ast.GroupComment):
+            return cls(comment=fluent_entry.content, fluent_type="GroupComment")
+        if isinstance(fluent_entry, ast.Comment):
+            return cls(comment=fluent_entry.content, fluent_type="DetachedComment")
+        if isinstance(fluent_entry, ast.Term):
+            return cls._create_from_fluent_pattern(
+                fluent_entry, "Term", f"-{fluent_entry.id.name}", comment
+            )
+        if isinstance(fluent_entry, ast.Message):
+            return cls._create_from_fluent_pattern(
+                fluent_entry, "Message", fluent_entry.id.name, comment
+            )
+        raise ValueError(f"Unhandled fluent type: {fluent_entry.__class__.__name__}")
 
-            @staticmethod
-            def visit_Placeable(node):
-                this._placeables.append(serialize_placeable(node))
+    @classmethod
+    def _create_from_fluent_pattern(cls, fluent_entry, fluent_type, unit_id, comment):
+        """Create a new unit from a fluent entry that has a Pattern value."""
+        lines = []
+        source = cls._fluent_pattern_to_source(fluent_entry.value)
+        if source:
+            lines.append(source)
+        for attr in fluent_entry.attributes:
+            attr_source = cls._fluent_pattern_to_source(attr.value)
+            source = f".{attr.id.name} ="
+            if "\n" in attr_source:
+                # Multi-line Attributes placed on newline.
+                source += "\n"
+            else:
+                source += " "
+            source += attr_source
+            lines.append(source)
+        return cls(
+            source="\n".join(lines),
+            unit_id=unit_id,
+            comment=comment,
+            fluent_type=fluent_type,
+            placeholders=cls._fluent_pattern_placeholders(fluent_entry, fluent_type),
+        )
 
-            @staticmethod
-            def visit_Comment(node):
-                if this._type not in [ast.Message, ast.Term]:
-                    this._type = ast.Comment
-                this.addnote(node.content)
+    @staticmethod
+    def _fluent_pattern_to_source(pattern):
+        """Convert the fluent Pattern into a source string."""
+        if not pattern:
+            return None
 
-            @staticmethod
-            def visit_GroupComment(node):
-                this._type = ast.GroupComment
-                this.addnote(node.content)
+        if not pattern.elements:
+            raise ValueError("Unexpected fluent Pattern without any elements")
 
-            @staticmethod
-            def visit_ResourceComment(node):
-                this._type = ast.ResourceComment
-                this.addnote(node.content)
+        first_element = pattern.elements[0]
+        if isinstance(first_element, ast.TextElement):
+            # Replace the special characters "*", "[" and "." with a
+            # StringLiteral if they appear at the start of a line.
+            # NOTE: These are specified in the fluent EBNF's "indented_char".
+            # Normally, these characters cannot appear at the start of a line
+            # for a value because they are part of the syntax, so they must be
+            # escaped. However, as an exception, these characters may appear at
+            # the very start of a Pattern, on the same line as the "=" sign.
+            # For example:
+            #     m = .start
+            # or
+            #     m = *start
+            #         another line
+            #
+            # We want to escape these special characters for two reasons:
+            #   1. For consistency with other lines not being able to start with
+            #      such a character in multiline values. There is no "=" sign in
+            #      the derived source to indicate the exception.
+            #   2. To make re-serialization easier. In particular, when we
+            #      serialize the FluentUnit's source, we place the source on a
+            #      newline for consistent behaviour.
+            first_char = first_element.value[0]
+            if first_char in ("[", ".", "*"):
+                # Replace with literals.
+                # NOTE: An empty TextElement is ok for the FluentSerializer.
+                first_element.value = first_element.value[1:]
+                pattern.elements.insert(0, ast.Placeable(ast.StringLiteral(first_char)))
 
-            def visit_Identifier(self, node):
-                if self._found_id:
-                    return
-                if this._type == ast.Message:
-                    # Only save the first identifier we encounter (the entry's
-                    # value will also contain identifiers if it has selectors).
-                    this._id = node.name
-                    self._found_id = True
-                elif this._type == ast.Term:
-                    this._id = "-" + node.name
-                    self._found_id = True
+        # Create a fluent Message with the given pattern and serialize it.
+        # We use serialize_entry which is part of python-fluent's public API.
+        source = FluentSerializer().serialize_entry(
+            ast.Message(ast.Identifier("i"), value=pattern)
+        )
 
-            def visit_Message(self, node):
-                this._type = ast.Message
-                this._set_value(source_from_entry(node))
-                self.generic_visit(node)
+        # Strip away the id part: "i =". For single-line values, a space is also
+        # added. For multi-line values, a newline is added.
+        # NOTE: Since we escaped any leading special character, the newline is
+        # expected to always be added for multiline values.
+        source = re.sub(r"^i =( |\n)", "", source, count=1)
+        # Strip away the trailing newline that the serializer adds.
+        source = re.sub(r"\n$", "", source, count=1)
 
-            def visit_Term(self, node):
-                this._type = ast.Term
-                this._set_value(source_from_entry(node))
-                self.generic_visit(node)
+        # Remove the common indent.
+        # NOTE: textwrap.dedent also collapses blank lines.
+        return textwrap.dedent(source)
 
-        Parser().visit(entry)
+    @staticmethod
+    def _fluent_pattern_placeholders(fluent_entry, fluent_type):
+        """Get the placeholders expected for the given fluent entry."""
+        ref_visitor = _ReferenceVisitor(fluent_type)
+        ref_visitor.visit(fluent_entry.value)
+        # NOTE: For Terms, we do not look through references in the Attributes.
+        # Only Term's have their Attributes appear in their source, and Term
+        # Attributes tend to be locale-specific, which we don't want to
+        # influence the placeholders.
+        # FIXME: For Messages, we expect Attributes to contain the same
+        # references in translations, but the placeholders have no way to
+        # distinguish between whether the placeholder is found in the same
+        # attribute or not. So we do not include them.
+        return list(ref_visitor.placeholders)
 
     def to_entry(self):
-        fp = FluentParser(False)
+        """Convert the unit into a corresponding fluent AST Entry.
 
-        # Handle standalone comments separately; they don't have any values or
-        # attributes, just comment text.
-        if self._type in [ast.ResourceComment, ast.GroupComment, ast.Comment]:
-            return (self._type)(self.getnotes())
-
-        assert self.source is not None
-        value = fp.maybe_get_pattern(FluentParserStream(self.source))
-
-        attributes = [
-            ast.Attribute(
-                ast.Identifier(id),
-                fp.maybe_get_pattern(FluentParserStream(value)),
-            )
-            for (id, value) in self._attributes.items()
-        ]
-
-        comment = None
-        if self.getnotes():
-            comment = ast.Comment(self.getnotes())
-
+        :return: A new fluent AST Entry, if one was created.
+        :rtype: Entry or None
+        :raises ValueError: if the unit source contains an error.
+        """
         fluent_id = self.getid()
-        if self._type == ast.Term:
-            # Remove the prefix "-".
-            fluent_id = fluent_id[1:]
+        if fluent_id:
+            # Remove the leading "-" for Terms.
+            fluent_id = re.sub(r"^-", "", fluent_id, count=1)
+        if self.fluent_type == "ResourceComment":
+            # Create a comment, even if empty. Especially since empty
+            # GroupComments are meant to end a previous GroupComment's
+            # scope.
+            return ast.ResourceComment(content=(self.getnotes() or ""))
+        if self.fluent_type == "GroupComment":
+            return ast.GroupComment(content=(self.getnotes() or ""))
+        if self.fluent_type == "DetachedComment":
+            return ast.Comment(content=(self.getnotes() or ""))
+        if self.fluent_type in ("Term", "Message"):
+            return self._source_to_fluent_entry()
+        raise ValueError(f"Unhandled fluent_type: {self.fluent_type}")
 
-        return (self._type if self._type is not None else ast.Message)(
-            ast.Identifier(fluent_id),
-            value=value,
-            attributes=attributes,
-            comment=comment,
-        )
+    def _source_to_fluent_entry(self):
+        """Convert a FluentUnit's source to a fluent Term or Message."""
+        entry = self._try_source_to_fluent_entry()
+        if isinstance(entry, str):
+            raise ValueError(
+                f'Error in source of FluentUnit "{self.getid()}":\n{entry}'
+            )
+        return entry
+
+    def _try_source_to_fluent_entry(self):
+        """Convert a FluentUnit's source to a generic fluent Entry. Returns a
+        string with an error message if this fails.
+        """
+        source = self.source
+        if source is None or not source.strip():
+            return None
+
+        # Create a fluent Message by prefixing the source with "unit-id = \n"
+        # and parsing it. After each newline we also indent so that it is
+        # considered part of the same entry.
+        source_lines = [(f"{self.getid()} =", "")]
+        for line in source.split("\n"):
+            source_lines.append((" ", line))
+        source = "\n".join([added + orig for (added, orig) in source_lines])
+
+        # We use parse which is part of python-fluent's public API.
+        # The other advantage is that the entry will return Junk with an error
+        # description if there are syntax errors.
+        # NOTE: We cannot reliably use FluentParser.parse_entry because it does
+        # not parse the entire input, but only up until the entry ends. So if a
+        # source contains syntax to start another entry it will not throw an
+        # error. For example, a line that starts with "*" will end an entry.
+        res = parse(source)
+
+        # First look for junk.
+        for entry in res.body:
+            if isinstance(entry, ast.Junk):
+                error_message = []
+                for annotation in entry.annotations:
+                    # Convert the fluent error position into a line number and
+                    # offset of the unit's source.
+                    offset = annotation.span.start
+                    line = 0
+                    for added, orig in source_lines:
+                        if not orig:
+                            # Entire line was added, so we want to skip this
+                            # line. If we are within this line, then the offset
+                            # will be set to "0" for the next loop.
+                            line_len = len(added) + 1
+                            offset = max(0, offset - line_len)
+                            continue
+                        added_len = len(added)
+                        # Plus one for the newline/end-of-line.
+                        line_len = added_len + len(orig) + 1
+                        if offset < line_len:
+                            # On this line.
+                            offset = max(0, offset - added_len)
+                            break
+                        offset -= line_len
+                        line += 1
+                    error_message.append(
+                        f"{annotation.code}: {annotation.message} "
+                        f"[line {line + 1}, column {offset + 1}]"
+                    )
+                return "\n".join(error_message)
+        if len(res.body) != 1:
+            # This is unexpected since if the user tried to insert extra
+            # Entries, they would have likely given us Junk above since we
+            # indented *all* lines, which would prevent starting a new entry.
+            return "Unexpectedly found {len(res.body)} fluent Entries"
+        entry = res.body[0]
+        if self.fluent_type == "Term" and not isinstance(entry, ast.Term):
+            # Also unexpected since we started with "-tmp =", which starts a new
+            # Term.
+            return (
+                f"Unexpectedly found a fluent {entry.__class__.name__} "
+                "Entry rather than a Term"
+            )
+        if self.fluent_type != "Term" and not isinstance(entry, ast.Message):
+            # Also unexpected since we started with "tmp =", which starts a new
+            # Message.
+            return (
+                f"Unexpectedly found a fluent {entry.__class__.name__} "
+                "Entry rather than a Message"
+            )
+
+        return entry
+
+
+class _ReferenceVisitor(visitor.Visitor):
+    """Private class used to extract the reference ids contained within a
+    Pattern.
+    """
+
+    # NOTE: This class is used to extract *expected* placeholder strings. I.e. a
+    # translation of this unit would *also* be expected to include this
+    # placeholder text.
+    #
+    # We extract the MessageReferences, TermReferences and
+    # VariableReferences because we would normally expect them to appear in a
+    # translation.
+    #
+    # In contrast, other fluent Expressions are not wanted:
+    #   + StringLiteral and NumberLiteral are able to represent literal
+    #     characters, which wouldn't necessarily be present in a
+    #     translation.
+    #   + FunctionReference is for function calls, normally to format a
+    #     number or date, which may not be needed in a translation.
+    #   + SelectExpression is for branching logic. Whilst sometimes this
+    #     would be expected in a translation (e.g. based on the plural
+    #     category of a variable) it isn't always necessary (e.g. one locale
+    #     branches based on whether a Term starts with a vowel or not).
+
+    def __init__(self, fluent_type):
+        self.fluent_type = fluent_type
+        self.placeholders = set()
+
+    def visit_MessageReference(self, node):
+        # If a MessageReference appears in a value, we expect that to also
+        # appear in a translation's value as well.
+        # TODO: Are there reasonable cases where one locale would use one of
+        # these references, but another would not?
+        # NOTE: MessageReferences cannot be used as a SelectorExpression's
+        # selector, nor do they accept callable arguments. Therefore, we only
+        # expect them to appear in the form "{ message-id }".
+        placeholder = "{ " + node.id.name
+        if node.attribute:
+            placeholder += "." + node.attribute.name
+        placeholder += " }"
+        self.placeholders.add(placeholder)
+        # NOTE: We do not call Visitor.generic_visit because there is no child
+        # to descend into for this type.
+
+    def visit_TermReference(self, node):
+        if node.attribute:
+            # A TermReference with an attribute should only appear in a
+            # SelectExpression as the selector. We only expect this to be a
+            # locale-specific selector (e.g. based on some language property of
+            # the Term) so we do not add it to our placeholders.
+            return
+        # Otherwise, we expect a TermReference to also appear in a translation's
+        # value as well.
+        # NOTE: TermReferences cannot be used as a SelectorExpression's
+        # selector.
+        # TODO: TermReferences can accept callable arguments. Normally these
+        # arguments are locale-specific (e.g. passing in some grammatical
+        # context). So it can either appear as "{ -term-id }" or something like
+        # "{ -term-id(arg1: "val", arg2: "val") }".
+        # Technically, something like "{ -term-id({ message-id }) }", or more
+        # complex Expressions are allowed for positional arguments, but these
+        # would have no use, so we only match the regex with named arguments.
+        self.placeholders.add("{ -" + node.id.name + " }")
+
+    def visit_VariableReference(self, node):
+        if self.fluent_type == "Term":
+            # Variables for terms are normally locale-specific (like some
+            # grammatical context), so we do not include these.
+            return
+        # TODO: VaraibleReferences can appear as Function arguments or as
+        # SelectExpression selectors, but they are not wrapped in "{" and "}"
+        # in these cases.
+        self.placeholders.add("{ $" + node.id.name + " }")
+
+    def visit_SelectExpression(self, node):
+        # We only want to visit the variants, rather than the select expression.
+        for variant in node.variants:
+            self.generic_visit(variant)
 
 
 class FluentFile(base.TranslationStore):
@@ -193,21 +455,58 @@ class FluentFile(base.TranslationStore):
         super().__init__(**kwargs)
         self.filename = getattr(inputfile, "name", "")
         if inputfile is not None:
-            fluentsrc = inputfile.read()
-            self.parse(fluentsrc)
+            self.parse(inputfile.read())
 
     def parse(self, fluentsrc):
         resource = parse(fluentsrc.decode("utf-8"))
         for entry in resource.body:
             # Handle this unit separately if it is invalid.
             if isinstance(entry, ast.Junk):
-                for annotation in entry.annotations:
-                    raise ValueError(
-                        f"{annotation.code}: {annotation.message} [offset {annotation.span.start}]"
-                    )
+                raise self._fluent_junk_to_error(entry)
 
-            self.addunit(FluentUnit(entry=entry))
+        for entry in resource.body:
+            if isinstance(entry, ast.BaseComment):
+                self.addunit(FluentUnit.new_from_entry(entry))
+            elif isinstance(entry, (ast.Term, ast.Message)):
+                self.addunit(
+                    FluentUnit.new_from_entry(
+                        entry,
+                        getattr(entry.comment, "content", ""),
+                    )
+                )
+            else:
+                raise ValueError(
+                    f"Unhandled fluent Entry type: {entry.__class__.__name__}"
+                )
+
+    @staticmethod
+    def _fluent_junk_to_error(junk):
+        """Convert the given fluent Junk object into a ValueError."""
+        error_message = [
+            "Parsing error for fluent source: "
+            + junk.content.strip()[0:64].replace("\n", "\\n")
+            + "[...]"
+        ]
+        for annotation in junk.annotations:
+            error_message.append(
+                f"{annotation.code}: {annotation.message} [offset {annotation.span.start}]"
+            )
+        return ValueError("\n".join(error_message))
 
     def serialize(self, out):
-        body = [unit.to_entry() for unit in self.units]
-        out.write(serialize(ast.Resource(body)).encode(self.encoding))
+        body = []
+        for unit in self.units:
+            entry = unit.to_entry()
+            if not entry:
+                continue
+            if unit.fluent_type in ("Term", "Message"):
+                comment = unit.getnotes()
+                if comment:
+                    entry.comment = ast.Comment(comment)
+            body.append(entry)
+
+        serialized = serialize(ast.Resource(body))
+        # The Fluent parser may insert a blank line "    \n" in a multiline
+        # value that has a gap. We tidy those up here.
+        serialized = re.sub(r"\n +\n", "\n\n", serialized)
+        out.write(serialized.encode(self.encoding))

--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -57,7 +57,6 @@ class FluentUnit(base.TranslationUnit):
         super().__init__(source)
         self._type = None
         self._id = None
-        self._errors = {}
         self._attributes = {}
         self._placeables = []
         if source is not None:
@@ -78,12 +77,6 @@ class FluentUnit(base.TranslationUnit):
 
     def setid(self, value):
         self._id = value
-
-    def adderror(self, errorname, errortext):
-        self._errors[errorname] = errortext
-
-    def geterrors(self):
-        return self._errors
 
     def isheader(self):
         return self._type in [

--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -122,10 +122,15 @@ class FluentUnit(base.TranslationUnit):
                 this.addnote(node.content)
 
             def visit_Identifier(self, node):
-                if not self._found_id:
+                if self._found_id:
+                    return
+                if this._type == ast.Message:
                     # Only save the first identifier we encounter (the entry's
                     # value will also contain identifiers if it has selectors).
                     this._id = node.name
+                    self._found_id = True
+                elif this._type == ast.Term:
+                    this._id = "-" + node.name
                     self._found_id = True
 
             def visit_Message(self, node):
@@ -163,8 +168,13 @@ class FluentUnit(base.TranslationUnit):
         if self.getnotes():
             comment = ast.Comment(self.getnotes())
 
+        fluent_id = self.getid()
+        if self._type == ast.Term:
+            # Remove the prefix "-".
+            fluent_id = fluent_id[1:]
+
         return (self._type if self._type is not None else ast.Message)(
-            ast.Identifier(self.getid()),
+            ast.Identifier(fluent_id),
             value=value,
             attributes=attributes,
             comment=comment,

--- a/translate/storage/test_fluent.py
+++ b/translate/storage/test_fluent.py
@@ -65,7 +65,7 @@ term-usage = I can code { -some-term }!
         assert len(fluent_file.units) == 2
 
         term_unit = fluent_file.units[0]
-        assert term_unit.getid() == "some-term"
+        assert term_unit.getid() == "-some-term"
         assert term_unit.source == "Fizz Buzz"
 
         term_unit = fluent_file.units[1]

--- a/translate/storage/test_fluent.py
+++ b/translate/storage/test_fluent.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import re
+import textwrap
 from io import BytesIO
 
 from pytest import raises
@@ -37,179 +39,1948 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
         fluent_file = fluent.FluentFile(dummyfile)
         return fluent_file
 
+    @staticmethod
+    def fluent_serialize(fluent_file):
+        # The __bytes__ method on TranslationStore calls FluentFile.serialize.
+        return bytes(fluent_file).decode("utf-8")
+
     def fluent_regen(self, fluent_source):
         """Helper that converts Fluent source to a FluentFile object and back."""
-        return bytes(self.fluent_parse(fluent_source)).decode("utf-8")
+        return self.fluent_serialize(self.fluent_parse(fluent_source))
 
-    def test_simpledefinition(self):
-        """Checks that a simple Fluent definition is parsed correctly."""
-        fluent_source = "test_me = I can code!"
+    @staticmethod
+    def quick_fluent_file(unit_specs):
+        """Helper to create a FluentFile populated by the FluentUnits
+        parametrised in `unit_specs`.
+        """
+        fluent_file = fluent.FluentFile()
+        for spec in unit_specs:
+            fluent_file.addunit(
+                fluent.FluentUnit(
+                    source=spec.get("source", None),
+                    unit_id=spec.get("id", None),
+                    comment=spec.get("comment", None),
+                    fluent_type=spec.get("type", None),
+                )
+            )
+        return fluent_file
+
+    @staticmethod
+    def assert_units(fluent_file, expect_units):
+        """Assert that the given FluentFile has the expected FluentUnits.
+
+        :param FluentFile fluent_file: The file to test.
+        :param list[dict] expect_units: A list of the expected units, specified
+            by the dictionary values. The "id", "source", "type" and "comment"
+            values are matched with the corresponding property. If "type" is
+            missing, it will be chosen based on the "id". Otherwise, a falsey
+            value is used if a value is unspecified. In addition, the "refs"
+            value is matched against the placeholders property.
+        """
+        for unit, expect in zip(fluent_file.units, expect_units):
+            unit_id = expect.get("id", None)
+            assert unit_id == unit.getid()
+            id_type = None
+            if unit_id:
+                if unit_id.startswith("-"):
+                    id_type = "Term"
+                else:
+                    id_type = "Message"
+            assert expect.get("type", id_type) == unit.fluent_type
+            if unit.fluent_type.endswith("Comment"):
+                assert unit.isheader()
+                assert not unit.istranslatable()
+            else:
+                assert not unit.isheader()
+                assert unit.istranslatable()
+            # Order shouldn't be important.
+            placeholders = {"{ " + ref_id + " }" for ref_id in expect.get("refs", [])}
+            assert placeholders == set(unit.placeholders)
+            assert expect.get("comment", "") == unit.getnotes()
+            assert expect.get("source", None) == unit.source
+            assert unit.target == unit.source
+        assert len(fluent_file.units) == len(expect_units)
+
+    def basic_test(self, fluent_source, expect_units, expect_serialize=None):
+        """Assert that the given fluent source parses correctly to the expected
+        FluentFile, and reserializes correctly.
+
+        :param str fluent_source: The fluent source. Any common indent in this
+            will be removed before parsing.
+        :param list[dict] expect_units: The expected units in the parsed
+            FluentFile (see assert_units).
+        :param str expect_serialize: The expected serialization, if it would be
+            different from fluent_source. Any common indent in this will be
+            removed before comparing.
+        """
+        # Rather than requiring multiline strings start at the newline, we just
+        # remove the common indent.
+        fluent_source = textwrap.dedent(fluent_source)
+        if expect_serialize is None:
+            expect_serialize = fluent_source
+        else:
+            expect_serialize = textwrap.dedent(expect_serialize)
+
         fluent_file = self.fluent_parse(fluent_source)
-        assert len(fluent_file.units) == 1
-        fluent_unit = fluent_file.units[0]
-        assert fluent_unit.getid() == "test_me"
-        assert fluent_unit.source == "I can code!"
+        self.assert_units(fluent_file, expect_units)
+        assert self.fluent_serialize(fluent_file) == expect_serialize
+        if expect_serialize != fluent_source:
+            # Double check that a regen of expect_serialize will give us back
+            # exactly the same string.
+            assert self.fluent_regen(expect_serialize) == expect_serialize
 
-    def test_simpledefinition_source(self):
-        """Checks that a simple Fluent definition can be regenerated as source."""
-        fluent_source = "test_me = I can code!"
-        fluent_regen = self.fluent_regen(fluent_source)
-        assert fluent_source + "\n" == fluent_regen
+    def assert_serialize(self, fluent_file, expect_serialize):
+        """Assert that the given FluentFile serializes to the given string.
 
-    def test_term(self):
-        """Checks that a Fluent definition with a term is parsed correctly."""
-        fluent_source = """-some-term = Fizz Buzz
-term-usage = I can code { -some-term }!
-"""
-        fluent_file = self.fluent_parse(fluent_source)
-        assert len(fluent_file.units) == 2
+        :param FluentFile fluent_file: The FluentFile to serialize.
+        :param str expect_serialize: The expected result. Any common indent in
+            this value will be removed before comparison.
+        """
+        expect_serialize = textwrap.dedent(expect_serialize)
+        assert self.fluent_serialize(fluent_file) == expect_serialize
 
-        term_unit = fluent_file.units[0]
-        assert term_unit.getid() == "-some-term"
-        assert term_unit.source == "Fizz Buzz"
+    def assert_parse_failure(self, fluent_source, error_part):
+        """Assert that the given fluent source fails to parse into a
+        FluentFile.
 
-        term_unit = fluent_file.units[1]
-        assert term_unit.getid() == "term-usage"
-        assert term_unit.source == "I can code { -some-term }!"
-        assert term_unit.getplaceables() == ["{ -some-term }"]
-
-    def test_term_source(self):
-        """Checks that a Fluent definition with a term can be regenerated as source."""
-        fluent_source = """-some-term = Fizz Buzz
-term-usage = I can code { -some-term }!
-"""
-        fluent_regen = self.fluent_regen(fluent_source)
-        assert fluent_source == fluent_regen
-
-    def test_comments(self):
-        """Checks that we handle # comments."""
-        fluent_source = """# A comment
-key = value
-"""
-        fluent_file = self.fluent_parse(fluent_source)
-        assert len(fluent_file.units) == 1
-        fluent_unit = fluent_file.units[0]
-        assert fluent_unit.getnotes() == "A comment"
-
-        fluent_unit.addnote("Another comment", position="replace")
-        assert bytes(fluent_file).decode() == fluent_source.replace(
-            "A comment", "Another comment"
+        :param str fluent_source: The fluent source. Any common indent will be
+            removed before processing.
+        :param str error_part: The part of the fluent_source that will be
+            highlighted in the error message.
+        """
+        fluent_source = textwrap.dedent(fluent_source)
+        error_regex = (
+            r"^Parsing error for fluent source: " + error_part + r".*(\nE[0-9]+: .*)*$"
         )
-
-    def test_multiline_comments(self):
-        """Checks that we handle # comments across several lines."""
-        fluent_source = """# A comment
-# with a second line!
-key = value
-"""
-        fluent_file = self.fluent_parse(fluent_source)
-        assert len(fluent_file.units) == 1
-        fluent_unit = fluent_file.units[0]
-        assert fluent_unit.getnotes() == "A comment\nwith a second line!"
-
-    # Example from https://projectfluent.org/fluent/guide/comments.html
-    COMMENTS_EXAMPLE = """# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-
-### Localization for Server-side strings of Firefox Screenshots
-
-
-## Global phrases shared across pages
-
-my-shots = My Shots
-home-link = Home
-screenshots-description =
-    Screenshots made simple. Take, save, and
-    share screenshots without leaving Firefox.
-
-## Creating page
-
-# Note: { $title } is a placeholder for the title of the web page
-# captured in the screenshot. The default, for pages without titles, is
-# creating-page-title-default.
-creating-page-title = Creating { $title }
-creating-page-title-default = page
-creating-page-wait-message = Saving your shot…
-"""
-
-    def test_standalone_comments(self):
-        """Checks that we handle standalone comments."""
-        fluent_source = self.COMMENTS_EXAMPLE
-        fluent_file = self.fluent_parse(fluent_source)
-
-        # ((istranslatable, isheader), comment.startswith)
-        expected_units = [
-            ((False, True), "This Source Code"),
-            ((False, True), "Localization for Server-side"),
-            ((False, True), "Global phrases shared across pages"),
-            ((True, False), ""),
-            ((True, False), ""),
-            ((True, False), ""),
-            ((False, True), "Creating page"),
-            ((True, False), "Note: { $title } is a placeholder"),
-            ((True, False), ""),
-            ((True, False), ""),
-        ]
-        assert len(fluent_file.units) == len(expected_units)
-
-        for expected, actual in zip(expected_units, fluent_file.units):
-            assert (
-                actual.istranslatable(),
-                actual.isheader(),
-            ) == expected[0]
-            assert actual.getnotes().startswith(expected[1])
-
-    def test_standalone_comments_source(self):
-        """Checks that a Fluent definition with comments can be regenerated as source."""
-        fluent_source = self.COMMENTS_EXAMPLE
-        fluent_regen = self.fluent_regen(fluent_source)
-        assert fluent_source == fluent_regen
-
-    def test_source_with_selectors(self):
-        """Checks that we handle selectors."""
-        fluent_source = """emails =
-    { $unreadEmails ->
-        [one] You have one unread email.
-       *[other] You have { $unreadEmails } unread emails.
-    }
-"""
-        fluent_regen = self.fluent_regen(fluent_source)
-        assert fluent_source == fluent_regen
-
-    def test_errors(self):
-        """Checks that errors are extracted."""
-        fluent_source = """valid-unit = I'm great!
-= I'm not.
-"""
-        with raises(ValueError):
+        with raises(ValueError, match=error_regex):
             self.fluent_parse(fluent_source)
 
-    def test_attributes(self):
-        """Checks that we handle attributes."""
-        fluent_source = """login-input = Predefined value
-    .placeholder = email@example.com
-    .aria-label = Login input value
-    .title = Type your login email
-"""
-        fluent_file = self.fluent_parse(fluent_source)
-        assert len(fluent_file.units) == 1
-        fluent_unit = fluent_file.units[0]
-        assert fluent_unit.getid() == "login-input"
-        assert (
-            fluent_unit.source == "Predefined value\n"
-            ".placeholder = email@example.com\n"
-            ".aria-label = Login input value\n"
-            ".title = Type your login email"
+    def assert_serialize_failure(self, fluent_file, error_regex):
+        """Assert that the given FluentFile fails to serialize.
+
+        :param FluentFile fluent_file: The FluentFile to try and serialize.
+        :param str error_regex: The expected error expression.
+        """
+        with raises(ValueError, match=error_regex):
+            self.fluent_serialize(fluent_file)
+
+    def test_simple_values(self):
+        """Test a simple fluent Message and Term."""
+        self.basic_test(
+            """\
+            test_me = I can code!
+            """,
+            [{"id": "test_me", "source": "I can code!"}],
+        )
+        self.basic_test(
+            """\
+            -my-term = Term Content
+            """,
+            [{"id": "-my-term", "source": "Term Content"}],
         )
 
-    def test_attributes_source(self):
-        """Checks that attributes can be regenerated as source."""
-        fluent_source = """login-input = Predefined value
-    .placeholder = email@example.com
-    .aria-label = Login input value
-    .title = Type your login email
-"""
-        fluent_regen = self.fluent_regen(fluent_source)
-        assert fluent_source == fluent_regen
+    def test_with_comment(self):
+        """Test a fluent Message and Term with a Comment."""
+        self.basic_test(
+            """\
+            # A comment
+            test-message = test content
+            """,
+            [{"id": "test-message", "source": "test content", "comment": "A comment"}],
+        )
+        self.basic_test(
+            """\
+            # A comment
+            -test-term = test content
+            """,
+            [{"id": "-test-term", "source": "test content", "comment": "A comment"}],
+        )
+
+    def test_message_with_attributes(self):
+        """Test a fluent Message with Attributes."""
+        self.basic_test(
+            """\
+            message = test content
+                .first = First attribute
+                .second = Second attribute
+            """,
+            [
+                {
+                    "id": "message",
+                    "source": "test content\n"
+                    ".first = First attribute\n"
+                    ".second = Second attribute",
+                },
+            ],
+        )
+        # Any indent is ok, but re-serializes as 4-spaces.
+        self.basic_test(
+            """\
+            message = test content
+              .first = 1
+                  .second = 2
+             .third = 3
+            """,
+            [
+                {
+                    "id": "message",
+                    "source": "test content\n"
+                    ".first = 1\n"
+                    ".second = 2\n"
+                    ".third = 3",
+                }
+            ],
+            """\
+            message = test content
+                .first = 1
+                .second = 2
+                .third = 3
+            """,
+        )
+        # With comment.
+        self.basic_test(
+            """\
+            # A comment
+            my-id = test content
+                .first = First attribute
+                .attr-2 = Second attribute
+            """,
+            [
+                {
+                    "id": "my-id",
+                    "source": "test content\n"
+                    ".first = First attribute\n"
+                    ".attr-2 = Second attribute",
+                    "comment": "A comment",
+                },
+            ],
+        )
+        # Message with no value, but does have attributes.
+        self.basic_test(
+            """\
+            # No value
+            my-id =
+                .first = First
+                .attr-2 = Second
+            """,
+            [
+                {
+                    "id": "my-id",
+                    "source": ".first = First\n.attr-2 = Second",
+                    "comment": "No value",
+                },
+            ],
+        )
+
+        # A comment between attributes is not allowed.
+        self.assert_parse_failure(
+            """\
+            # Top comment
+            -my-term = content
+            # Try to comment
+                .first = First
+                .attr-2 = Second
+            """,
+            r"\.first = First",
+        )
+
+    def test_term_with_attributes(self):
+        """Test a fluent Term with Attributes."""
+        self.basic_test(
+            """\
+            # A comment
+            -term = test content
+                .first = First attribute
+                .second = Second attribute
+            """,
+            [
+                {
+                    "id": "-term",
+                    "source": "test content\n"
+                    ".first = First attribute\n"
+                    ".second = Second attribute",
+                    "comment": "A comment",
+                }
+            ],
+        )
+
+        # Cannot have a term with no value, but with attributes.
+        self.assert_parse_failure(
+            """\
+            -my-term =
+                .first = First
+                .attr-2 = Second
+            """,
+            r"-my-term =",
+        )
+        fluent_file = self.quick_fluent_file(
+            [{"type": "Term", "source": ".attr = string", "id": "-term"}]
+        )
+        self.assert_serialize_failure(
+            fluent_file,
+            r'^Error in source of FluentUnit "-term":\n'
+            r'.*Expected term "-term" to have a value \[line 1, column 1\]$',
+        )
+
+    def test_whitespace(self):
+        """Test behaviour for leading and trailing whitespace."""
+
+        # Expect leading whitespace and trailing whietspace to be dropped.
+        # TODO: Do we want to try and generate warnings for this?
+        def subtest_whitespace(whitespace):
+            # Test leading and trailing whitespace.
+            for position in ["start", "end"]:
+                source = f"{whitespace}ok" if position == "start" else f"ok{whitespace}"
+                # Single line Message.
+                fluent_file = self.quick_fluent_file(
+                    [{"type": "Message", "source": source, "id": "message"}]
+                )
+                self.assert_serialize(fluent_file, "message = ok\n")
+                # Single line Message Attribute.
+                fluent_file = self.quick_fluent_file(
+                    [{"type": "Message", "source": f".a = {source}", "id": "m"}]
+                )
+                self.assert_serialize(
+                    fluent_file,
+                    """\
+                    m =
+                        .a = ok
+                    """,
+                )
+                # Single line Term.
+                fluent_file = self.quick_fluent_file(
+                    [{"type": "Term", "source": source, "id": "-term"}]
+                )
+                self.assert_serialize(fluent_file, "-term = ok\n")
+
+                # Start or end of Term's value, with attributes.
+                fluent_file = self.quick_fluent_file(
+                    [{"type": "Term", "source": f"{source}\n.attr = a", "id": "-term"}]
+                )
+                self.assert_serialize(
+                    fluent_file,
+                    """\
+                    -term = ok
+                        .attr = a
+                    """,
+                )
+
+        subtest_whitespace(" ")
+        subtest_whitespace("\n")
+        subtest_whitespace("  ")
+        subtest_whitespace(" \n ")
+
+        # Test multiline common indent is lost. But difference in indent is
+        # preserved.
+        fluent_file = self.quick_fluent_file(
+            [{"type": "Message", "source": " line 1\n   line 2", "id": "m"}]
+        )
+        self.assert_serialize(
+            fluent_file,
+            """\
+            m =
+                line 1
+                  line 2
+            """,
+        )
+
+        # Test that leading and trailing blank lines are lost.
+        fluent_file.units[0].source = "\nline 1\nline 2"
+        self.assert_serialize(
+            fluent_file,
+            """\
+            m =
+                line 1
+                line 2
+            """,
+        )
+        fluent_file.units[0].source = "  \n \nline 1\nline 2"
+        self.assert_serialize(
+            fluent_file,
+            """\
+            m =
+                line 1
+                line 2
+            """,
+        )
+        fluent_file.units[0].source = "line 1\nline 2\n\n  "
+        self.assert_serialize(
+            fluent_file,
+            """\
+            m =
+                line 1
+                line 2
+            """,
+        )
+
+        # Test that trailing spaces on lines are preserved, apart from the last
+        # line, as per fluent's rules.
+        fluent_file.units[0].source = "line 1   \n line 2  \nline 3   \n  "
+        self.assert_serialize(
+            fluent_file, "m =\n" "    line 1   \n" "     line 2  \n" "    line 3\n"
+        )
+
+    def test_empty_unit_source(self):
+        """Test behaviour when we have an empty FluentUnit source."""
+
+        def subtest_empty_unit_source(source):
+            # Empty units are not serialized.
+            for fluent_type, unit_id in [
+                ("Message", "m2"),
+                ("Term", "-term-1"),
+            ]:
+                fluent_file = self.quick_fluent_file(
+                    [{"type": fluent_type, "source": source, "id": unit_id}]
+                )
+                # Empty file.
+                self.assert_serialize(fluent_file, "")
+
+                # With a previous unit and following unit.
+                # Previous unit and following unit are still serialized.
+                fluent_file = self.quick_fluent_file(
+                    [
+                        {"type": "Message", "source": "a", "id": "m1"},
+                        {"type": fluent_type, "source": source, "id": unit_id},
+                        {"type": "Message", "source": "b", "id": "m3"},
+                    ]
+                )
+                self.assert_serialize(fluent_file, "m1 = a\nm3 = b\n")
+
+            if source is None:
+                return
+
+            # A Term that has an empty value with attributes, or empty
+            # attributes, simply throws because this is a syntax error within a
+            # single source.
+            fluent_file = self.quick_fluent_file(
+                [
+                    {"type": "Message", "source": "ok", "id": "message"},
+                    {"type": "Term", "source": f"{source}\n.attr = ok", "id": "-term"},
+                ]
+            )
+            self.assert_serialize_failure(
+                fluent_file, r'^Error in source of FluentUnit "-term":'
+            )
+            # Empty Attribute for a Term
+            fluent_file.units[1].source = f"ok\n.attr = {source}"
+            self.assert_serialize_failure(
+                fluent_file, r'^Error in source of FluentUnit "-term":'
+            )
+
+            # For a Message, an empty start is ok.
+            fluent_file = self.quick_fluent_file(
+                [
+                    {"type": "Message", "source": "ok", "id": "message"},
+                    {"type": "Message", "source": f"{source}\n.attr = ok", "id": "m"},
+                ]
+            )
+            self.assert_serialize(
+                fluent_file,
+                """\
+                message = ok
+                m =
+                    .attr = ok
+                """,
+            )
+            # Empty attribute is not ok.
+            fluent_file.units[1].source = f"ok\n.attr = {source}"
+            self.assert_serialize_failure(
+                fluent_file, r'^Error in source of FluentUnit "m":'
+            )
+
+        subtest_empty_unit_source(None)
+        subtest_empty_unit_source("")
+        subtest_empty_unit_source(" ")
+        subtest_empty_unit_source("\n")
+        subtest_empty_unit_source("\n ")
+
+    def test_multiline_value(self):
+        """Test multiline values for fluent Messages and Terms."""
+        # Starting on the same line.
+        self.basic_test(
+            """\
+            message = My multiline
+              message
+            """,
+            [{"id": "message", "source": "My multiline\nmessage"}],
+            """\
+            message =
+                My multiline
+                message
+            """,
+        )
+
+        # With a gap after first line.
+        self.basic_test(
+            """\
+            message = My multiline
+
+              gap
+            """,
+            [{"id": "message", "source": "My multiline\n\ngap"}],
+            """\
+            message =
+                My multiline
+
+                gap
+            """,
+        )
+        # With gap after second line.
+        self.basic_test(
+            """\
+            -term = My multiline
+                  term with
+
+                  a gap
+            """,
+            [{"id": "-term", "source": "My multiline\nterm with\n\na gap"}],
+            """\
+            -term =
+                My multiline
+                term with
+
+                a gap
+            """,
+        )
+
+        # Whitespace that goes beyond the common indent is preserved.
+        # NOTE: The whitespace after the = is ignored.
+        self.basic_test(
+            """\
+            -term =    Term
+               lies across
+              three lines
+            """,
+            [{"id": "-term", "source": "Term\n lies across\nthree lines"}],
+            """\
+            -term =
+                Term
+                 lies across
+                three lines
+            """,
+        )
+
+        # With the multiline value starting on a newline.
+        self.basic_test(
+            """\
+            -term =
+                My multiline
+                term
+            """,
+            [{"id": "-term", "source": "My multiline\nterm"}],
+        )
+
+        # With a gap.
+        self.basic_test(
+            """\
+            -term =
+              My multiline
+
+              gap
+            """,
+            [{"id": "-term", "source": "My multiline\n\ngap"}],
+            """\
+            -term =
+                My multiline
+
+                gap
+            """,
+        )
+        # With a gap at the start is ignored.
+        self.basic_test(
+            """\
+            message =
+
+             starts with a gap
+            """,
+            [{"id": "message", "source": "starts with a gap"}],
+            """\
+            message = starts with a gap
+            """,
+        )
+
+        # Whitespace at line start
+        # NOTE: The whitespace for the first line is not ignored.
+        self.basic_test(
+            """\
+            message =
+                  message with
+                preserved
+                 whitespace
+            """,
+            [{"id": "message", "source": "  message with\npreserved\n whitespace"}],
+        )
+
+        # Trailing whitespace is preserved in fluent for all but the last line.
+        self.basic_test(
+            "message =  \n" " trailing  \n" " whitespace \n" " last line  \n",
+            [{"id": "message", "source": "trailing  \nwhitespace \nlast line"}],
+            "message =\n" "    trailing  \n" "    whitespace \n" "    last line\n",
+        )
+        # Starting on the same line, and with gap.
+        self.basic_test(
+            "message =   trailing  \n" " whitespace \n" "    \n" " last line  \n",
+            [{"id": "message", "source": "trailing  \nwhitespace \n\nlast line"}],
+            "message =\n" "    trailing  \n" "    whitespace \n" "\n" "    last line\n",
+        )
+
+    def test_multiline_message_attributes(self):
+        """Test multiline Attributes for fluent Messages."""
+        # Starting on the same line.
+        self.basic_test(
+            """\
+            message =
+              .attr = My multiline
+             attribute
+            """,
+            [{"id": "message", "source": ".attr =\nMy multiline\nattribute"}],
+            """\
+            message =
+                .attr =
+                    My multiline
+                    attribute
+            """,
+        )
+
+        # With a gap after first line.
+        self.basic_test(
+            """\
+            message =
+             .attr = My multiline
+
+                  gap
+            """,
+            [{"id": "message", "source": ".attr =\nMy multiline\n\ngap"}],
+            """\
+            message =
+                .attr =
+                    My multiline
+
+                    gap
+            """,
+        )
+        # With gap after second line.
+        self.basic_test(
+            """\
+            message = My multiline
+                  message with
+
+                  a gap
+                  .attr = My multiline
+                    attribute with
+
+                    a gap
+            """,
+            [
+                {
+                    "id": "message",
+                    "source": "My multiline\n"
+                    "message with\n"
+                    "\n"
+                    "a gap\n"
+                    ".attr =\n"
+                    "My multiline\n"
+                    "attribute with\n"
+                    "\n"
+                    "a gap",
+                },
+            ],
+            """\
+            message =
+                My multiline
+                message with
+
+                a gap
+                .attr =
+                    My multiline
+                    attribute with
+
+                    a gap
+            """,
+        )
+
+        # Whitespace that goes beyond the common indent is preserved.
+        # NOTE: The whitespace for the first line is ignored.
+        self.basic_test(
+            """\
+            message = Message
+              .attr =     Attribute
+                lies across
+              three lines
+            """,
+            [
+                {
+                    "id": "message",
+                    "source": "Message\n"
+                    ".attr =\n"
+                    "Attribute\n"
+                    "  lies across\n"
+                    "three lines",
+                },
+            ],
+            """\
+            message = Message
+                .attr =
+                    Attribute
+                      lies across
+                    three lines
+            """,
+        )
+
+        # With the multiline value starting on a newline.
+        self.basic_test(
+            """\
+            message = Message
+                .a =
+                    My multiline
+                    attribute
+            """,
+            [
+                {
+                    "id": "message",
+                    "source": "Message\n" ".a =\n" "My multiline\n" "attribute",
+                },
+            ],
+        )
+
+        # With a gap.
+        self.basic_test(
+            """\
+            message =
+             Message
+                .a =
+              My multiline
+
+              gap
+            """,
+            [
+                {
+                    "id": "message",
+                    "source": "Message\n" ".a =\n" "My multiline\n" "\n" "gap",
+                },
+            ],
+            """\
+            message = Message
+                .a =
+                    My multiline
+
+                    gap
+            """,
+        )
+        # With a gap at the start is ignored.
+        self.basic_test(
+            """\
+            message =
+             .a =
+
+             starts with a gap
+            """,
+            [{"id": "message", "source": ".a = starts with a gap"}],
+            """\
+            message =
+                .a = starts with a gap
+            """,
+        )
+
+        # Whitespace at line start
+        # NOTE: The whitespace for the first line is not ignored.
+        self.basic_test(
+            """\
+            message = Message
+                .attr =
+                     attribute with
+                    preserved
+                      whitespace
+            """,
+            [
+                {
+                    "id": "message",
+                    "source": "Message\n"
+                    ".attr =\n"
+                    " attribute with\n"
+                    "preserved\n"
+                    "  whitespace",
+                },
+            ],
+        )
+
+        # Trailing whitespace is preserved in fluent for all but the last line.
+        self.basic_test(
+            "message = Message \n"
+            ".attr = \n"
+            " trailing  \n"
+            " whitespace \n"
+            " last line  \n",
+            [
+                {
+                    "id": "message",
+                    "source": "Message\n"
+                    ".attr =\n"
+                    "trailing  \n"
+                    "whitespace \n"
+                    "last line",
+                },
+            ],
+            "message = Message\n"
+            "    .attr =\n"
+            "        trailing  \n"
+            "        whitespace \n"
+            "        last line\n",
+        )
+        # Starting on the same line, and with gap.
+        self.basic_test(
+            "message = Message\n"
+            " .attr =    trailing  \n"
+            " whitespace \n"
+            "    \n"
+            " last line  \n",
+            [
+                {
+                    "id": "message",
+                    "source": "Message\n"
+                    ".attr =\n"
+                    "trailing  \n"
+                    "whitespace \n"
+                    "\n"
+                    "last line",
+                },
+            ],
+            "message = Message\n"
+            "    .attr =\n"
+            "        trailing  \n"
+            "        whitespace \n"
+            "\n"
+            "        last line\n",
+        )
+
+    def test_multiline_term_attributes(self):
+        """Test multiline Attributes for fluent Terms."""
+        # NOTE: Multiline attributes for fluent Terms would not usually be of
+        # much use, but we still check that they behave as expected when
+        # present.
+
+        # Starting on the same line.
+        self.basic_test(
+            """\
+            -term = val
+              .attr = My multiline
+             attribute
+            """,
+            [{"id": "-term", "source": "val\n.attr =\nMy multiline\nattribute"}],
+            """\
+            -term = val
+                .attr =
+                    My multiline
+                    attribute
+            """,
+        )
+
+        # With a gap after first line.
+        self.basic_test(
+            """\
+            -term = val
+             .attr = My multiline
+
+                  gap
+            """,
+            [{"id": "-term", "source": "val\n.attr =\nMy multiline\n\ngap"}],
+            """\
+            -term = val
+                .attr =
+                    My multiline
+
+                    gap
+            """,
+        )
+        # With gap after second line.
+        self.basic_test(
+            """\
+            -term = My multiline
+                  term with
+
+                  a gap
+                  .attr = My multiline
+                    attribute with
+
+                    a gap
+            """,
+            [
+                {
+                    "id": "-term",
+                    "source": "My multiline\nterm with\n\na gap\n"
+                    ".attr =\nMy multiline\nattribute with\n\na gap",
+                }
+            ],
+            """\
+            -term =
+                My multiline
+                term with
+
+                a gap
+                .attr =
+                    My multiline
+                    attribute with
+
+                    a gap
+            """,
+        )
+
+        # Whitespace that goes beyond the common indent is preserved.
+        # NOTE: The whitespace for the first line is ignored.
+        self.basic_test(
+            """\
+            -term = Term
+              .attr =     Attribute
+                lies across
+              three lines
+            """,
+            [
+                {
+                    "id": "-term",
+                    "source": "Term\n"
+                    ".attr =\n"
+                    "Attribute\n"
+                    "  lies across\n"
+                    "three lines",
+                }
+            ],
+            """\
+            -term = Term
+                .attr =
+                    Attribute
+                      lies across
+                    three lines
+            """,
+        )
+
+        # With the multiline value starting on a newline.
+        self.basic_test(
+            """\
+            -term = Term
+                .a =
+                    My multiline
+                    attribute
+            """,
+            [{"id": "-term", "source": "Term\n.a =\nMy multiline\nattribute"}],
+        )
+
+        # With a gap.
+        self.basic_test(
+            """\
+            -term =
+             Term
+                .a =
+              My multiline
+
+              gap
+            """,
+            [{"id": "-term", "source": "Term\n.a =\nMy multiline\n\ngap"}],
+            """\
+            -term = Term
+                .a =
+                    My multiline
+
+                    gap
+            """,
+        )
+        # With a gap at the start is ignored.
+        self.basic_test(
+            """\
+            -term = val
+             .a =
+
+             starts with a gap
+            """,
+            [{"id": "-term", "source": "val\n.a = starts with a gap"}],
+            """\
+            -term = val
+                .a = starts with a gap
+            """,
+        )
+
+        # Whitespace at line start
+        # NOTE: The whitespace for the first line is not ignored.
+        self.basic_test(
+            """\
+            -term = Term
+                .attr =
+                     attribute with
+                    preserved
+                      whitespace
+            """,
+            [
+                {
+                    "id": "-term",
+                    "source": "Term\n"
+                    ".attr =\n"
+                    " attribute with\n"
+                    "preserved\n"
+                    "  whitespace",
+                }
+            ],
+        )
+
+        # Trailing whitespace is preserved in fluent for all but the last line.
+        self.basic_test(
+            "-term =  \n" " trailing  \n" " whitespace \n" " last line  \n",
+            [{"id": "-term", "source": "trailing  \nwhitespace \nlast line"}],
+            "-term =\n" "    trailing  \n" "    whitespace \n" "    last line\n",
+        )
+        # Starting on the same line, and with gap.
+        self.basic_test(
+            "-term =   trailing  \n" " whitespace \n" "    \n" " last line  \n",
+            [{"id": "-term", "source": "trailing  \nwhitespace \n\nlast line"}],
+            "-term =\n" "    trailing  \n" "    whitespace \n" "\n" "    last line\n",
+        )
+
+    def test_special_syntax_characters(self):
+        """Test special syntax characters at the start of a line."""
+
+        # ".", "*" and "[" cannot appear at the start of a multiline line, but
+        # as a special case they can appear at the start of a value on the same
+        # line without throwing a fluent syntax error. But we expect out
+        # FluentFile to escape these values for consistency.
+        def subtest_special_syntax_characters(char, ok_at_start):
+            # Test *within* a single-line Message, Term, and Attributes.
+            # Should be the same in all cases.
+            middle_value = f"e{char}and more"
+            self.basic_test(
+                f"""\
+                message = {middle_value}
+                """,
+                [{"id": "message", "source": middle_value}],
+            )
+            self.basic_test(
+                f"""\
+                message =
+                    .a = {middle_value}
+                """,
+                [{"id": "message", "source": f".a = {middle_value}"}],
+            )
+            self.basic_test(
+                f"""\
+                -term = {middle_value}
+                """,
+                [{"id": "-term", "source": middle_value}],
+            )
+            self.basic_test(
+                f"""\
+                -term = val
+                    .a = {middle_value}
+                """,
+                [{"id": "-term", "source": f"val\n.a = {middle_value}"}],
+            )
+
+            # Test with just the character on its own, or at the start of a
+            # value.
+            if ok_at_start:
+                escaped_char = char
+            else:
+                escaped_char = f'{{ "{char}" }}'
+
+            for value in [char, f"{char}at start"]:
+                escaped_value = value.replace(char, escaped_char)
+                # Test at start of a single-line Message, Term, and Attributes.
+                self.basic_test(
+                    f"""\
+                    message = {value}
+                    """,
+                    [{"id": "message", "source": escaped_value}],
+                    f"""\
+                    message = {escaped_value}
+                    """,
+                )
+                self.basic_test(
+                    f"""\
+                    message =
+                        .a = {value}
+                    """,
+                    [{"id": "message", "source": f".a = {escaped_value}"}],
+                    f"""\
+                    message =
+                        .a = {escaped_value}
+                    """,
+                )
+                self.basic_test(
+                    f"""\
+                    -term = {value}
+                    """,
+                    [{"id": "-term", "source": escaped_value}],
+                    f"""\
+                    -term = {escaped_value}
+                    """,
+                )
+                self.basic_test(
+                    f"""\
+                    -term = val
+                        .a = {value}
+                    """,
+                    [{"id": "-term", "source": f"val\n.a = {escaped_value}"}],
+                    f"""\
+                    -term = val
+                        .a = {escaped_value}
+                    """,
+                )
+
+                # Do same with start of a multiline.
+                self.basic_test(
+                    f"""\
+                    message = {value}
+                     {middle_value}
+                    """,
+                    [{"id": "message", "source": f"{escaped_value}\n{middle_value}"}],
+                    f"""\
+                    message =
+                        {escaped_value}
+                        {middle_value}
+                    """,
+                )
+                self.basic_test(
+                    f"""\
+                    message =
+                        .a = {value}
+                     {middle_value}
+                    """,
+                    [
+                        {
+                            "id": "message",
+                            "source": f".a =\n{escaped_value}\n{middle_value}",
+                        }
+                    ],
+                    f"""\
+                    message =
+                        .a =
+                            {escaped_value}
+                            {middle_value}
+                    """,
+                )
+                self.basic_test(
+                    f"""\
+                    -term = {value}
+                     {middle_value}
+                    """,
+                    [{"id": "-term", "source": f"{escaped_value}\n{middle_value}"}],
+                    f"""\
+                    -term =
+                        {escaped_value}
+                        {middle_value}
+                    """,
+                )
+                self.basic_test(
+                    f"""\
+                    -term = val
+                        .a = {value}
+                     {middle_value}
+                    """,
+                    [
+                        {
+                            "id": "-term",
+                            "source": f"val\n.a =\n{escaped_value}\n{middle_value}",
+                        }
+                    ],
+                    f"""\
+                    -term = val
+                        .a =
+                            {escaped_value}
+                            {middle_value}
+                    """,
+                )
+
+                if ok_at_start:
+                    continue
+
+                # Confirm that starting a newline with one of these characters would
+                # throw an error.
+                self.assert_parse_failure(
+                    f"""\
+                    message =
+                        {value}
+                    """,
+                    r".*" + re.escape(value),
+                )
+                self.assert_parse_failure(
+                    f"""\
+                    message = ok
+                        {value}
+                    """,
+                    r".*" + re.escape(value),
+                )
+                self.assert_parse_failure(
+                    f"""\
+                    -term = ok
+                        {value}
+                    """,
+                    r".*" + re.escape(value),
+                )
+                self.assert_parse_failure(
+                    f"""\
+                    -term = ok
+                      .attr =
+                        {value}
+                    """,
+                    r".*" + re.escape(value),
+                )
+
+                for fluent_type, unit_id, source in [
+                    ("Message", "message1", value),
+                    ("Message", "message2", f"{middle_value}\n{value}"),
+                    ("Message", "message3", f"val\n.attr = \n{value}"),
+                    ("Term", "-term1", value),
+                    ("Term", "-term2", f"val\n.attr =\n{value}"),
+                ]:
+                    fluent_file = self.quick_fluent_file(
+                        [{"type": fluent_type, "source": source, "id": unit_id}]
+                    )
+                    self.assert_serialize_failure(
+                        fluent_file,
+                        f'^Error in source of FluentUnit "{unit_id}":',
+                    )
+                # As a special case, an Attribute can start with this and not
+                # throw an exception because it starts after an "=" sign.
+                fluent_file = self.quick_fluent_file(
+                    [
+                        {
+                            "type": "Term",
+                            "source": f"val\n.attr = {value}\n{middle_value}",
+                            "id": "-term",
+                        }
+                    ]
+                )
+                # Note that the serializer will keep it starting on the first line,
+                # even though it is a multiline value.
+                self.assert_serialize(
+                    fluent_file,
+                    f"""\
+                    -term = val
+                        .attr = {value}
+                            {middle_value}
+                    """,
+                )
+
+        # Characters that cannot be included at the start of a block. As
+        # specified in the fluent EBNF's "indented_char"
+        subtest_special_syntax_characters(".", False)
+        subtest_special_syntax_characters("*", False)
+        subtest_special_syntax_characters("[", False)
+        # Even though these are used in some syntax, they can be at the start of
+        # a block:
+        subtest_special_syntax_characters("]", True)
+        subtest_special_syntax_characters("#", True)
+        subtest_special_syntax_characters("(", True)
+        subtest_special_syntax_characters(")", True)
+        subtest_special_syntax_characters(":", True)
+        subtest_special_syntax_characters("$", True)
+        subtest_special_syntax_characters("-", True)
+        subtest_special_syntax_characters(">", True)
+        subtest_special_syntax_characters('"', True)
+        subtest_special_syntax_characters(",", True)
+
+    def test_multiline_message_term_comments(self):
+        """Test multiline Comments for fluent Messages and Terms."""
+        self.basic_test(
+            """\
+            # A comment
+            # over two lines
+            message = My Content
+            """,
+            [
+                {
+                    "id": "message",
+                    "source": "My Content",
+                    "comment": "A comment\nover two lines",
+                }
+            ],
+        )
+        self.basic_test(
+            """\
+            # A comment
+            #
+            # with a gap
+            -term = My Content
+                .attr = val
+            """,
+            [
+                {
+                    "id": "-term",
+                    "source": "My Content\n.attr = val",
+                    "comment": "A comment\n\nwith a gap",
+                }
+            ],
+        )
+
+    def test_resource_comments(self):
+        """Test fluent ResourceComments."""
+        self.basic_test(
+            """\
+            ### My resource comment
+            """,
+            [{"type": "ResourceComment", "comment": "My resource comment"}],
+            """\
+            ### My resource comment
+
+            """,
+        )
+        # Does not enter the message's comment.
+        self.basic_test(
+            """\
+            ### My resource
+            ### comment
+            message = value
+            """,
+            [
+                {"type": "ResourceComment", "comment": "My resource\ncomment"},
+                {"id": "message", "source": "value"},
+            ],
+            """\
+            ### My resource
+            ### comment
+
+            message = value
+            """,
+        )
+        # Blank line is preserved.
+        self.basic_test(
+            """\
+            ###
+            """,
+            [{"type": "ResourceComment", "comment": ""}],
+            """\
+            ###
+
+            """,
+        )
+
+    def test_group_comments(self):
+        """Test fluent GroupComments."""
+        self.basic_test(
+            """\
+            ## My group comment
+            """,
+            [{"type": "GroupComment", "comment": "My group comment"}],
+            """\
+            ## My group comment
+
+            """,
+        )
+        # Does not enter the term's comment.
+        self.basic_test(
+            """\
+            ## My group
+            ## comment
+            -term = value
+            """,
+            [
+                {"type": "GroupComment", "comment": "My group\ncomment"},
+                {"id": "-term", "source": "value"},
+            ],
+            """\
+            ## My group
+            ## comment
+
+            -term = value
+            """,
+        )
+        # Blank line is preserved.
+        self.basic_test(
+            """\
+            ##
+            """,
+            [{"type": "GroupComment", "comment": ""}],
+            """\
+            ##
+
+            """,
+        )
+
+    def test_detached_comment(self):
+        """Test fluent Comments with no Message or Term."""
+        self.basic_test(
+            """\
+            # My detached comment
+            """,
+            [{"type": "DetachedComment", "comment": "My detached comment"}],
+            """\
+            # My detached comment
+
+            """,
+        )
+        # A gap is sufficient to separate a comment from a message.
+        self.basic_test(
+            """\
+            # My detached
+            # comment
+
+            message = value
+            """,
+            [
+                {"type": "DetachedComment", "comment": "My detached\ncomment"},
+                {"id": "message", "source": "value"},
+            ],
+        )
+        # Separates from other comments as well.
+        self.basic_test(
+            """\
+            # My detached
+            # comment
+
+            # Another detached
+
+            # term comment
+            -term = value
+            """,
+            [
+                {"type": "DetachedComment", "comment": "My detached\ncomment"},
+                {"type": "DetachedComment", "comment": "Another detached"},
+                {"id": "-term", "source": "value", "comment": "term comment"},
+            ],
+            """\
+            # My detached
+            # comment
+
+
+            # Another detached
+
+            # term comment
+            -term = value
+            """,
+        )
+        # Blank line is preserved.
+        self.basic_test(
+            """\
+            #
+            """,
+            [{"type": "DetachedComment", "comment": ""}],
+            """\
+            #
+
+            """,
+        )
+
+    def test_reference(self):
+        """Test fluent MessageReferences, TermReferences and
+        VariableReferences."""
+        # Test reference to a term or message.
+        self.basic_test(
+            """\
+            -term1 = { -term2 } and { message }!
+            ref-message = { -term1 } with { message } { -term2 }
+                .attribute = { -term2 } over { message }
+            """,
+            # The FluentUnit just uses the same text.
+            # The references in the value become refs.
+            # NOTE: attribute refs do not.
+            [
+                {
+                    "id": "-term1",
+                    "source": "{ -term2 } and { message }!",
+                    "refs": ["-term2", "message"],
+                },
+                {
+                    "id": "ref-message",
+                    "source": "{ -term1 } with { message } { -term2 }\n"
+                    ".attribute = { -term2 } over { message }",
+                    "refs": ["-term1", "message", "-term2"],
+                },
+            ],
+        )
+        # TermReference with arguments.
+        self.basic_test(
+            """\
+            message = I am { -term1(tense: "present") }
+            -term = Going to { -term1(tense: "present", number: 7.5) } now
+            """,
+            [
+                {
+                    "id": "message",
+                    "source": 'I am { -term1(tense: "present") }',
+                    "refs": ["-term1"],
+                },
+                {
+                    "id": "-term",
+                    "source": 'Going to { -term1(tense: "present", number: 7.5) } now',
+                    "refs": ["-term1"],
+                },
+            ],
+        )
+        # Test references to a message's attribute.
+        self.basic_test(
+            """\
+            ref-message = { message.attribute }
+                .attribute = { i-9.attr } over { i-9 }
+            """,
+            # The FluentUnit just uses the same text.
+            [
+                {
+                    "id": "ref-message",
+                    "source": "{ message.attribute }\n"
+                    ".attribute = { i-9.attr } over { i-9 }",
+                    "refs": ["message.attribute"],
+                },
+            ],
+        )
+
+        # Test reference to variable.
+        self.basic_test(
+            """\
+            -term1 = Term with { $var }
+            ref-message = { $num1 } is greater than { $num2 }
+                .attribute = { $other-var } used
+            """,
+            # The FluentUnit just uses the same text.
+            [
+                # Variables used in terms do not become a ref since they are
+                # locale-specific.
+                {"id": "-term1", "source": "Term with { $var }", "refs": []},
+                {
+                    "id": "ref-message",
+                    "source": "{ $num1 } is greater than { $num2 }\n"
+                    ".attribute = { $other-var } used",
+                    "refs": ["$num1", "$num2"],
+                },
+            ],
+        )
+
+        # Mix.
+        self.basic_test(
+            """\
+            message = { $var } with { message.attr } and { -term }
+            """,
+            [
+                {
+                    "id": "message",
+                    "source": "{ $var } with { message.attr } and { -term }",
+                    "refs": ["$var", "message.attr", "-term"],
+                }
+            ],
+        )
+
+        # Repeated references are included twice only appear once in
+        # refs.
+        self.basic_test(
+            """\
+            message = { $var } with { -term0 } and { $var }
+            """,
+            [
+                {
+                    "id": "message",
+                    "source": "{ $var } with { -term0 } and { $var }",
+                    "refs": ["$var", "-term0"],
+                }
+            ],
+        )
+
+    def test_literals(self):
+        """Test fluent Literals."""
+        self.basic_test(
+            """\
+            -term = Term with number { 5 } literal and string { "s" } literal.
+            message = { " " } space literal
+                .attr = number { 79 }
+            """,
+            [
+                {
+                    "id": "-term",
+                    "source": 'Term with number { 5 } literal and string { "s" } literal.',
+                },
+                {
+                    "id": "message",
+                    "source": '{ " " } space literal\n' + ".attr = number { 79 }",
+                },
+            ],
+        )
+
+    def test_selectors(self):
+        """Test fluent selectors."""
+        self.basic_test(
+            """\
+            amount =
+                { $num ->
+                    [one] One apple.
+                   *[other] { $num } apples.
+                }
+            """,
+            # The FluentUnit just uses the same text.
+            [
+                {
+                    "id": "amount",
+                    "source": "{ $num ->\n"
+                    "    [one] One apple.\n"
+                    "   *[other] { $num } apples.\n"
+                    "}",
+                    # Get ref from the second variant.
+                    "refs": ["$num"],
+                }
+            ],
+        )
+
+        # Selector where the variable is not used in the branches.
+        self.basic_test(
+            """\
+            amount =
+                { $num ->
+                    [one] One apple.
+                   *[other] Some apples.
+                }
+            """,
+            # The FluentUnit just uses the same text.
+            [
+                {
+                    "id": "amount",
+                    "source": "{ $num ->\n"
+                    "    [one] One apple.\n"
+                    "   *[other] Some apples.\n"
+                    "}",
+                    # Get no ref.
+                    "refs": [],
+                }
+            ],
+        )
+
+        # On attribute, and using a Term Attribute.
+        self.basic_test(
+            """\
+            amount = { $num ->
+                [one] One apple.
+                 *[other] { $num } apples.
+            }
+             .attr = { -term-ref.vowel-start ->
+                 [yes] Have an { -term-ref }.
+               *[no] Have a { -term-ref }.
+             }
+            """,
+            # The FluentUnit just uses the same text.
+            [
+                {
+                    "id": "amount",
+                    "source": "{ $num ->\n"
+                    "    [one] One apple.\n"
+                    "   *[other] { $num } apples.\n"
+                    "}\n"
+                    ".attr =\n"
+                    "{ -term-ref.vowel-start ->\n"
+                    "    [yes] Have an { -term-ref }.\n"
+                    "   *[no] Have a { -term-ref }.\n"
+                    "}",
+                    "refs": ["$num"],
+                },
+            ],
+            """\
+            amount =
+                { $num ->
+                    [one] One apple.
+                   *[other] { $num } apples.
+                }
+                .attr =
+                    { -term-ref.vowel-start ->
+                        [yes] Have an { -term-ref }.
+                       *[no] Have a { -term-ref }.
+                    }
+            """,
+        )
+
+        # Selector with other text.
+        self.basic_test(
+            """\
+            amount =
+                Just eat { $num ->
+                    [one] an apple
+                   *[other] { $num } apples
+                } today.
+            """,
+            # The FluentUnit just uses the same text.
+            [
+                {
+                    "id": "amount",
+                    "source": "Just eat { $num ->\n"
+                    "    [one] an apple\n"
+                    "   *[other] { $num } apples\n"
+                    "} today.",
+                    "refs": ["$num"],
+                }
+            ],
+        )
+
+        # Sub-selector
+        self.basic_test(
+            """\
+            sub =
+                .a =
+                    { $num ->
+                        [zero] no apples
+                       *[other]
+                            { $num ->
+                                [one] { $num } apple
+                               *[other] { $num } apples
+                            } and { $num2 ->
+                                [one] { $num2 } oranges
+                               *[other] { $num2 } oranges
+                            }
+                    }
+            """,
+            [
+                {
+                    "id": "sub",
+                    "source": ".a =\n"
+                    "{ $num ->\n"
+                    "    [zero] no apples\n"
+                    "   *[other]\n"
+                    "        { $num ->\n"
+                    "            [one] { $num } apple\n"
+                    "           *[other] { $num } apples\n"
+                    "        } and { $num2 ->\n"
+                    "            [one] { $num2 } oranges\n"
+                    "           *[other] { $num2 } oranges\n"
+                    "        }\n"
+                    "}",
+                    # No refs since this is an attribute only.
+                }
+            ],
+        )
+
+        # Selector missing a default.
+        self.assert_parse_failure(
+            """\
+            message = { $var ->
+                [first] First
+                [second] Second
+            }
+            """,
+            r"message = { \$var ->",
+        )
+
+        fluent_file = self.quick_fluent_file(
+            [
+                {
+                    "type": "Message",
+                    "source": "{ $var ->\n[first] First\n[second] Second\n}",
+                    "id": "bad",
+                }
+            ]
+        )
+        self.assert_serialize_failure(
+            fluent_file,
+            r'^Error in source of FluentUnit "bad":\n.* \[line 4, column 1\]$',
+        )
+
+    def test_functions(self):
+        """Test fluent functions."""
+        self.basic_test(
+            """\
+            time = Time is { DATETIME($now, hour: "numeric") }
+            number = { NUMBER($var-num, minimumIntegerDigits: 4) } up
+            -term =
+                { NUMBER($n) ->
+                    [0] -> Term0
+                   *[other] -> Term
+                }
+            """,
+            # The FluentUnit just uses the same text.
+            [
+                {
+                    "id": "time",
+                    "source": 'Time is { DATETIME($now, hour: "numeric") }',
+                    "refs": ["$now"],
+                },
+                {
+                    "id": "number",
+                    "source": "{ NUMBER($var-num, minimumIntegerDigits: 4) } up",
+                    "refs": ["$var-num"],
+                },
+                {
+                    "id": "-term",
+                    "source": "{ NUMBER($n) ->\n"
+                    "    [0] -> Term0\n"
+                    "   *[other] -> Term\n"
+                    "}",
+                    # No variable refs for Term.
+                    "refs": [],
+                },
+            ],
+        )
+
+    def test_html_markup(self):
+        """Test that Message and Term values can contain html markup."""
+        self.basic_test(
+            """\
+            # The `link` is a link to the help page.
+            help = visit <a data-l10n-name="link">our help page</a> for more information.
+            """,
+            [
+                {
+                    "id": "help",
+                    "source": "visit "
+                    '<a data-l10n-name="link">our help page</a>'
+                    " for more information.",
+                    "comment": "The `link` is a link to the help page.",
+                }
+            ],
+        )
+
+    def test_parse_errors(self):
+        """Test that errors are extracted when parsing."""
+        self.assert_parse_failure(
+            """\
+            message = hello
+            # break
+            .floating-attribute = yellow
+            """,
+            r"\.floating-attribute = yellow",
+        )
+        self.assert_parse_failure(
+            """\
+            message = { -ref
+            """,
+            r"message = { -ref",
+        )
+
+    @staticmethod
+    def test_unit_ids():
+        """Test that setting valid ids is ok, and invalid ids are blocked."""
+        # Test valid ids.
+        for fluent_type, unit_id in [
+            ("Term", "-id"),
+            ("Message", "i0"),
+            ("Term", "-i9_8-h"),
+        ]:
+            unit = fluent.FluentUnit(
+                source="ok", unit_id=unit_id, fluent_type=fluent_type
+            )
+            unit.setid(unit_id + "a")
+            assert unit.getid() == unit_id + "a"
+        # Test invalid ids.
+        ok_id_dict = {"Message": "i", "Term": "-i"}
+        for fluent_type, unit_id in [
+            ("Term", "id"),
+            ("Term", "id.a"),
+            ("Term", "-id.a"),
+            ("Term", "--id"),
+            ("Message", "-id"),
+            ("Message", "id.a"),
+            ("Message", "a@"),
+            ("Message", "0id"),
+        ]:
+            with raises(ValueError, match=r"^Invalid id "):
+                fluent.FluentUnit(
+                    source="test", unit_id=unit_id, fluent_type=fluent_type
+                )
+            ok_id = ok_id_dict.get(fluent_type)
+            unit = fluent.FluentUnit(
+                source="test", unit_id=ok_id, fluent_type=fluent_type
+            )
+            with raises(ValueError, match=r"^Invalid id "):
+                unit.setid(unit_id)
+            assert unit.getid() == ok_id
+
+    def test_serialize_errors(self):
+        """Test that errors are extracted when serializing."""
+        fluent_file = self.quick_fluent_file(
+            [
+                {"type": "Message", "source": "fine", "id": "ok"},
+                {"type": "Message", "source": "tmp", "id": "message-id"},
+            ]
+        )
+        # Fluent syntax errors are not allowed.
+        for source, line, column in [
+            # Open placeable without closing.
+            ("{", 1, 2),
+            # Invalid id.
+            ("includes { -b@d-term }", 1, 14),
+            # Closing placeable without opening.
+            ("ok\n.bad = open } bracket", 2, 13),
+            # Invalid number literal.
+            ("ok\n.ok = value\n  .bad = { .5 }\n.attr = value", 3, 12),
+        ]:
+            fluent_file.units[1].source = source
+            self.assert_serialize_failure(
+                fluent_file,
+                r'^Error in source of FluentUnit "message-id":\n.* '
+                f"\\[line {line}, column {column}\\]$",
+            )
+
+    def test_several_entries(self):
+        """Test when we have several fluent Entries."""
+        self.basic_test(
+            """\
+            # My license
+            #
+            # for this file.
+
+
+            ### NOTE: Please be careful!
+
+
+            ## This group is special 🍄.
+
+            # Term to use
+            -term-1 =
+                { $possessive ->
+                   *[no] Elephant
+                    [yes] Elephant's
+                }
+                .vowel-start = yes
+            # Variables:
+            #   $var (string) - Some variable
+            message-1 =
+                Please select { $var } to continue.
+
+                Thanks.
+            message-2 = New Window 🙂
+                .title = Opens a new window
+                .accesskey = N
+            # Watch out for this one.
+            message-3 =
+                .title = This { -term-1 } is great
+                .alt =
+                    { -term-1.vowel-start ->
+                        [yes] An { -term-1(possessive: "yes") } tail.
+                       *[no] A { -term-1(possessive: "yes") } tail.
+                    }
+
+            ##
+
+            # Another message
+            final-message = done!
+            """,
+            [
+                {"type": "DetachedComment", "comment": "My license\n\nfor this file."},
+                {"type": "ResourceComment", "comment": "NOTE: Please be careful!"},
+                {"type": "GroupComment", "comment": "This group is special 🍄."},
+                {
+                    "id": "-term-1",
+                    "source": "{ $possessive ->\n"
+                    "   *[no] Elephant\n"
+                    "    [yes] Elephant's\n"
+                    "}\n"
+                    ".vowel-start = yes",
+                    "comment": "Term to use",
+                },
+                {
+                    "id": "message-1",
+                    "source": "Please select { $var } to continue.\n\nThanks.",
+                    "comment": "Variables:\n  $var (string) - Some variable",
+                    "refs": ["$var"],
+                },
+                {
+                    "id": "message-2",
+                    "source": "New Window 🙂\n"
+                    ".title = Opens a new window\n"
+                    ".accesskey = N",
+                },
+                {
+                    "id": "message-3",
+                    "source": ".title = This { -term-1 } is great\n"
+                    ".alt =\n"
+                    "{ -term-1.vowel-start ->\n"
+                    '    [yes] An { -term-1(possessive: "yes") } tail.\n'
+                    '   *[no] A { -term-1(possessive: "yes") } tail.\n'
+                    "}",
+                    "comment": "Watch out for this one.",
+                },
+                {"type": "GroupComment", "comment": ""},
+                {
+                    "id": "final-message",
+                    "source": "done!",
+                    "comment": "Another message",
+                },
+            ],
+        )

--- a/translate/storage/test_fluent.py
+++ b/translate/storage/test_fluent.py
@@ -197,12 +197,12 @@ creating-page-wait-message = Saving your shot…
         assert len(fluent_file.units) == 1
         fluent_unit = fluent_file.units[0]
         assert fluent_unit.getid() == "login-input"
-        assert fluent_unit.source == "Predefined value"
-        assert fluent_unit.getattributes() == {
-            "placeholder": "email@example.com",
-            "aria-label": "Login input value",
-            "title": "Type your login email",
-        }
+        assert (
+            fluent_unit.source == "Predefined value\n"
+            ".placeholder = email@example.com\n"
+            ".aria-label = Login input value\n"
+            ".title = Type your login email"
+        )
 
     def test_attributes_source(self):
         """Checks that attributes can be regenerated as source."""


### PR DESCRIPTION
We refactor the parsing and serializing of FluentFiles with a number of
improvements:

+ Fluent Term's keep a prefix "-" id so they can be better identified as  Terms, rather than Messages.
+ Fluent Terms and Messages expose all of their Attributes within a single FluentUnit in a fluent-ish syntax.
+ Multi-line values are now properly handled. In particular, the indent has been removed from the FluentUnit's source.
+ We no longer rely on methods from fluent.syntax sub-modlues that are not part of its public API (serialize_pattern, serialize_placeable, and FluentParser.maybe_get_pattern).
+ We throw ValueErrors if the FluentFile's FluentUnits do not serialize to valid fluent, with improved messaging (see issue https://github.com/translate/translate/issues/4448).
+ No longer include all fluent Placeables as placeholders since they may contain localized text. In particular, no longer include Placeables for SelectExpressions, FunctionReferences, NumberLiterals and StringLiterals.
+ We escape special characters "*", "[" and "." if they appear at the start of a value, for consistency with multiline values.
+ We include ResourceComments and GroupComments in the comments of FluentUnits under their scope.

We also refactor the test code and add coverage for these features and more.

Fixes https://github.com/translate/translate/issues/4649

Partially addresses https://github.com/translate/translate/issues/4448