### PR TITLE
feat(junitmsgfmt): Rewrite in python; add --untranslated option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,8 +42,7 @@ packages = find_namespace:
 python_requires = >=3.7
 include_package_data = 1
 zip_safe = 0
-scripts =   
-    tools/junitmsgfmt
+scripts =
     tools/mozilla/build_firefox.sh
     tools/mozilla/buildxpi.py
     tools/mozilla/get_moz_enUS.py
@@ -72,6 +71,7 @@ console_scripts =
         idml2po = translate.convert.idml2po:main
         ini2po = translate.convert.ini2po:main
         json2po = translate.convert.json2po:main
+        junitmsgfmt = translate.tools.junitmsgfmt:main
         mozfunny2prop = translate.convert.mozfunny2prop:main
         mozlang2po = translate.convert.mozlang2po:main
         moz2po = translate.convert.moz2po:main

--- a/tests/cli/data/test_junitmsgfmt_failure/one.po
+++ b/tests/cli/data/test_junitmsgfmt_failure/one.po
@@ -1,0 +1,9 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#, python-brace-format
+msgid "\"{input}\" is not a valid choice."
+msgstr "\"{value}\" is not a valid choice."

--- a/tests/cli/data/test_junitmsgfmt_failure/stdout.txt
+++ b/tests/cli/data/test_junitmsgfmt_failure/stdout.txt
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testsuite name="msgfmt" errors="0" skips="0" failures="1" tests="1" time="0.0000">
+  <testcase classname="msgfmt" name="check" file="./tests/cli/data/test_junitmsgfmt_failure/one.po" time="0.0000">
+    <failure message="Failure">one.po:2: warning: header field 'Project-Id-Version' missing in header
+one.po:2: warning: header field 'PO-Revision-Date' missing in header
+one.po:2: warning: header field 'Last-Translator' missing in header
+one.po:2: warning: header field 'Language-Team' missing in header
+one.po:2: warning: header field 'MIME-Version' missing in header
+one.po:2: warning: header field 'Content-Transfer-Encoding' missing in header
+one.po:9: a format specification for argument 'input' doesn't exist in 'msgstr'
+msgfmt: found 1 fatal error
+1 translated message.
+</failure>
+  </testcase>
+</testsuite>

--- a/tests/cli/data/test_junitmsgfmt_help/stdout.txt
+++ b/tests/cli/data/test_junitmsgfmt_help/stdout.txt
@@ -1,0 +1,8 @@
+usage: junitmsgfmt [-h] [--untranslated] files [files ...]
+
+positional arguments:
+  files
+
+options:
+  -h, --help      show this help message and exit
+  --untranslated  fail on untranslated messages

--- a/tests/cli/data/test_junitmsgfmt_untranslated/one.po
+++ b/tests/cli/data/test_junitmsgfmt_untranslated/one.po
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Hello."
+msgstr ""
+
+#, fuzzy
+msgid "Hello fuzzy."
+msgstr "Greetings..."
+

--- a/tests/cli/data/test_junitmsgfmt_untranslated/stdout.txt
+++ b/tests/cli/data/test_junitmsgfmt_untranslated/stdout.txt
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testsuite name="msgfmt" errors="0" skips="0" failures="1" tests="1" time="0.0000">
+  <testcase classname="msgfmt" name="check" file="./tests/cli/data/test_junitmsgfmt_untranslated/one.po" time="0.0000">
+    <failure message="Untranslated messages">one.po:2: warning: header field 'Project-Id-Version' missing in header
+one.po:2: warning: header field 'PO-Revision-Date' missing in header
+one.po:2: warning: header field 'Last-Translator' missing in header
+one.po:2: warning: header field 'Language-Team' missing in header
+one.po:2: warning: header field 'MIME-Version' missing in header
+one.po:2: warning: header field 'Content-Transfer-Encoding' missing in header
+0 translated messages, 1 fuzzy translation, 1 untranslated message.
+</failure>
+  </testcase>
+</testsuite>

--- a/tests/cli/test_junitmsgfmt_failure.sh
+++ b/tests/cli/test_junitmsgfmt_failure.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source $(dirname $0)/test.inc.sh
+
+python $PYTHON_ARGS $(which junitmsgfmt) $one
+check_results

--- a/tests/cli/test_junitmsgfmt_help.sh
+++ b/tests/cli/test_junitmsgfmt_help.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source $(dirname $0)/test.inc.sh
+
+python $PYTHON_ARGS $(which junitmsgfmt) -h
+start_checks
+has_stdout
+end_checks

--- a/tests/cli/test_junitmsgfmt_untranslated.sh
+++ b/tests/cli/test_junitmsgfmt_untranslated.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source $(dirname $0)/test.inc.sh
+
+python $PYTHON_ARGS $(which junitmsgfmt) --untranslated $one
+check_results

--- a/translate/tools/junitmsgfmt.py
+++ b/translate/tools/junitmsgfmt.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import subprocess
+import xml.etree.ElementTree as etree
+from argparse import ArgumentParser
+from os.path import basename
+from time import time
+from typing import Iterable, NamedTuple
+
+
+class MsgfmtTester:
+    def __init__(self, files: Iterable[str], untranslated=False):
+        self._detect_untranslated = untranslated
+        self._files = files
+
+    def run(self):
+        results = list(map(self._run_msgfmt, self._files))
+        self._print_results(results)
+
+    def _run_msgfmt(self, pofile: str):
+        start_time = time()
+        process = subprocess.Popen(
+            ["msgfmt", "-cv", "-o", "/dev/null", pofile],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        stdout, stderr = process.communicate()
+        assert not stdout, "Unexpected stdout received."
+        stderr = stderr.replace(pofile, basename(pofile))
+
+        failures: list[CheckFailure] = []
+        if process.returncode:
+            failures.append(CheckFailure(stderr, "Failure"))
+        elif self._detect_untranslated and "untranslated" in stderr:
+            failures.append(CheckFailure(stderr, "Untranslated messages"))
+        return CheckResult(
+            pofile,
+            0 if "test_junitmsgfmt" in pofile else time() - start_time,
+            failures,
+        )
+
+    def _print_results(self, results: list[CheckResult]):
+        failures = len([r for r in results if len(r.failures)])
+        total_time = sum([r.time for r in results], 0)
+        root = etree.Element(
+            "testsuite",
+            name="msgfmt",
+            errors="0",
+            skips="0",
+            failures=str(failures),
+            tests=str(len(results)),
+            time=f"{total_time:.4f}",
+        )
+        for result in results:
+            case = etree.SubElement(
+                root,
+                "testcase",
+                classname="msgfmt",
+                name="check",
+                file=result.file,
+                time=f"{result.time:.4f}",
+            )
+            for failure in result.failures:
+                etree.SubElement(
+                    case, "failure", message=failure.message
+                ).text = failure.text
+        etree.indent(root)
+        print(etree.tostring(root, encoding="unicode", xml_declaration=True))
+
+
+class CheckResult(NamedTuple):
+    file: str
+    time: float
+    failures: list[CheckFailure]
+
+
+class CheckFailure(NamedTuple):
+    text: str
+    message: str
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--untranslated",
+        action="store_true",
+        default=False,
+        help="fail on untranslated messages",
+    )
+    parser.add_argument("files", nargs="+")
+
+    args = parser.parse_args()
+
+    MsgfmtTester(args.files, untranslated=args.untranslated).run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I started to add junit output to pocount, but figured out it's better to rewrite existing junitmsgfmt to report untranslated messages.

Default behaviour is the same as the old one, and with `--untranslated` option it will add failures for files with untranslated messages.

I would like to hear some feedback, especially for tests as this is my first PR here.

Refs #4879