### PR TITLE
rc: Ignore pragma encoding on unicode files

### DIFF
--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -387,7 +387,11 @@ class rcfile(base.TranslationStore):
 
         for statement in results:
             # Parse pragma
-            if statement[0] == "#pragma" and "code_page" in statement[1]:
+            if (
+                statement[0] == "#pragma"
+                and "code_page" in statement[1]
+                and self.encoding not in ("utf-8", "utf-16")
+            ):
                 expected_encoding = parse_encoding_pragma(statement[1])
                 if expected_encoding and expected_encoding != self.encoding:
                     self.units = []


### PR DESCRIPTION
We already know the correct charset in that case and restarting in 8-bit charset will not bring anything good.

Fixes #4853