### PR TITLE
rc: preserver newlines in po2rc

### DIFF
--- a/translate/convert/test_po2rc.py
+++ b/translate/convert/test_po2rc.py
@@ -329,3 +329,40 @@ msgstr "Vypnout..."
             rc_result = rcfile(handle)
         assert len(rc_result.units) == 4
         assert rc_result.units[3].target == "Vypnout..."
+
+    def test_convert_newlines(self):
+        """Tests the conversion to a po file"""
+        source = """
+STRINGTABLE
+BEGIN
+ID_T_1 "Hello"
+END
+"""
+        expected = """
+STRINGTABLE
+BEGIN
+    ID_T_1                  "Ahoj"
+END
+"""
+        pofile = """
+#: STRINGTABLE.ID_T_1
+msgid "Hello"
+msgstr "Ahoj"
+"""
+        self.create_testfile("simple.rc", "\r\n".join(source.splitlines()))
+        self.create_testfile("simple.po", pofile)
+        self.run_command(
+            template="simple.rc", i="simple.po", o="output.rc", l="LANG_CZECH"
+        )
+        with self.open_testfile("output.rc", "rb") as handle:
+            content = handle.read()
+            assert content == "\r\n".join(expected.splitlines()).encode()
+
+        self.create_testfile("simple.rc", "\n".join(source.splitlines()))
+        self.create_testfile("simple.po", pofile)
+        self.run_command(
+            template="simple.rc", i="simple.po", o="output.rc", l="LANG_CZECH"
+        )
+        with self.open_testfile("output.rc", "rb") as handle:
+            content = handle.read()
+            assert content == "\n".join(expected.splitlines()).encode()

--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -327,6 +327,7 @@ class rcfile(base.TranslationStore):
         self.filename = getattr(inputfile, "name", "")
         self.lang = lang
         self.sublang = sublang
+        self.newline = "\r\n"
         if inputfile is not None:
             rcsrc = inputfile.read()
             inputfile.close()
@@ -375,6 +376,14 @@ class rcfile(base.TranslationStore):
             decoded, self.encoding = self.detect_encoding(
                 rcsrc, default_encodings=[self.default_encoding]
             )
+
+        # Extract first newline
+        for line in decoded.splitlines(True):
+            if len(line) >= 2 and line[-2] in ("\r", "\n"):
+                self.newline = line[-2:]
+            else:
+                self.newline = line[-1]
+            break
 
         decoded = decoded.replace("\r", "")
 


### PR DESCRIPTION
This avoids producing messy files with half of lines using \r\n and half \n.