### PR TITLE
feat: Drop python 3.7

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,14 +22,13 @@ jobs:
       matrix:
         requirements: [latest]
         python-version:
-        - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
         include:
         - requirements: minimal
-          python-version: '3.7'
+          python-version: '3.8'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         requirements: [latest]
         python-version:
-        - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         requirements: [latest]
         python-version:
-        - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
   rev: v3.4.0
   hooks:
   - id: pyupgrade
-    args: [--py36-plus]
+    args: [--py38-plus]
 - repo: https://github.com/psf/black
   rev: 23.3.0
   hooks:

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ feature set. This cal be easily specified during pip installation::
    Will install all optional dependencies convering support for many other
    formats.
 
-The Toolkit requires Python 3.7 or newer.
+The Toolkit requires Python 3.8 or newer.
 
 The package lxml is required. You should install version 4.6.3 or later.
 <http://lxml.de/> Depending on your platform, the easiest way to install might

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,4 @@
 pytest==7.3.1
 pytest-cov==4.0.0
 pytest-xdist==3.3.0
-syrupy==4.0.2; python_version >= "3.8"
+syrupy==4.0.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,5 @@
 -r optional.txt
 pytest==7.3.1
 pytest-cov==4.1.0
-pytest-xdist==3.3.0
 pytest-xdist==3.3.1
 syrupy==4.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -39,7 +38,7 @@ project_urls =
 
 [options]
 packages = find_namespace:
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = 1
 zip_safe = 0
 scripts =

--- a/translate/tools/_test_utils.py
+++ b/translate/tools/_test_utils.py
@@ -1,11 +1,3 @@
-import sys
-
-import pytest
-
-requires_py38_mark = pytest.mark.skipif(
-    sys.version_info < (3, 8), reason="Requires python 3.8"
-)
-
 test_po_files = [
     "tests/cli/data/test_pocount_po_csv/one.po",
     "tests/cli/data/test_pocount_po_file/one.po",

--- a/translate/tools/pocount.py
+++ b/translate/tools/pocount.py
@@ -34,18 +34,13 @@ import sys
 from argparse import ArgumentParser
 from collections import defaultdict
 from dataclasses import dataclass
+from functools import cached_property
 from operator import itemgetter
 
 from translate.lang.common import Common
 from translate.misc.multistring import multistring
 from translate.storage import factory
 from translate.storage.workflow import StateEnum
-
-try:
-    from functools import cached_property
-except ImportError:
-    # Fix for python 3.7
-    cached_property = property
 
 extended_state_strings = {
     StateEnum.EMPTY: "empty",

--- a/translate/tools/test_junitmsgfmt.py
+++ b/translate/tools/test_junitmsgfmt.py
@@ -2,10 +2,7 @@ from pytest import mark, param
 
 from translate.tools import junitmsgfmt
 
-from ._test_utils import requires_py38_mark
 
-
-@requires_py38_mark
 @mark.parametrize(
     "opts",
     [

--- a/translate/tools/test_pocount.py
+++ b/translate/tools/test_pocount.py
@@ -5,7 +5,7 @@ from pytest import mark
 from translate.storage import po
 from translate.tools import pocount
 
-from ._test_utils import requires_py38_mark, test_po_files
+from ._test_utils import test_po_files
 
 
 class TestCount:
@@ -166,7 +166,6 @@ msgstr ""
         assert stats["totalsourcewords"] == 6
 
 
-@requires_py38_mark
 @mark.parametrize("style", ["csv", "full", "short-strings", "short-words"])
 @mark.parametrize("incomplete", [True, False], ids=lambda v: f"incomplete={v}")
 @mark.parametrize("no_color", [True, False], ids=lambda v: f"no-color={v}")


### PR DESCRIPTION
Python 3.7 security support ends in 1 month and 1 week, and snapshot testing (syrupy) requires at least 3.8 to work, let's drop it from CI, and then start using snapshot testing instead of the old shell-based tests.