### PR TITLE
Fluent: add some API for use in weblate

### DIFF
--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -334,7 +334,7 @@ class FluentUnit(base.TranslationUnit):
         string with an error message if this fails.
         """
         source = self.source
-        if source is None or not source.strip():
+        if not source:
             return None
 
         # Create a fluent Message by prefixing the source with "unit-id = \n"

--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import re
 import textwrap
+from collections.abc import Iterator
 from typing import BinaryIO
 
 from fluent.syntax import FluentSerializer, ast, parse, serialize, visitor
@@ -83,6 +84,581 @@ class _SanitizeVisitor(visitor.Visitor):
                 pattern.elements.insert(0, ast.Placeable(ast.StringLiteral(first_char)))
 
         self.generic_visit(pattern)
+
+
+def _fluent_pattern_to_source(pattern: ast.Pattern) -> str:
+    """Convert the fluent Pattern into a source string."""
+    if not pattern.elements:
+        raise ValueError("Unexpected fluent Pattern without any elements")
+
+    sanitizer = _SanitizeVisitor()
+    sanitizer.visit(pattern)
+
+    # Create a fluent Message with the given pattern and serialize it.
+    # We use serialize_entry which is part of python-fluent's public API.
+    source = FluentSerializer().serialize_entry(
+        ast.Message(ast.Identifier("i"), value=pattern)
+    )
+
+    # Strip away the id part: "i =". For single-line values, a space is also
+    # added. For multi-line values, a newline is added.
+    # NOTE: Since we escaped any leading special character, the newline is
+    # expected to always be added for multiline values.
+    source = re.sub(r"^i =( |\n)", "", source, count=1)
+    # Strip away the trailing newline that the serializer adds.
+    source = re.sub(r"\n$", "", source, count=1)
+
+    # Remove the common indent.
+    # NOTE: textwrap.dedent also collapses blank lines.
+    return textwrap.dedent(source)
+
+
+class FluentReference:
+    """Represents a reference Expression found in a fluent Pattern."""
+
+    def __init__(
+        self,
+        reference: (ast.MessageReference | ast.TermReference | ast.VariableReference),
+    ) -> None:
+        """
+        :param reference: The reference this represents.
+        :type reference: MessageReference or TermReference or VariableReference
+        """
+        if isinstance(reference, ast.MessageReference):
+            self._type_name = "message"
+            attribute = reference.attribute
+        elif isinstance(reference, ast.TermReference):
+            self._type_name = "term"
+            attribute = reference.attribute
+        elif isinstance(reference, ast.VariableReference):
+            self._type_name = "variable"
+            attribute = None
+        else:
+            raise ValueError(f"Unhandled reference type {reference.__class__.__name__}")
+        ref_name = reference.id.name
+        if attribute:
+            ref_name += f".{attribute.name}"
+        self._name = ref_name
+
+    @property
+    def type_name(self) -> str:
+        """The name for the type of reference.
+
+        :type: str
+        """
+        return self._type_name
+
+    @property
+    def name(self) -> str:
+        """The the reference name.
+
+        :type: str
+        """
+        return self._name
+
+
+class _ReferenceVisitor(visitor.Visitor):
+    """Private class used to extract the Fluent references found below a fluent
+    object.
+    """
+
+    def __init__(self) -> None:
+        self.refs: list[FluentReference] = []
+
+    def _add_ref(
+        self,
+        node: ast.MessageReference | ast.TermReference | ast.VariableReference,
+    ) -> None:
+        self.refs.append(FluentReference(node))
+
+    def visit_MessageReference(self, node: ast.MessageReference) -> None:
+        self._add_ref(node)
+        # NOTE: We do not call Visitor.generic_visit because there is no child
+        # to descend into for this type.
+
+    def visit_TermReference(self, node: ast.TermReference) -> None:
+        self._add_ref(node)
+
+    def visit_VariableReference(self, node: ast.VariableReference) -> None:
+        self._add_ref(node)
+
+
+class FluentSelectorNode:
+    """Represents a single Fluent SelectExpression.
+
+    Each instance will store details about the SelectExpression's selector, and
+    will have a child FluentSelectorBranch for each Variant in the
+    SelectExpression. It's parent FluentSelectorBranch represents the Fluent
+    Pattern this SelectExpression was found within.
+    """
+
+    def __init__(
+        self,
+        select_expression: ast.SelectExpression,
+        parent_branch: FluentSelectorBranch,
+    ) -> None:
+        """
+        :param select_expression: The SelectExpression this represents.
+        :type selector: SelectExpression
+        :param parent_branch: The branch this node belongs to.
+        :type parent_branch: FluentSelectorBranch
+        """
+        self._selector = select_expression.selector.clone()
+        self._serialized_selector: str | None = None
+        self._selector_references: list[FluentReference] | None = None
+
+        self._parent_branch = parent_branch
+
+        # We create a new FluentSelectorBranch for each Variant found in this
+        # select expression.
+        # NOTE: We expect _child_branches to be non-empty since a
+        # SelectExpression must have at least one (default) variant.
+        self._child_branches = [
+            FluentSelectorBranch(variant.value, variant, self)
+            for variant in select_expression.variants
+        ]
+
+    @property
+    def parent_branch(self) -> FluentSelectorBranch:
+        """The branch this node is below.
+
+        The branch represents the Fluent Pattern the SelectExpression was found
+        within.
+
+        :type: FluentSelectorBranch
+        """
+        return self._parent_branch
+
+    @property
+    def child_branches(self) -> list[FluentSelectorBranch]:
+        """The child branches for this node.
+
+        The child branches represent the Variants found within the
+        SelectExpression.
+
+        :type: list[FluentSelectorBranch]
+        """
+        return self._child_branches
+
+    @property
+    def serialized_selector(self) -> str:
+        """A serialized form of the SelectExpression's selector Expression.
+
+        :type: str
+        """
+        if self._serialized_selector is None:
+            # NOTE: Current fluent.syntax library only allows the select
+            # expression's selector to be a:
+            #  + TermReference with an attribute,
+            #  + VariableReference,
+            #  + FunctionReference,
+            #  + StringLiteral, or
+            #  + NumberLiteral
+            pattern = ast.Pattern([ast.Placeable(self._selector)])
+            serialized = _fluent_pattern_to_source(pattern)
+            # Strip the outer pattern that we wrapped it in.
+            serialized = re.sub("^{ *", "", serialized, count=1)
+            serialized = re.sub(" *}$", "", serialized, count=1)
+            self._serialized_selector = serialized
+        return self._serialized_selector
+
+    @property
+    def selector_references(self) -> list[FluentReference]:
+        """The references found in the SelectExpression's selector Expression.
+
+        These are in the order of appearance.
+
+        :type: list[FluentReference]
+        """
+        if self._selector_references is None:
+            ref_visitor = _ReferenceVisitor()
+            ref_visitor.visit(self._selector)
+            # Take the refs from the visitor.
+            self._selector_references = ref_visitor.refs
+        return self._selector_references
+
+
+class FluentSelectorBranch:
+    """Represents a Fluent Pattern.
+
+    The Pattern can either be the Fluent value or Attribute for a Message or
+    Term, or it can belong to a SelectExpression's Variant.
+
+    Each instance will have one FluentSelectorNode child for each
+    SelectExpression found within the Pattern.
+
+    If an instance represents a Variant Pattern, it will also store other
+    details about the Variant and it will have a parent FluentSelectorNode that
+    represents the SelectExpression the Variant was found within.
+    """
+
+    def __init__(
+        self,
+        pattern: ast.Pattern,
+        variant: ast.Variant | None,
+        parent_node: FluentSelectorNode | None,
+    ) -> None:
+        """
+        :param pattern: The Pattern this represents.
+        :type pattern: Pattern
+        :param variant: The Variant this Pattern belongs to, or None if this is
+        a top-level Pattern.
+        :type variant: Variant or None
+        :param parent_node: The parent node this belongs to, or None if this is
+        a top-level Pattern.
+        :type selector: FluentSelectorNode or None
+        """
+        self._variant = variant.clone() if variant else None
+        self._top_references: list[FluentReference] | None = None
+
+        self._parent_node = parent_node
+
+        self._child_nodes: list[FluentSelectorNode] = []
+        self._elements: list[FluentSelectorNode | ast.PatternElement] = []
+        for element in pattern.elements:
+            # If we have a select expression, we convert it into a
+            # FluentSelectorNode. Otherwise we keep a copy of the raw
+            # PatternElement.
+            # NOTE: It is important to keep the FluentSelectorNodes and
+            # PatternElements ordered in the same list to be able to generate
+            # the flat Patterns.
+            select_expression = self._get_select_expression(element)
+            if select_expression:
+                node = FluentSelectorNode(select_expression, self)
+                self._elements.append(node)
+                self._child_nodes.append(node)
+            else:
+                self._elements.append(element.clone())
+
+    @staticmethod
+    def _get_select_expression(
+        fluent_node: ast.PatternElement,
+    ) -> ast.SelectExpression | None:
+        """Get the SelectExpression found below the given PatternElement
+        fluent_node, or return None if the PatternElement does not contain one.
+        """
+        # A SelectExpression will be wrapped by at least on Placeable, but in
+        # principle could be be wrapped by a longer series of Placeables.
+        while isinstance(fluent_node, ast.Placeable):
+            fluent_node = fluent_node.expression
+            if isinstance(fluent_node, ast.SelectExpression):
+                return fluent_node
+        return None
+
+    @property
+    def parent_node(self) -> FluentSelectorNode | None:
+        """The parent this branch is below, if any.
+
+        The node represents the SelectExpression the Fluent Pattern was found
+        within if it belonged to a Variant.
+
+        :type: FluentSelectorNode or None
+        """
+        return self._parent_node
+
+    @property
+    def child_nodes(self) -> list[FluentSelectorNode]:
+        """The child nodes for this branch.
+
+        The child nodes represent the SelectExpressions found within the
+        Pattern.
+
+        :type: list[FluentSelectorNode]
+        """
+        return self._child_nodes
+
+    @property
+    def top_references(self) -> list[FluentReference]:
+        """The references found in the Pattern.
+
+        This excludes any references found within any child SelectExpression.
+
+        These are in the order of appearance.
+
+        :type: list[FluentReference]
+        """
+        if self._top_references is None:
+            ref_visitor = _ReferenceVisitor()
+            for element in self._elements:
+                if isinstance(element, FluentSelectorNode):
+                    continue
+                ref_visitor.visit(element)
+            # Take the refs from the visitor.
+            self._top_references = ref_visitor.refs
+        return self._top_references
+
+    @property
+    def key(self) -> str:
+        """The key value for the Variant this Pattern belonged to.
+
+        This will be an empty string if this Pattern did not belong to a
+        Variant.
+
+        :type: str
+        """
+        if not self._variant:
+            return ""
+        key = self._variant.key
+        if isinstance(key, ast.NumberLiteral):
+            return key.value
+        if isinstance(key, ast.Identifier):
+            return key.name
+        raise ValueError(f"Unhandled key type {key.__class__.__name__}")
+
+    @property
+    def default(self) -> bool:
+        """Whether the Variant this Pattern belonged to was the default.
+
+        This will default to True if this Pattern was top-level and did not
+        belong to a Variant.
+
+        :type: bool
+        """
+        if not self._variant:
+            return True
+        return self._variant.default
+
+    def to_flat_pattern_elements(
+        self,
+        branches: list[FluentSelectorBranch],
+    ) -> Iterator[ast.PatternElement]:
+        """Extract a stream of PatternElements using the given branches.
+
+        This will yield the PatternElements found in the original Pattern in
+        the same order, except it will never yield a SelectExpression, and hence
+        be "flat". Instead, for any SelectExpression that would have
+        been present, this method will choose only one of its Variants and yield
+        the PatternElements found within, and so on for any further
+        SelectExpressions found within.
+
+        The Variants are chosen using the `branches` list, by finding the first
+        branch that belongs to the node representing the SelectExpression.
+        Therefore, the `branches` list must contain a branch for every such
+        decision. This should be a list of branches returned by
+        :meth:`~FluentSelectorBranch.branch_paths`.
+
+        :param branches: The branches we should follow when we reach nodes.
+        :type branches: list(FluentSelectorBranch)
+        :return: A iterator of pattern elements.
+        :rtype: Iterator[PatternElement]
+        :raise ValueError: If we reach a node that has no branch in the given
+        list.
+        """
+        for element in self._elements:
+            if isinstance(element, FluentSelectorNode):
+                branch = None
+                for child in element.child_branches:
+                    if child in branches:
+                        branch = child
+                        break
+                if branch is None:
+                    raise ValueError(
+                        "branches is missing a branch for a FluentSelectorNode"
+                    )
+                yield from branch.to_flat_pattern_elements(branches)
+            else:
+                yield element.clone()
+
+    def to_flat_string(self, branches: list[FluentSelectorBranch]) -> str:
+        """The Pattern in a flat string form using the given branches.
+
+        This will extract a flat Pattern using the given branches as specified
+        in :meth:`~FluentSelectorBranch.to_flat_pattern_elements`, and will
+        serialize it. The returned string represents one of the possible
+        variants for the original Pattern.
+
+        :param branches: The branches we should follow when we reach nodes.
+        :type branches: list(FluentSelectorBranch)
+        :return: The flat string.
+        :rtype: str
+        :raise ValueError: If we reach a node that has no branch in the given
+        list.
+        """
+        pattern = ast.Pattern(list(self.to_flat_pattern_elements(branches)))
+        return _fluent_pattern_to_source(pattern)
+
+    def branch_paths(self) -> Iterator[list[FluentSelectorBranch]]:
+        """Generates a list of unique branch paths.
+
+        Each "path" is a list of branches, not including this instance itself,
+        that selects one of the possible variants for the original Pattern.
+
+        This is similar to all permutations of the branches found in any
+        descendant node, with the condition that every branch in the permutation
+        must also have its ancestor branch, other than this instance, in the
+        same permutation. This ensures that each path would produce a unique
+        result when passed to :meth:`~FluentSelectorBranch.to_flat_string` and
+        :meth:`~FluentSelectorBranch.to_flat_pattern_elements`.
+
+        :return: An iterator over all unique branch paths.
+        :rtype: Iterator[list[FluentSelectorBranch]]
+        """
+        # This involves a mix of depth-first tree-traversal over the
+        # nodes and and permutations over the individual children of the
+        # branches.
+        # NOTE: We do *not* want to simply traverse over all permutations of all
+        # descendant branches. This is because some of these permutations
+        # produce the same flat Pattern. E.g.
+        #
+        #   message = { $var1 ->
+        #       [one] first
+        #      *[other]
+        #           { $var2 ->
+        #               [one] second
+        #              *[other] third
+        #           }
+        #   }
+        #
+        # All permutations would give:
+        #
+        #     $var1    $var2    final text
+        #     ____________________________
+        #     one      one      first
+        #     one      other    first
+        #     other    one      second
+        #     other    other    third
+        #
+        # So we would get the same text "first" twice.
+        #
+        # Instead, we only want to increment over the permutations of a
+        # node if its ancestor branch is included.
+        iterator = _SelectorBranchIterator(self)
+        while True:
+            yield list(iterator.selected_branches())
+            if not iterator.next():
+                return
+
+
+class _SelectorBranchIterator:
+    """Private class to iterate over the nodes in a branch.
+
+    At any given stage, this will track the selection state of all of its child
+    branches.
+    """
+
+    def __init__(self, branch: FluentSelectorBranch) -> None:
+        """
+        :param branch: The branch to iterate over.
+        :type branch: FluentSelectorBranch
+        """
+        self.branch = branch
+        self.node_iterators = [
+            _SelectorNodeIterator(node) for node in branch.child_nodes
+        ]
+
+    def next(self) -> bool:
+        """Iterate the selection state of this branch forward one step.
+
+        :return: True if the node was able to iterate forward, otherwise resets
+        itself and returns False.
+        :rtype: bool
+        """
+        # We try and iterate the selection state of one of our node children
+        # until one of them does not reset itself.
+        # This is similar to a digit counter: we try and increment a digit by 1,
+        # otherwise we reset the digit to 0 and try and increment the next digit
+        # instead.
+        for node_iterator in self.node_iterators:
+            if node_iterator.next():
+                return True
+        return False
+
+    def selected_branches(self) -> Iterator[FluentSelectorBranch]:
+        """Return all the branches that are selected at this stage.
+
+        This does not include this branch itself.
+
+        :return: An iterator over all currently selected branches.
+        :rtype: Iterator[FluentSelectorBranch]
+        """
+        for node_it in self.node_iterators:
+            branch_it = node_it.selected_branch_iterator()
+            yield branch_it.branch
+            yield from branch_it.selected_branches()
+
+
+class _SelectorNodeIterator:
+    """Private class to iterate over the branches in a node.
+
+    At at any given stage, only one of the branches is selected.
+    """
+
+    def __init__(self, node: FluentSelectorNode) -> None:
+        """
+        :param node: The node whose branches we want to iterate over.
+        :type node: FluentSelectorNode
+        """
+        self.node = node
+        self._index = 0
+        self.branch_iterators = [
+            _SelectorBranchIterator(branch) for branch in node.child_branches
+        ]
+
+    def next(self) -> bool:
+        """Iterate the selection state of this branch forward one step.
+
+        :return: True if the node was able to iterate forward, otherwise resets
+        itself and returns False.
+        :rtype: bool
+        """
+        # First we try to iterate the selected branch.
+        if self.branch_iterators[self._index].next():
+            return True
+        # The selected branch was reset, so we try and select the next branch
+        # instead if possible.
+        self._index += 1
+        if self._index >= len(self.branch_iterators):
+            # We reset our selection to the first branch again.
+            self._index = 0
+            return False
+        return True
+
+    def selected_branch_iterator(self) -> _SelectorBranchIterator:
+        """The iterator for the currently selected branch.
+
+        :return: The selected branch.
+        :rtype: _SelectorBranchIterator
+        """
+        return self.branch_iterators[self._index]
+
+
+class FluentPart:
+    """Represents a "part" of a fluent Entry.
+
+    This can either represent its value or one of its Attributes.
+    """
+
+    def __init__(self, name: str, pattern: ast.Pattern) -> None:
+        """
+        :param name: The name of this part.
+        :type name: str
+        :param pattern: The Fluent Pattern for this part.
+        :type pattern: Pattern
+        """
+        self._name = name
+        self._pattern = pattern
+        self._top_branch: FluentSelectorBranch | None = None
+
+    @property
+    def name(self) -> str:
+        """The name of the part.
+
+        This will be an empty string for Entry values, and the attribute name
+        for Entry Attributes.
+
+        :type: str
+        """
+        return self._name
+
+    @property
+    def top_branch(self) -> FluentSelectorBranch:
+        """The top-level selector branch that represents this part's Pattern.
+
+        :type: FluentSelectorBranch
+        """
+        if not self._top_branch:
+            self._top_branch = FluentSelectorBranch(self._pattern, None, None)
+        return self._top_branch
 
 
 def _duplicate_attribute(entry: ast.Term | ast.Message) -> ast.Attribute | None:
@@ -233,9 +809,9 @@ class FluentUnit(base.TranslationUnit):
         """Create a new unit from a fluent entry that has a Pattern value."""
         lines = []
         if fluent_entry.value:
-            lines.append(cls._fluent_pattern_to_source(fluent_entry.value))
+            lines.append(_fluent_pattern_to_source(fluent_entry.value))
         for attr in fluent_entry.attributes:
-            attr_source = cls._fluent_pattern_to_source(attr.value)
+            attr_source = _fluent_pattern_to_source(attr.value)
             source = f".{attr.id.name} ="
             if "\n" in attr_source:
                 # Multi-line Attributes placed on newline.
@@ -252,40 +828,20 @@ class FluentUnit(base.TranslationUnit):
             placeholders=cls._fluent_pattern_placeholders(fluent_entry, fluent_type),
         )
 
-    @staticmethod
-    def _fluent_pattern_to_source(pattern: ast.Pattern) -> str:
-        """Convert the fluent Pattern into a source string."""
-        if not pattern.elements:
-            raise ValueError("Unexpected fluent Pattern without any elements")
+    @classmethod
+    def _descendant_refs(
+        cls, branch: FluentSelectorBranch
+    ) -> Iterator[FluentReference]:
+        yield from branch.top_references
+        for node in branch.child_nodes:
+            for child_branch in node.child_branches:
+                yield from cls._descendant_refs(child_branch)
 
-        sanitizer = _SanitizeVisitor()
-        sanitizer.visit(pattern)
-
-        # Create a fluent Message with the given pattern and serialize it.
-        # We use serialize_entry which is part of python-fluent's public API.
-        source = FluentSerializer().serialize_entry(
-            ast.Message(ast.Identifier("i"), value=pattern)
-        )
-
-        # Strip away the id part: "i =". For single-line values, a space is also
-        # added. For multi-line values, a newline is added.
-        # NOTE: Since we escaped any leading special character, the newline is
-        # expected to always be added for multiline values.
-        source = re.sub(r"^i =( |\n)", "", source, count=1)
-        # Strip away the trailing newline that the serializer adds.
-        source = re.sub(r"\n$", "", source, count=1)
-
-        # Remove the common indent.
-        # NOTE: textwrap.dedent also collapses blank lines.
-        return textwrap.dedent(source)
-
-    @staticmethod
+    @classmethod
     def _fluent_pattern_placeholders(
-        fluent_entry: ast.Message | ast.Term, fluent_type: str
+        cls, fluent_entry: ast.Message | ast.Term, fluent_type: str
     ) -> list[str]:
         """Get the placeholders expected for the given fluent entry."""
-        ref_visitor = _ReferenceVisitor(fluent_type)
-        ref_visitor.visit(fluent_entry.value)
         # NOTE: For Terms, we do not look through references in the Attributes.
         # Only Term's have their Attributes appear in their source, and Term
         # Attributes tend to be locale-specific, which we don't want to
@@ -294,7 +850,18 @@ class FluentUnit(base.TranslationUnit):
         # references in translations, but the placeholders have no way to
         # distinguish between whether the placeholder is found in the same
         # attribute or not. So we do not include them.
-        return list(ref_visitor.placeholders)
+        if not fluent_entry.value:
+            return []
+        placeholders = set()
+        for ref in cls._descendant_refs(FluentPart("", fluent_entry.value).top_branch):
+            if ref.type_name == "message":
+                placeholders.add(f"{{ {ref.name} }}")
+            elif ref.type_name == "term":
+                placeholders.add(f"{{ -{ref.name} }}")
+            elif ref.type_name == "variable" and fluent_type != "Term":
+                # For Terms, variables tend to be locale-specific.
+                placeholders.add(f"{{ ${ref.name} }}")
+        return list(placeholders)
 
     def to_entry(self) -> ast.Entry | None:
         """Convert the unit into a corresponding fluent AST Entry.
@@ -329,7 +896,7 @@ class FluentUnit(base.TranslationUnit):
             )
         return entry_or_error
 
-    def _try_source_to_fluent_entry(self) -> ast.Entry | str | None:
+    def _try_source_to_fluent_entry(self) -> ast.Message | ast.Term | str | None:
         """Convert a FluentUnit's source to a generic fluent Entry. Returns a
         string with an error message if this fails.
         """
@@ -412,85 +979,49 @@ class FluentUnit(base.TranslationUnit):
 
         return entry
 
+    # API used in weblate.
 
-class _ReferenceVisitor(visitor.Visitor):
-    """Private class used to extract the reference ids contained within a
-    Pattern.
-    """
+    def get_syntax_error(self) -> str | None:
+        """Get the Fluent syntax error for this unit, if it has one.
 
-    # NOTE: This class is used to extract *expected* placeholder strings. I.e. a
-    # translation of this unit would *also* be expected to include this
-    # placeholder text.
-    #
-    # We extract the MessageReferences, TermReferences and
-    # VariableReferences because we would normally expect them to appear in a
-    # translation.
-    #
-    # In contrast, other fluent Expressions are not wanted:
-    #   + StringLiteral and NumberLiteral are able to represent literal
-    #     characters, which wouldn't necessarily be present in a
-    #     translation.
-    #   + FunctionReference is for function calls, normally to format a
-    #     number or date, which may not be needed in a translation.
-    #   + SelectExpression is for branching logic. Whilst sometimes this
-    #     would be expected in a translation (e.g. based on the plural
-    #     category of a variable) it isn't always necessary (e.g. one locale
-    #     branches based on whether a Term starts with a vowel or not).
+        :return: The syntax error message, or None if it has no error.
+        :rtype: str or None
+        """
+        if self.fluent_type not in ("Term", "Message"):
+            return None
+        entry_or_error = self._try_source_to_fluent_entry()
+        if isinstance(entry_or_error, str):
+            return entry_or_error
+        return None
 
-    def __init__(self, fluent_type: str) -> None:
-        self.fluent_type = fluent_type
-        self.placeholders: set[str] = set()
+    def get_parts(self) -> list[FluentPart] | None:
+        """Get all the distinct parts that make up the fluent Pattern generated
+        by the unit's source.
 
-    def visit_MessageReference(self, node: ast.MessageReference) -> None:
-        # If a MessageReference appears in a value, we expect that to also
-        # appear in a translation's value as well.
-        # TODO: Are there reasonable cases where one locale would use one of
-        # these references, but another would not?
-        # NOTE: MessageReferences cannot be used as a SelectorExpression's
-        # selector, nor do they accept callable arguments. Therefore, we only
-        # expect them to appear in the form "{ message-id }".
-        placeholder = "{ " + node.id.name
-        if node.attribute:
-            placeholder += "." + node.attribute.name
-        placeholder += " }"
-        self.placeholders.add(placeholder)
-        # NOTE: We do not call Visitor.generic_visit because there is no child
-        # to descend into for this type.
+        A Term and Message unit may have a value part, which is the entry's main
+        string value, as well as multiple additional attribute parts.
 
-    def visit_TermReference(self, node: ast.TermReference) -> None:
-        if node.attribute:
-            # A TermReference with an attribute should only appear in a
-            # SelectExpression as the selector. We only expect this to be a
-            # locale-specific selector (e.g. based on some language property of
-            # the Term) so we do not add it to our placeholders.
-            return
-        # Otherwise, we expect a TermReference to also appear in a translation's
-        # value as well.
-        # NOTE: TermReferences cannot be used as a SelectorExpression's
-        # selector.
-        # TODO: TermReferences can accept callable arguments. Normally these
-        # arguments are locale-specific (e.g. passing in some grammatical
-        # context). So it can either appear as "{ -term-id }" or something like
-        # "{ -term-id(arg1: "val", arg2: "val") }".
-        # Technically, something like "{ -term-id({ message-id }) }", or more
-        # complex Expressions are allowed for positional arguments, but these
-        # would have no use, so we only match the regex with named arguments.
-        self.placeholders.add("{ -" + node.id.name + " }")
+        :return: The parts that make up the string, or None if it has some
+            syntax error.
+        :rtype: list[FluentPart] or None
+        """
+        if self.fluent_type not in ("Term", "Message"):
+            return []
 
-    def visit_VariableReference(self, node: ast.VariableReference) -> None:
-        if self.fluent_type == "Term":
-            # Variables for terms are normally locale-specific (like some
-            # grammatical context), so we do not include these.
-            return
-        # TODO: VaraibleReferences can appear as Function arguments or as
-        # SelectExpression selectors, but they are not wrapped in "{" and "}"
-        # in these cases.
-        self.placeholders.add("{ $" + node.id.name + " }")
+        entry_or_error = self._try_source_to_fluent_entry()
+        if isinstance(entry_or_error, str):
+            return None
 
-    def visit_SelectExpression(self, node: ast.SelectExpression) -> None:
-        # We only want to visit the variants, rather than the select expression.
-        for variant in node.variants:
-            self.generic_visit(variant)
+        if not entry_or_error:
+            # Empty.
+            return []
+
+        parts = []
+        if entry_or_error.value:
+            parts.append(FluentPart("", entry_or_error.value))
+        for attr in entry_or_error.attributes:
+            parts.append(FluentPart(attr.id.name, attr.value))
+        return parts
 
 
 class FluentFile(base.TranslationStore):

--- a/translate/storage/test_fluent.py
+++ b/translate/storage/test_fluent.py
@@ -68,19 +68,284 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
             )
         return fluent_file
 
-    @staticmethod
+    @classmethod
+    def assert_references(
+        cls,
+        references: list[fluent.FluentReference],
+        expect_refs: list[dict[str, Any]],
+    ) -> None:
+        """Assert that the list of references matches the expected."""
+        for ref, expect in zip(references, expect_refs):
+            assert expect.get("type") == ref.type_name
+            assert expect.get("name") == ref.name
+        assert len(expect_refs) == len(references)
+
+    @classmethod
+    def assert_selector_branch(
+        cls,
+        selector_branch: fluent.FluentSelectorBranch,
+        expect_index: int,
+        found_selector_branches: list[dict[str, Any]],
+        found_selector_nodes: list[dict[str, Any]],
+    ) -> None:
+        """Assert that the given selector branch matches the expected entry in
+        found_selector_branches at the given expect_index.
+        """
+        assert expect_index >= 0
+        assert expect_index < len(found_selector_branches)
+        if found_selector_branches[expect_index]["instance"] is None:
+            # First time we have come across this selector, so add it to our
+            # list and make sure it matches the expected.
+            found_selector_branches[expect_index]["instance"] = selector_branch
+            assert found_selector_branches[expect_index]["key"] == selector_branch.key
+            assert (
+                found_selector_branches[expect_index]["default"]
+                == selector_branch.default
+            )
+            parent_node_index = found_selector_branches[expect_index]["parent-node"]
+            if parent_node_index is None:
+                assert selector_branch.parent_node is None
+            else:
+                cls.assert_selector_node(
+                    selector_branch.parent_node,
+                    parent_node_index,
+                    found_selector_branches,
+                    found_selector_nodes,
+                )
+            cls.assert_references(
+                selector_branch.top_references,
+                found_selector_branches[expect_index]["top-refs"],
+            )
+            expect_children = found_selector_branches[expect_index]["child-nodes"]
+            for child, expected_child in zip(
+                selector_branch.child_nodes, expect_children
+            ):
+                cls.assert_selector_node(
+                    child,
+                    expected_child,
+                    found_selector_branches,
+                    found_selector_nodes,
+                )
+            assert len(expect_children) == len(selector_branch.child_nodes)
+        else:
+            # We already have this selector index, make sure it matches the same
+            # instance that we already have.
+            assert found_selector_branches[expect_index]["instance"] == selector_branch
+
+    @classmethod
+    def assert_selector_node(
+        cls,
+        selector_node: fluent.FluentSelectorNode | None,
+        expect_index: int,
+        found_selector_branches: list[dict[str, Any]],
+        found_selector_nodes: list[dict[str, Any]],
+    ) -> None:
+        """Assert that the given selector node matches the expected entry in
+        found_selector_nodes at the given expect_index.
+        """
+        assert selector_node is not None
+        assert expect_index >= 0
+        assert expect_index < len(found_selector_nodes)
+        if found_selector_nodes[expect_index]["instance"] is None:
+            # First time we have come across this selector, so add it to our
+            # list and make sure it matches the expected serialization.
+            found_selector_nodes[expect_index]["instance"] = selector_node
+            assert (
+                found_selector_nodes[expect_index]["serialized"]
+                == selector_node.serialized_selector
+            )
+            cls.assert_selector_branch(
+                selector_node.parent_branch,
+                found_selector_nodes[expect_index]["parent-branch"],
+                found_selector_branches,
+                found_selector_nodes,
+            )
+            cls.assert_references(
+                selector_node.selector_references,
+                found_selector_nodes[expect_index]["selector-refs"],
+            )
+            expect_children = found_selector_nodes[expect_index]["child-branches"]
+            for child, expected_child in zip(
+                selector_node.child_branches, expect_children
+            ):
+                cls.assert_selector_branch(
+                    child,
+                    expected_child,
+                    found_selector_branches,
+                    found_selector_nodes,
+                )
+            assert len(expect_children) == len(selector_node.child_branches)
+        else:
+            # We already have this selector index, make sure it matches the same
+            # instance that we already have.
+            assert found_selector_nodes[expect_index]["instance"] == selector_node
+
+    @classmethod
+    def assert_parts(
+        cls,
+        fluent_unit: fluent.FluentUnit,
+        expect_parts: list[dict[str, Any]] | None,
+    ) -> None:
+        """Assert that the given fluent unit has the expected parts.
+
+        Each part should be a dictionary defining its "name", "selector-nodes",
+        "selector-branches" and "pattern-variants".
+
+        The "selector-nodes" and "selector-branches" should be a list of
+        expected nodes and branches in the part. Each should be a dictionary of
+        the expected properties. In particular, their "parent-branch",
+        "parent-node", "child-branches" and "child-nodes" entries should
+        reference the index of the expected branch or node in this list.
+
+        If the "selector-nodes" is not specified, this will assume there are no
+        expected nodes. If "selector-branches" is not specified, this will
+        assume that the only branch in this part is the default top-level
+        branch.
+
+        The "pattern-variants" should be a list of expected variants, each a
+        dictionary defining its expected "select-path", using the indices of the
+        corresponding entry in "selector-branches", and their expected "source".
+
+        If "pattern-variants" is not specified, this will assume we expect only
+        a single variant whose "select-path" is empty and whose "source" is just
+        extracted from the unit's source.
+
+        If `expect_parts` itself is None, then the parts will be extracted from
+        the unit's source, and only one variant will be assumed for each part.
+        """
+        build_expect_parts = False
+        if expect_parts is None:
+            expect_parts = []
+            build_expect_parts = True
+
+        # First we generate `auto_source` which is used when one of the parts
+        # does not include a "pattern-variants".
+        #
+        # We grab this by taking all the strings found between the attribute
+        # names.
+        #
+        # This won't work in general if the unit's source contains more than one
+        # variant, so the variant's "source" will need to be determined by the
+        # caller instead.
+        auto_source: dict[str, str] = {}
+        value, *attrs = re.split(
+            r"\n?^ *\.([a-zA-Z][a-zA-Z0-9_-]*) *= *\n?",
+            fluent_unit.source or "",
+            flags=re.MULTILINE,
+        )
+
+        if value:
+            auto_source[""] = value
+            if build_expect_parts:
+                # Expect only one variants with no refs and using the
+                # auto_source.
+                expect_parts.append({"name": ""})
+        assert len(attrs) % 2 == 0
+        for i in range(0, len(attrs), 2):
+            auto_source[attrs[i]] = attrs[i + 1]
+            if build_expect_parts:
+                expect_parts.append({"name": attrs[i]})
+
+        unit_parts = fluent_unit.get_parts()
+        assert unit_parts is not None
+        for part, expected_part in zip(unit_parts, expect_parts):
+            assert expected_part.get("name") == part.name
+
+            found_selector_nodes = [
+                {
+                    "instance": None,
+                    "serialized": node.get("serialized"),
+                    "parent-branch": node.get("parent-branch"),
+                    "child-branches": node.get("child-branches", []),
+                    "selector-refs": node.get("selector-refs", []),
+                }
+                for node in expected_part.get("selector-nodes", [])
+            ]
+
+            expect_branches = expected_part.get("selector-branches", None)
+            if expect_branches is None:
+                expect_branches = [
+                    {
+                        "key": "",
+                        "default": True,
+                    }
+                ]
+            found_selector_branches = [
+                {
+                    "instance": None,
+                    "key": branch.get("key"),
+                    "default": branch.get("default", False),
+                    "parent-node": branch.get("parent-node", None),
+                    "child-nodes": branch.get("child-nodes", []),
+                    "top-refs": branch.get("top-refs", []),
+                }
+                for branch in expect_branches
+            ]
+            cls.assert_selector_branch(
+                part.top_branch,
+                0,
+                found_selector_branches,
+                found_selector_nodes,
+            )
+            # Should have visited all selectors and branches at this point.
+            for selector_node in found_selector_nodes:
+                # Each one visited at least once.
+                assert selector_node["instance"] is not None
+            for selector_branch in found_selector_branches:
+                # Each one visited at least once.
+                assert selector_branch["instance"] is not None
+
+            expect_variants = expected_part.get("pattern-variants", None)
+            if expect_variants is None:
+                # Only expect one variant by default.
+                expect_variants = [
+                    {
+                        "select-path": (),
+                        "source": auto_source[part.name],
+                    }
+                ]
+            pattern_variants = [
+                (path, part.top_branch.to_flat_string(path))
+                for path in part.top_branch.branch_paths()
+            ]
+            for (path, source), expected_variant in zip(
+                pattern_variants,
+                expect_variants,
+            ):
+                assert expected_variant.get("source") == source
+                expect_path = expected_variant.get("select-path")
+                for branch, index in zip(path, expect_path):
+                    cls.assert_selector_branch(
+                        branch,
+                        index,
+                        found_selector_branches,
+                        found_selector_nodes,
+                    )
+                assert len(expect_path) == len(path)
+            # Same number of variants.
+            assert len(expect_variants) == len(pattern_variants)
+
+        assert len(expect_parts) == len(unit_parts)
+
+    @classmethod
     def assert_units(
-        fluent_file: fluent.FluentFile, expect_units: list[dict[str, Any]]
+        cls, fluent_file: fluent.FluentFile, expect_units: list[dict[str, Any]]
     ) -> None:
         """Assert that the given FluentFile has the expected FluentUnits.
 
         :param FluentFile fluent_file: The file to test.
         :param list[dict] expect_units: A list of the expected units, specified
-            by the dictionary values. The "id", "source", "type" and "comment"
-            values are matched with the corresponding property. If "type" is
-            missing, it will be chosen based on the "id". Otherwise, a falsey
-            value is used if a value is unspecified. In addition, the "refs"
-            value is matched against the placeholders property.
+            by the dictionary values.
+
+            The "id", "source", "type" and "comment" values are matched with the
+            corresponding property. If "type" is missing, it will be chosen
+            based on the "id". Otherwise, a falsey value is used if a value is
+            unspecified.
+
+            The "refs" value is matched against the placeholders property.
+
+            If given, the "parts" value is matches against the unit's
+            `get_parts`. See `assert_parts`.
         """
         for unit, expect in zip(fluent_file.units, expect_units):
             unit_id = expect.get("id", None)
@@ -104,6 +369,9 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
             assert expect.get("comment", "") == unit.getnotes()
             assert expect.get("source", None) == unit.source
             assert unit.target == unit.source
+            assert unit.get_syntax_error() is None
+
+            cls.assert_parts(unit, expect.get("parts", None))
         assert len(fluent_file.units) == len(expect_units)
 
     def basic_test(
@@ -168,15 +436,27 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
             self.fluent_parse(fluent_source)
 
     def assert_serialize_failure(
-        self, fluent_file: fluent.FluentFile, error_regex: str
+        self,
+        fluent_file: fluent.FluentFile,
+        error_unit: fluent.FluentUnit,
+        error_msg: str = r".+",
     ) -> None:
         """Assert that the given FluentFile fails to serialize.
 
         :param FluentFile fluent_file: The FluentFile to try and serialize.
-        :param str error_regex: The expected error expression.
+        :param FluentUnit error_unit: The FluentUnit that is expected to fail.
+        :param str error_msg: The expected syntax error for the unit.
         """
-        with raises(ValueError, match=error_regex):
+        with raises(
+            ValueError,
+            match=f'^Error in source of FluentUnit "{error_unit.getid()}":\\n',
+        ):
             self.fluent_serialize(fluent_file)
+
+        syntax_error = error_unit.get_syntax_error()
+        assert syntax_error is not None
+        assert re.match(error_msg, syntax_error)
+        assert error_unit.get_parts() is None
 
     def test_simple_values(self):
         """Test a simple fluent Message and Term."""
@@ -328,8 +608,8 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
         )
         self.assert_serialize_failure(
             fluent_file,
-            r'^Error in source of FluentUnit "message":\n'
-            r'The "attr" attribute is assigned to more than once$',
+            fluent_file.units[0],
+            '^The "attr" attribute is assigned to more than once$',
         )
 
     def test_term_with_attributes(self):
@@ -366,7 +646,7 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
         )
         self.assert_serialize_failure(
             fluent_file,
-            r'^Error in source of FluentUnit "-term":\n'
+            fluent_file.units[0],
             r'.*Expected term "-term" to have a value \[line 1, column 1\]$',
         )
 
@@ -400,7 +680,7 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
         )
         self.assert_serialize_failure(
             fluent_file,
-            r'^Error in source of FluentUnit "-term":\n'
+            fluent_file.units[0],
             r'The "attr" attribute is assigned to more than once$',
         )
 
@@ -539,16 +819,12 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                 fluent_file = self.quick_fluent_file(
                     [{"type": "Message", "source": source, "id": "message"}]
                 )
-                self.assert_serialize_failure(
-                    fluent_file, r'^Error in source of FluentUnit "message":'
-                )
+                self.assert_serialize_failure(fluent_file, fluent_file.units[0])
 
                 fluent_file = self.quick_fluent_file(
                     [{"type": "Term", "source": source, "id": "-term"}]
                 )
-                self.assert_serialize_failure(
-                    fluent_file, r'^Error in source of FluentUnit "-term":'
-                )
+                self.assert_serialize_failure(fluent_file, fluent_file.units[0])
 
             # A Term that has an empty value with attributes, or empty
             # attributes, simply throws because this is a syntax error within a
@@ -559,14 +835,10 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     {"type": "Term", "source": f"{source}\n.attr = ok", "id": "-term"},
                 ]
             )
-            self.assert_serialize_failure(
-                fluent_file, r'^Error in source of FluentUnit "-term":'
-            )
+            self.assert_serialize_failure(fluent_file, fluent_file.units[1])
             # Empty Attribute for a Term
             fluent_file.units[1].source = f"ok\n.attr = {source}"
-            self.assert_serialize_failure(
-                fluent_file, r'^Error in source of FluentUnit "-term":'
-            )
+            self.assert_serialize_failure(fluent_file, fluent_file.units[1])
 
             # For a Message, an empty start is ok.
             fluent_file = self.quick_fluent_file(
@@ -587,7 +859,8 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
             # Empty attribute is not ok.
             fluent_file.units[1].source = f"ok\n.attr = {source}"
             self.assert_serialize_failure(
-                fluent_file, r'^Error in source of FluentUnit "m":'
+                fluent_file,
+                fluent_file.units[1],
             )
 
         subtest_whitespace_unit_source("")
@@ -1306,6 +1579,50 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                             f"        {escaped_value}\n"
                             f"        {middle_value}\n"
                             "}",
+                            "parts": [
+                                {
+                                    "name": "a",
+                                    "selector-nodes": [
+                                        {
+                                            "serialized": "$var",
+                                            "parent-branch": 0,
+                                            "child-branches": [1, 2],
+                                            "selector-refs": [
+                                                {
+                                                    "type": "variable",
+                                                    "name": "var",
+                                                },
+                                            ],
+                                        }
+                                    ],
+                                    "selector-branches": [
+                                        {
+                                            "key": "",
+                                            "default": True,
+                                            "child-nodes": [0],
+                                        },
+                                        {
+                                            "key": "one",
+                                            "parent-node": 0,
+                                        },
+                                        {
+                                            "key": "other",
+                                            "parent-node": 0,
+                                            "default": True,
+                                        },
+                                    ],
+                                    "pattern-variants": [
+                                        {
+                                            "select-path": (1,),
+                                            "source": "ok",
+                                        },
+                                        {
+                                            "select-path": (2,),
+                                            "source": f"{escaped_value}\n{middle_value}",
+                                        },
+                                    ],
+                                },
+                            ],
                         }
                     ],
                     f"""\
@@ -1376,7 +1693,7 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     )
                     self.assert_serialize_failure(
                         fluent_file,
-                        f'^Error in source of FluentUnit "{unit_id}":',
+                        fluent_file.units[0],
                     )
                 # As a special case, an Attribute can start with this and not
                 # throw an exception because it starts after an "=" sign.
@@ -1853,19 +2170,61 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                 .attribute = { -term2 } over { message }
             """,
             # The FluentUnit just uses the same text.
-            # The references in the value become refs.
-            # NOTE: attribute refs do not.
             [
                 {
                     "id": "-term1",
                     "source": "{ -term2 } and { message }!",
                     "refs": ["-term2", "message"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [
+                                        {"type": "term", "name": "term2"},
+                                        {"type": "message", "name": "message"},
+                                    ],
+                                }
+                            ],
+                        },
+                    ],
                 },
                 {
                     "id": "ref-message",
                     "source": "{ -term1 } with { message } { -term2 }\n"
                     ".attribute = { -term2 } over { message }",
                     "refs": ["-term1", "message", "-term2"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [
+                                        {"type": "term", "name": "term1"},
+                                        {"type": "message", "name": "message"},
+                                        {"type": "term", "name": "term2"},
+                                    ],
+                                }
+                            ],
+                        },
+                        {
+                            "name": "attribute",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [
+                                        {"type": "term", "name": "term2"},
+                                        {"type": "message", "name": "message"},
+                                    ],
+                                }
+                            ],
+                        },
+                    ],
                 },
             ],
         )
@@ -1880,11 +2239,35 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     "id": "message",
                     "source": 'I am { -term1(tense: "present") }',
                     "refs": ["-term1"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [{"type": "term", "name": "term1"}],
+                                }
+                            ],
+                        }
+                    ],
                 },
                 {
                     "id": "-term",
                     "source": 'Going to { -term1(tense: "present", number: 7.5) } now',
                     "refs": ["-term1"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [{"type": "term", "name": "term1"}],
+                                }
+                            ],
+                        }
+                    ],
                 },
             ],
         )
@@ -1901,6 +2284,36 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     "source": "{ message.attribute }\n"
                     ".attribute = { i-9.attr } over { i-9 }",
                     "refs": ["message.attribute"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [
+                                        {
+                                            "type": "message",
+                                            "name": "message.attribute",
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                        {
+                            "name": "attribute",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [
+                                        {"type": "message", "name": "i-9.attr"},
+                                        {"type": "message", "name": "i-9"},
+                                    ],
+                                }
+                            ],
+                        },
+                    ],
                 },
             ],
         )
@@ -1916,12 +2329,55 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
             [
                 # Variables used in terms do not become a ref since they are
                 # locale-specific.
-                {"id": "-term1", "source": "Term with { $var }", "refs": []},
+                {
+                    "id": "-term1",
+                    "source": "Term with { $var }",
+                    "refs": [],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [{"type": "variable", "name": "var"}],
+                                }
+                            ],
+                        },
+                    ],
+                },
                 {
                     "id": "ref-message",
                     "source": "{ $num1 } is greater than { $num2 }\n"
                     ".attribute = { $other-var } used",
                     "refs": ["$num1", "$num2"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [
+                                        {"type": "variable", "name": "num1"},
+                                        {"type": "variable", "name": "num2"},
+                                    ],
+                                }
+                            ],
+                        },
+                        {
+                            "name": "attribute",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [
+                                        {"type": "variable", "name": "other-var"},
+                                    ],
+                                }
+                            ],
+                        },
+                    ],
                 },
             ],
         )
@@ -1936,12 +2392,27 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     "id": "message",
                     "source": "{ $var } with { message.attr } and { -term }",
                     "refs": ["$var", "message.attr", "-term"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [
+                                        {"type": "variable", "name": "var"},
+                                        {"type": "message", "name": "message.attr"},
+                                        {"type": "term", "name": "term"},
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
                 }
             ],
         )
 
-        # Repeated references are included twice only appear once in
-        # refs.
+        # Repeated references are included twice.
         self.basic_test(
             """\
             message = { $var } with { -term0 } and { $var }
@@ -1951,6 +2422,22 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     "id": "message",
                     "source": "{ $var } with { -term0 } and { $var }",
                     "refs": ["$var", "-term0"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [
+                                        {"type": "variable", "name": "var"},
+                                        {"type": "term", "name": "term0"},
+                                        {"type": "variable", "name": "var"},
+                                    ],
+                                }
+                            ],
+                        },
+                    ],
                 }
             ],
         )
@@ -1995,6 +2482,56 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     "}",
                     # Get ref from the second variant.
                     "refs": ["$num"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "$num",
+                                    "parent-branch": 0,
+                                    "child-branches": [1, 2],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num",
+                                        }
+                                    ],
+                                }
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                },
+                                {
+                                    "key": "one",
+                                    "parent-node": 0,
+                                },
+                                {
+                                    "key": "other",
+                                    "parent-node": 0,
+                                    "default": True,
+                                    "top-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num",
+                                        },
+                                    ],
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1,),
+                                    "source": "One apple.",
+                                },
+                                {
+                                    "select-path": (2,),
+                                    "source": "{ $num } apples.",
+                                },
+                            ],
+                        }
+                    ],
                 }
             ],
         )
@@ -2018,6 +2555,50 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     "}",
                     # Get no ref.
                     "refs": [],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "$num",
+                                    "parent-branch": 0,
+                                    "child-branches": [1, 2],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num",
+                                        },
+                                    ],
+                                }
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                },
+                                {
+                                    "key": "one",
+                                    "parent-node": 0,
+                                },
+                                {
+                                    "key": "other",
+                                    "parent-node": 0,
+                                    "default": True,
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1,),
+                                    "source": "One apple.",
+                                },
+                                {
+                                    "select-path": (2,),
+                                    "source": "Some apples.",
+                                },
+                            ],
+                        }
+                    ],
                 }
             ],
         )
@@ -2048,6 +2629,110 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     "   *[no] Have a { -term-ref }.\n"
                     "}",
                     "refs": ["$num"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "$num",
+                                    "parent-branch": 0,
+                                    "child-branches": [1, 2],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num",
+                                        },
+                                    ],
+                                }
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                },
+                                {
+                                    "key": "one",
+                                    "parent-node": 0,
+                                },
+                                {
+                                    "key": "other",
+                                    "parent-node": 0,
+                                    "default": True,
+                                    "top-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num",
+                                        },
+                                    ],
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1,),
+                                    "source": "One apple.",
+                                },
+                                {
+                                    "select-path": (2,),
+                                    "source": "{ $num } apples.",
+                                },
+                            ],
+                        },
+                        {
+                            "name": "attr",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "-term-ref.vowel-start",
+                                    "parent-branch": 0,
+                                    "child-branches": [1, 2],
+                                    "selector-refs": [
+                                        {
+                                            "type": "term",
+                                            "name": "term-ref.vowel-start",
+                                        },
+                                    ],
+                                }
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                },
+                                {
+                                    "key": "yes",
+                                    "parent-node": 0,
+                                    "top-refs": [
+                                        {
+                                            "type": "term",
+                                            "name": "term-ref",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "key": "no",
+                                    "parent-node": 0,
+                                    "default": True,
+                                    "top-refs": [
+                                        {
+                                            "type": "term",
+                                            "name": "term-ref",
+                                        },
+                                    ],
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1,),
+                                    "source": "Have an { -term-ref }.",
+                                },
+                                {
+                                    "select-path": (2,),
+                                    "source": "Have a { -term-ref }.",
+                                },
+                            ],
+                        },
+                    ],
                 },
             ],
             """\
@@ -2082,6 +2767,56 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     "   *[other] { $num } apples\n"
                     "} today.",
                     "refs": ["$num"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "$num",
+                                    "parent-branch": 0,
+                                    "child-branches": [1, 2],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num",
+                                        },
+                                    ],
+                                }
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                },
+                                {
+                                    "key": "one",
+                                    "parent-node": 0,
+                                },
+                                {
+                                    "key": "other",
+                                    "parent-node": 0,
+                                    "default": True,
+                                    "top-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num",
+                                        },
+                                    ],
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1,),
+                                    "source": "Just eat an apple today.",
+                                },
+                                {
+                                    "select-path": (2,),
+                                    "source": "Just eat { $num } apples today.",
+                                },
+                            ],
+                        },
+                    ],
                 }
             ],
         )
@@ -2098,7 +2833,7 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                                 [one] { $num } apple
                                *[other] { $num } apples
                             } and { $num2 ->
-                                [one] { $num2 } oranges
+                                [one] { $num2 } orange
                                *[other] { $num2 } oranges
                             }
                     }
@@ -2114,11 +2849,420 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     "            [one] { $num } apple\n"
                     "           *[other] { $num } apples\n"
                     "        } and { $num2 ->\n"
-                    "            [one] { $num2 } oranges\n"
+                    "            [one] { $num2 } orange\n"
                     "           *[other] { $num2 } oranges\n"
                     "        }\n"
                     "}",
-                    # No refs since this is an attribute only.
+                    "refs": [],
+                    "parts": [
+                        {
+                            "name": "a",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "$num",
+                                    "parent-branch": 0,
+                                    "child-branches": [1, 2],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "serialized": "$num",
+                                    "parent-branch": 2,
+                                    "child-branches": [3, 4],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "serialized": "$num2",
+                                    "parent-branch": 2,
+                                    "child-branches": [5, 6],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num2",
+                                        },
+                                    ],
+                                },
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                },
+                                {
+                                    "key": "zero",
+                                    "parent-node": 0,
+                                    "child-nodes": [],
+                                },
+                                {
+                                    "key": "other",
+                                    "default": True,
+                                    "parent-node": 0,
+                                    "child-nodes": [1, 2],
+                                },
+                                {
+                                    "key": "one",
+                                    "parent-node": 1,
+                                    "child-nodes": [],
+                                    "top-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "key": "other",
+                                    "parent-node": 1,
+                                    "child-nodes": [],
+                                    "default": True,
+                                    "top-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "key": "one",
+                                    "parent-node": 2,
+                                    "child-nodes": [],
+                                    "top-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num2",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "key": "other",
+                                    "default": True,
+                                    "parent-node": 2,
+                                    "child-nodes": [],
+                                    "top-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "num2",
+                                        },
+                                    ],
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1,),
+                                    "source": "no apples",
+                                },
+                                {
+                                    "select-path": (2, 3, 5),
+                                    "source": "{ $num } apple and { $num2 } orange",
+                                },
+                                {
+                                    "select-path": (2, 4, 5),
+                                    "source": "{ $num } apples and { $num2 } orange",
+                                },
+                                {
+                                    "select-path": (2, 3, 6),
+                                    "source": "{ $num } apple and { $num2 } oranges",
+                                },
+                                {
+                                    "select-path": (2, 4, 6),
+                                    "source": "{ $num } apples and { $num2 } oranges",
+                                },
+                            ],
+                        },
+                    ],
+                }
+            ],
+        )
+
+        # Check matches_selector property of the references.
+        self.basic_test(
+            """\
+            m =
+                { $var ->
+                   *[other] { $var }
+                }
+            """,
+            [
+                {
+                    "id": "m",
+                    "source": "{ $var ->\n   *[other] { $var }\n}",
+                    "refs": ["$var"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "$var",
+                                    "parent-branch": 0,
+                                    "child-branches": [1],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "var",
+                                        },
+                                    ],
+                                }
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                },
+                                {
+                                    "key": "other",
+                                    "parent-node": 0,
+                                    "default": True,
+                                    "top-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "var",
+                                        },
+                                    ],
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1,),
+                                    "source": "{ $var }",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
+
+        # Reference is inside a function in the selector.
+        self.basic_test(
+            """\
+            m =
+                { MYFUNCTION($other, $var, option: 6) ->
+                   *[other] { $var }
+                }
+            """,
+            [
+                {
+                    "id": "m",
+                    "source": "{ MYFUNCTION($other, $var, option: 6) ->\n"
+                    "   *[other] { $var }\n"
+                    "}",
+                    "refs": ["$var"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "MYFUNCTION($other, $var, option: 6)",
+                                    "parent-branch": 0,
+                                    "child-branches": [1],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "other",
+                                        },
+                                        {
+                                            "type": "variable",
+                                            "name": "var",
+                                        },
+                                    ],
+                                }
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                },
+                                {
+                                    "key": "other",
+                                    "parent-node": 0,
+                                    "default": True,
+                                    "top-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "var",
+                                        },
+                                    ],
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1,),
+                                    "source": "{ $var }",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
+
+        # $var is outside the selector
+        self.basic_test(
+            """\
+            m =
+                { $var ->
+                   *[other] none
+                } { $var }
+            """,
+            [
+                {
+                    "id": "m",
+                    "source": "{ $var ->\n" "   *[other] none\n" "} { $var }",
+                    "refs": ["$var"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "$var",
+                                    "parent-branch": 0,
+                                    "child-branches": [1],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "var",
+                                        },
+                                    ],
+                                }
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                    "top-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "var",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "key": "other",
+                                    "parent-node": 0,
+                                    "default": True,
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1,),
+                                    "source": "none { $var }",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
+
+        # $var in sub-selector
+        self.basic_test(
+            """\
+            m =
+                { $var ->
+                   *[other]
+                        { -term.attr ->
+                            [a] { $var }
+                           *[b] { var }
+                        }
+                }
+            """,
+            [
+                {
+                    "id": "m",
+                    "source": "{ $var ->\n"
+                    "   *[other]\n"
+                    "        { -term.attr ->\n"
+                    "            [a] { $var }\n"
+                    "           *[b] { var }\n"
+                    "        }\n"
+                    "}",
+                    "refs": ["$var", "var"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "$var",
+                                    "parent-branch": 0,
+                                    "child-branches": [1],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "var",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "serialized": "-term.attr",
+                                    "parent-branch": 1,
+                                    "child-branches": [2, 3],
+                                    "selector-refs": [
+                                        {
+                                            "type": "term",
+                                            "name": "term.attr",
+                                        },
+                                    ],
+                                },
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                },
+                                {
+                                    "key": "other",
+                                    "default": True,
+                                    "parent-node": 0,
+                                    "child-nodes": [1],
+                                },
+                                {
+                                    "key": "a",
+                                    "parent-node": 1,
+                                    "top-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "var",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "key": "b",
+                                    "default": True,
+                                    "parent-node": 1,
+                                    "top-refs": [
+                                        {
+                                            "type": "message",
+                                            "name": "var",
+                                        },
+                                    ],
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1, 2),
+                                    "source": "{ $var }",
+                                },
+                                {
+                                    "select-path": (1, 3),
+                                    "source": "{ var }",
+                                },
+                            ],
+                        }
+                    ],
                 }
             ],
         )
@@ -2145,7 +3289,8 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
         )
         self.assert_serialize_failure(
             fluent_file,
-            r'^Error in source of FluentUnit "bad":\n.* \[line 4, column 1\]$',
+            fluent_file.units[0],
+            r"^.* \[line 4, column 1\]$",
         )
 
     def test_functions(self):
@@ -2156,8 +3301,8 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
             number = { NUMBER($var-num, minimumIntegerDigits: 4) } up
             -term =
                 { NUMBER($n) ->
-                    [0] -> Term0
-                   *[other] -> Term
+                    [0] Term0
+                   *[other] Term
                 }
             """,
             # The FluentUnit just uses the same text.
@@ -2166,20 +3311,90 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     "id": "time",
                     "source": 'Time is { DATETIME($now, hour: "numeric") }',
                     "refs": ["$now"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [{"type": "variable", "name": "now"}],
+                                },
+                            ],
+                        },
+                    ],
                 },
                 {
                     "id": "number",
                     "source": "{ NUMBER($var-num, minimumIntegerDigits: 4) } up",
                     "refs": ["$var-num"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [
+                                        {"type": "variable", "name": "var-num"}
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
                 },
                 {
                     "id": "-term",
                     "source": "{ NUMBER($n) ->\n"
-                    "    [0] -> Term0\n"
-                    "   *[other] -> Term\n"
+                    "    [0] Term0\n"
+                    "   *[other] Term\n"
                     "}",
                     # No variable refs for Term.
                     "refs": [],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "NUMBER($n)",
+                                    "parent-branch": 0,
+                                    "child-branches": [1, 2],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "n",
+                                        },
+                                    ],
+                                }
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                },
+                                {
+                                    "key": "0",
+                                    "parent-node": 0,
+                                },
+                                {
+                                    "key": "other",
+                                    "parent-node": 0,
+                                    "default": True,
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1,),
+                                    "source": "Term0",
+                                },
+                                {
+                                    "select-path": (2,),
+                                    "source": "Term",
+                                },
+                            ],
+                        },
+                    ],
                 },
             ],
         )
@@ -2325,8 +3540,8 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
             fluent_file.units[1].source = source
             self.assert_serialize_failure(
                 fluent_file,
-                r'^Error in source of FluentUnit "message-id":\n.* '
-                f"\\[line {line}, column {column}\\]$",
+                fluent_file.units[1],
+                f"^.+\\[line {line}, column {column}\\]$",
             )
 
     def test_several_entries(self):
@@ -2387,6 +3602,53 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     "}\n"
                     ".vowel-start = yes",
                     "comment": f"{resource_comment}\n{group1_comment}\nTerm to use",
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "$possessive",
+                                    "parent-branch": 0,
+                                    "child-branches": [1, 2],
+                                    "selector-refs": [
+                                        {
+                                            "type": "variable",
+                                            "name": "possessive",
+                                        }
+                                    ],
+                                }
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                },
+                                {
+                                    "key": "no",
+                                    "parent-node": 0,
+                                    "default": True,
+                                },
+                                {
+                                    "key": "yes",
+                                    "parent-node": 0,
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1,),
+                                    "source": "Elephant",
+                                },
+                                {
+                                    "select-path": (2,),
+                                    "source": "Elephant's",
+                                },
+                            ],
+                        },
+                        {
+                            "name": "vowel-start",
+                        },
+                    ],
                 },
                 {
                     "id": "message-1",
@@ -2394,6 +3656,18 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     "comment": f"{resource_comment}\n{group1_comment}\n"
                     "Variables:\n  $var (string) - Some variable",
                     "refs": ["$var"],
+                    "parts": [
+                        {
+                            "name": "",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [{"type": "variable", "name": "var"}],
+                                },
+                            ],
+                        },
+                    ],
                 },
                 {
                     "id": "message-2",
@@ -2411,6 +3685,72 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     '   *[no] A { -term-1(possessive: "yes") } tail.\n'
                     "}",
                     "comment": f"{resource_comment}\n{group1_comment}\nWatch out for this one.",
+                    "parts": [
+                        {
+                            "name": "title",
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "top-refs": [{"type": "term", "name": "term-1"}],
+                                },
+                            ],
+                        },
+                        {
+                            "name": "alt",
+                            "selector-nodes": [
+                                {
+                                    "serialized": "-term-1.vowel-start",
+                                    "parent-branch": 0,
+                                    "child-branches": [1, 2],
+                                    "selector-refs": [
+                                        {
+                                            "type": "term",
+                                            "name": "term-1.vowel-start",
+                                        },
+                                    ],
+                                }
+                            ],
+                            "selector-branches": [
+                                {
+                                    "key": "",
+                                    "default": True,
+                                    "child-nodes": [0],
+                                },
+                                {
+                                    "key": "yes",
+                                    "parent-node": 0,
+                                    "top-refs": [
+                                        {
+                                            "type": "term",
+                                            "name": "term-1",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "key": "no",
+                                    "default": True,
+                                    "parent-node": 0,
+                                    "top-refs": [
+                                        {
+                                            "type": "term",
+                                            "name": "term-1",
+                                        },
+                                    ],
+                                },
+                            ],
+                            "pattern-variants": [
+                                {
+                                    "select-path": (1,),
+                                    "source": 'An { -term-1(possessive: "yes") } tail.',
+                                },
+                                {
+                                    "select-path": (2,),
+                                    "source": 'A { -term-1(possessive: "yes") } tail.',
+                                },
+                            ],
+                        },
+                    ],
                 },
                 {"type": "GroupComment", "comment": ""},
                 {

--- a/translate/storage/test_fluent.py
+++ b/translate/storage/test_fluent.py
@@ -1267,6 +1267,38 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                             {middle_value}
                     """,
                 )
+                self.basic_test(
+                    f"""\
+                    message =
+                        .a = {{ $var ->
+                            [one] ok
+                            *[other] {value}
+                        {middle_value}
+                        }}
+                    """,
+                    [
+                        {
+                            "id": "message",
+                            "source": ".a =\n"
+                            "{ $var ->\n"
+                            "    [one] ok\n"
+                            "   *[other]\n"
+                            f"        {escaped_value}\n"
+                            f"        {middle_value}\n"
+                            "}",
+                        }
+                    ],
+                    f"""\
+                    message =
+                        .a =
+                            {{ $var ->
+                                [one] ok
+                               *[other]
+                                    {escaped_value}
+                                    {middle_value}
+                            }}
+                    """,
+                )
 
                 if ok_at_start:
                     continue
@@ -1299,6 +1331,15 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                     -term = ok
                       .attr =
                         {value}
+                    """,
+                    r".*" + re.escape(value),
+                )
+                self.assert_parse_failure(
+                    f"""\
+                    message = {{ $var ->
+                      *[other]
+                        {value}
+                    }}
                     """,
                     r".*" + re.escape(value),
                 )

--- a/translate/storage/test_fluent.py
+++ b/translate/storage/test_fluent.py
@@ -16,9 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import re
 import textwrap
 from io import BytesIO
+from typing import Any
 
 from pytest import raises
 
@@ -33,23 +36,23 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
     StoreClass = fluent.FluentFile
 
     @staticmethod
-    def fluent_parse(fluent_source):
+    def fluent_parse(fluent_source: str) -> fluent.FluentFile:
         """Helper that parses Fluent source without requiring files."""
         dummyfile = BytesIO(fluent_source.encode())
         fluent_file = fluent.FluentFile(dummyfile)
         return fluent_file
 
     @staticmethod
-    def fluent_serialize(fluent_file):
+    def fluent_serialize(fluent_file: fluent.FluentFile) -> str:
         # The __bytes__ method on TranslationStore calls FluentFile.serialize.
         return bytes(fluent_file).decode("utf-8")
 
-    def fluent_regen(self, fluent_source):
+    def fluent_regen(self, fluent_source: str) -> str:
         """Helper that converts Fluent source to a FluentFile object and back."""
         return self.fluent_serialize(self.fluent_parse(fluent_source))
 
     @staticmethod
-    def quick_fluent_file(unit_specs):
+    def quick_fluent_file(unit_specs: list[dict[str, str]]) -> fluent.FluentFile:
         """Helper to create a FluentFile populated by the FluentUnits
         parametrised in `unit_specs`.
         """
@@ -59,14 +62,16 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
                 fluent.FluentUnit(
                     source=spec.get("source", None),
                     unit_id=spec.get("id", None),
-                    comment=spec.get("comment", None),
-                    fluent_type=spec.get("type", None),
+                    comment=spec.get("comment", ""),
+                    fluent_type=spec.get("type", ""),
                 )
             )
         return fluent_file
 
     @staticmethod
-    def assert_units(fluent_file, expect_units):
+    def assert_units(
+        fluent_file: fluent.FluentFile, expect_units: list[dict[str, Any]]
+    ) -> None:
         """Assert that the given FluentFile has the expected FluentUnits.
 
         :param FluentFile fluent_file: The file to test.
@@ -101,7 +106,12 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
             assert unit.target == unit.source
         assert len(fluent_file.units) == len(expect_units)
 
-    def basic_test(self, fluent_source, expect_units, expect_serialize=None):
+    def basic_test(
+        self,
+        fluent_source: str,
+        expect_units: list[dict[str, Any]],
+        expect_serialize: str | None = None,
+    ) -> None:
         """Assert that the given fluent source parses correctly to the expected
         FluentFile, and reserializes correctly.
 
@@ -129,7 +139,9 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
             # exactly the same string.
             assert self.fluent_regen(expect_serialize) == expect_serialize
 
-    def assert_serialize(self, fluent_file, expect_serialize):
+    def assert_serialize(
+        self, fluent_file: fluent.FluentFile, expect_serialize: str
+    ) -> None:
         """Assert that the given FluentFile serializes to the given string.
 
         :param FluentFile fluent_file: The FluentFile to serialize.
@@ -139,7 +151,7 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
         expect_serialize = textwrap.dedent(expect_serialize)
         assert self.fluent_serialize(fluent_file) == expect_serialize
 
-    def assert_parse_failure(self, fluent_source, error_part):
+    def assert_parse_failure(self, fluent_source: str, error_part: str) -> None:
         """Assert that the given fluent source fails to parse into a
         FluentFile.
 
@@ -155,7 +167,9 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
         with raises(ValueError, match=error_regex):
             self.fluent_parse(fluent_source)
 
-    def assert_serialize_failure(self, fluent_file, error_regex):
+    def assert_serialize_failure(
+        self, fluent_file: fluent.FluentFile, error_regex: str
+    ) -> None:
         """Assert that the given FluentFile fails to serialize.
 
         :param FluentFile fluent_file: The FluentFile to try and serialize.


### PR DESCRIPTION
Follows from https://github.com/translate/translate/pull/4822

We do some general fixing up of the fluent code, then we add two methods to the FluentUnit that can be used in weblate:

- get_syntax_error: To extract a syntax error in the unit's source without needing to serialize the FluentFile.
- get_parts: To extract all the individual fluent-relevant parts of the unit's source, including its attributes and its variants. This will help weblate split a single source with multiple attributes and [select expressions](https://projectfluent.org/fluent/guide/selectors.html) into simple individual strings, which can then be checked.