### PR TITLE
aresource: fix single whitespace

### DIFF
--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -99,8 +99,8 @@ class AndroidResourceUnit(base.TranslationUnit):
                 # Handle whitespace collapsing
                 if c is not EOF and c in WHITESPACE:
                     space_count += 1
-                elif space_count > 1:
-                    # Remove duplicate whitespace; Pay attention: We
+                elif space_count >= 1:
+                    # Remove sequential whitespace; Pay attention: We
                     # don't do this if we are currently inside a quote,
                     # except for one special case: If we have unbalanced
                     # quotes, e.g. we reach eof while a quote is still
@@ -113,17 +113,6 @@ class AndroidResourceUnit(base.TranslationUnit):
                         i -= space_count - 1
                         if strip and (i == 1 or c is EOF):
                             del text[i - 1]
-                    space_count = 0
-                elif space_count == 1:
-                    # At this point we have a single whitespace character,
-                    # but it might be a newline or tab. If we write this
-                    # kind of insignificant whitespace into the .po file,
-                    # it will be considered significant on import. So,
-                    # make sure that this kind of whitespace is always a
-                    # standard space.
-                    text[i - 1] = " "
-                    if strip and not active_quote and (i == 1 or c is EOF):
-                        del text[i - 1]
                     space_count = 0
                 else:
                     space_count = 0

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -470,17 +470,17 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
         self.__check_parse("\u0230", r'<string name="test">\u0230</string>')
 
     def test_single_unescaped(self):
-        string = 'a b c d'
+        string = "a b c d"
         xml = '<string name="teststring">a\nb\tc d</string>'
         self.__check_parse(string, xml)
 
     def test_single_escaped_alone(self):
-        string = 'a\nb\tc d'
+        string = "a\nb\tc d"
         xml = '<string name="teststring">a"\n"b"\t"c" "d</string>'
         self.__check_parse(string, xml)
 
     def test_single_escaped_full(self):
-        string = 'a\nb\tc d'
+        string = "a\nb\tc d"
         xml = '<string name="teststring">"a\nb\tc d"</string>'
         self.__check_parse(string, xml)
 

--- a/translate/storage/test_aresource.py
+++ b/translate/storage/test_aresource.py
@@ -274,7 +274,7 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
 
     def test_parse_quoted_newlines(self):
         self.__check_parse(
-            "\n\nstring with newlines",
+            "\n\n\n\nstring with newlines",
             r"""<string name="teststring">"
 \n
 \nstring with newlines"</string>
@@ -468,6 +468,21 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
         with pytest.raises(ValueError):
             self.__check_parse("", r'<string name="test">\utest</string>')
         self.__check_parse("\u0230", r'<string name="test">\u0230</string>')
+
+    def test_single_unescaped(self):
+        string = 'a b c d'
+        xml = '<string name="teststring">a\nb\tc d</string>'
+        self.__check_parse(string, xml)
+
+    def test_single_escaped_alone(self):
+        string = 'a\nb\tc d'
+        xml = '<string name="teststring">a"\n"b"\t"c" "d</string>'
+        self.__check_parse(string, xml)
+
+    def test_single_escaped_full(self):
+        string = 'a\nb\tc d'
+        xml = '<string name="teststring">"a\nb\tc d"</string>'
+        self.__check_parse(string, xml)
 
 
 class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):


### PR DESCRIPTION
### Description
PR to fix single whitespace not preserved (#4884)

Includes three new tests to check single whitespace in no-quote, single-quote and full-quote.

### Explanation
A single space on android is not treated differently than multispace, the logic to replace/collapse multiple strings should be the same, as opposed to the source code comment.

### Extra modification
About the modified test (test_parse_quoted_newlines)

The input string on android:
![image](https://user-images.githubusercontent.com/10616202/233698904-947e6326-89c9-46f5-9741-22f3abc35a19.png)
when displayed on a textview:
![image](https://user-images.githubusercontent.com/10616202/233699247-6f8a46db-47ac-4abd-90f5-ff2c21145c17.png)
and fetched
![image](https://user-images.githubusercontent.com/10616202/233699462-cd29da2e-cfe7-473d-9a75-668710165faf.png)
returns
![image](https://user-images.githubusercontent.com/10616202/233699639-5a615fc4-eae3-423c-8c46-2b277ac55cd2.png)

Which makes sense, because the '\n' are always converted to linebreaks, and the actual linebreaks are only converter while inside a quoted part, which we are.


Fixes #4884