### PR TITLE
poxliff: Avoid using "None" as string when plural is not translated

### DIFF
--- a/translate/storage/poxliff.py
+++ b/translate/storage/poxliff.py
@@ -123,7 +123,7 @@ class PoXliffUnit(xliff.xliffunit):
 
     def gettarget(self, lang=None):
         if self.hasplural():
-            strings = [unit.target for unit in self.units]
+            strings = [unit.target or "" for unit in self.units]
             if strings:
                 return multistring(strings)
             else:

--- a/translate/storage/test_poxliff.py
+++ b/translate/storage/test_poxliff.py
@@ -122,3 +122,26 @@ class TestPOXLIFFfile(test_xliff.TestXLIFFfile):
             xlifffile.units[0].getnotes("po-translator")
             == "Zulu translation of program ABC"
         )
+
+    def test_plural(self):
+        minixlf = (
+            self.xliffskeleton
+            % """
+        <group id="1238108068" restype="x-gettext-plurals">
+                <trans-unit id="1238108068[0]" xml:space="preserve">
+                        <source>This field must contain at least {0,number} character</source>
+                </trans-unit>
+                <trans-unit id="1238108068[1]" xml:space="preserve">
+                        <source>This field must contain at least {0,number} characters</source>
+                </trans-unit>
+        </group>
+            """
+        )
+        xlifffile = self.StoreClass.parsestring(minixlf)
+        assert len(xlifffile.units) == 1
+        unit = xlifffile.units[0]
+        assert unit.source.strings == [
+            "This field must contain at least {0,number} character",
+            "This field must contain at least {0,number} characters",
+        ]
+        assert unit.target == ["", ""]


### PR DESCRIPTION
The emebdded unit returns None and passing it to multistring makes it "None" string.