### PR TITLE
json: Add support for go-i18n v2

### DIFF
--- a/docs/formats/json.rst
+++ b/docs/formats/json.rst
@@ -34,7 +34,8 @@ Example:
 Following JSON dialects are supported
 
 * Plain JSON files.
-* i18next
+* i18next v3 & v4
 * Web Extension i18n
-* `go-i18n <https://github.com/nicksnyder/go-i18n>`_
+* `go-i18n v1 & v2 <https://github.com/nicksnyder/go-i18n>`_
+* `gotext <https://pkg.go.dev/golang.org/x/text/cmd/gotext>`_
 * `ARB <https://github.com/google/app-resource-bundle/wiki/ApplicationResourceBundleSpecification>`_

--- a/translate/storage/test_jsonl10n.py
+++ b/translate/storage/test_jsonl10n.py
@@ -179,6 +179,36 @@ JSON_GOI18N = b"""[
 ]
 """
 
+JSON_GOI18N_V2 = b"""{
+    "key": "value",
+    "table": {
+        "description": "an article of furniture consisting of a flat, slablike top supported on one or more legs or other supports",
+        "other": "Table"
+    },
+    "tag": {
+        "description": "a piece or strip of strong paper, plastic, metal, leather, etc., for attaching by one end to something as a mark or label",
+        "one": "{{.count}} tag",
+        "other": "{{.count}} tags"
+    }
+}
+"""
+
+JSON_GOI18N_V2_COMPLEXE = b"""{
+    "key": {
+        "other": "value"
+    },
+    "table": {
+        "description": "an article of furniture consisting of a flat, slablike top supported on one or more legs or other supports",
+        "other": "Table"
+    },
+    "tag": {
+        "description": "a piece or strip of strong paper, plastic, metal, leather, etc., for attaching by one end to something as a mark or label",
+        "one": "{{.count}} tag",
+        "other": "{{.count}} tags"
+    }
+}
+"""
+
 JSON_ARB = b"""{
   "@@last_modified": "2019-11-06T22:41:37.002648",
   "Back": "Back",
@@ -968,6 +998,44 @@ class TestGoI18NJsonFile(test_monolingual.TestMonolingualStore):
         store.units[0].target = multistring(["{{.count}} tag"])
 
         assert '"other": ""' in bytes(store).decode()
+
+
+class TestGoI18NV2JsonFile(test_monolingual.TestMonolingualStore):
+    StoreClass = jsonl10n.GoI18NV2JsonFile
+
+    def test_plurals(self):
+        store = self.StoreClass()
+        store.parse(JSON_GOI18N_V2)
+
+        assert len(store.units) == 3
+        assert store.units[0].target == "value"
+        assert store.units[1].target == "Table"
+        assert store.units[2].target == multistring(
+            ["{{.count}} tag", "{{.count}} tags"]
+        )
+
+        assert bytes(store).decode() == JSON_GOI18N_V2.decode()
+
+    def test_plurals_missing(self):
+        store = self.StoreClass()
+        store.parse(JSON_GOI18N_V2)
+
+        store.units[2].target = multistring(["{{.count}} tag"])
+
+        assert '"other": "{{.count}} tag"' in bytes(store).decode()
+
+    def test_simplification(self):
+        store = self.StoreClass()
+        store.parse(JSON_GOI18N_V2_COMPLEXE)
+
+        assert len(store.units) == 3
+        assert store.units[0].target == "value"
+        assert store.units[1].target == "Table"
+        assert store.units[2].target == multistring(
+            ["{{.count}} tag", "{{.count}} tags"]
+        )
+
+        assert bytes(store).decode() == JSON_GOI18N_V2.decode()
 
 
 class TestARBJsonFile(test_monolingual.TestMonolingualStore):


### PR DESCRIPTION
go-i18n v2 supports other data-serialization format (TOML, YAML) with the same structure but I don't know if a mutualization is possible, nor how to do it. But if desirable I'm willing to try with some advices.