### PR TITLE
rc: Avoid excessive use of regular expressions

### DIFF
--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -52,22 +52,16 @@ from translate.storage import base
 
 
 def escape_to_python(string):
-    """Escape a given .rc string into a valid Python string."""
-    pystring = re.sub('"\\s*\\\\\n\\s*"', "", string)  # xxx"\n"xxx line continuation
-    pystring = re.sub("\\\\\\\n", "", pystring)  # backslash newline line continuation
-    pystring = re.sub(
-        "\\\\n", "\n", pystring
-    )  # Convert escaped newline to a real newline
-    pystring = re.sub(
-        "\\\\r", "\r", pystring
-    )  # Convert escaped carriage-return to a real carriage-return
-    pystring = re.sub("\\\\t", "\t", pystring)  # Convert escape tab to a real tab
-    pystring = re.sub(
-        "\\\\\\\\", "\\\\", pystring
-    )  # Convert escape backslash to a real escaped backslash
-    # Fix quotes
-    pystring = pystring.replace('""', '"')
-    return pystring
+    """Unescape a given .rc string into a valid Python string."""
+    return (
+        re.sub('"\\s*\\\\\n\\s*"', "", string)  # xxx"\n"xxx line continuation
+        .replace("\\\n", "")  # backslash newline line continuation
+        .replace(r"\r", "\r")
+        .replace(r"\n", "\n")
+        .replace(r"\t", "\t")
+        .replace(r"\\", "\\")
+        .replace('""', '"')
+    )
 
 
 def extract_text(values):
@@ -94,12 +88,13 @@ def extract_id(values):
 
 def escape_to_rc(string):
     """Escape a given Python string into a valid .rc string."""
-    rcstring = re.sub("\\\\", "\\\\\\\\", string)
-    rcstring = re.sub("\t", "\\\\t", rcstring)
-    rcstring = re.sub("\n", "\\\\n", rcstring)
-    rcstring = re.sub("\r", "\\\\r", rcstring)
-    rcstring = rcstring.replace('"', '""')
-    return rcstring
+    return (
+        string.replace("\\", r"\\")
+        .replace("\t", r"\t")
+        .replace("\n", r"\n")
+        .replace("\r", r"\r")
+        .replace('"', '""')
+    )
 
 
 class rcunit(base.TranslationUnit):


### PR DESCRIPTION
Use simple string replace instead. This also makes the code more readable due to removed additional escaping for re.