### PR TITLE
fix(ts2po): do not crash and skip unit if the context is empty

### DIFF
--- a/translate/convert/test_ts2po.py
+++ b/translate/convert/test_ts2po.py
@@ -142,6 +142,28 @@ new line</translation>
             == "Appears in the Help menu (on Windows and Linux) or the app menu (on macOS)."
         )
 
+    def test_emptycontext(self):
+        """test conversion with a leading empty context"""
+        tssource = """<!DOCTYPE TS><TS>
+<context>
+    <name></name>
+    <message>
+        <source>Message to ignore</source>
+        <translation>Missatge a ignorar</translation>
+    </message>
+</context>
+<context>
+    <name>ValidContext</name>
+    <message>
+        <source>Since we come from abroad, we thought the best thing we could do was to learn the local language and integrate ourselves.</source>
+        <translation>Com que venim de fora vam pensar que el millor que podíem fer era aprendre la llengua d'aquí i integrar-nos.</translation>
+    </message>
+</context>
+</TS>
+"""
+        pofile = self.ts2po(tssource)
+        assert pofile.units[1].source == "Since we come from abroad, we thought the best thing we could do was to learn the local language and integrate ourselves."
+        assert pofile.units[1].target == "Com que venim de fora vam pensar que el millor que podíem fer era aprendre la llengua d'aquí i integrar-nos."
 
 class TestTS2POCommand(test_convert.TestConvertCommand, TestTS2PO):
     """Tests running actual ts2po commands on files"""

--- a/translate/convert/test_ts2po.py
+++ b/translate/convert/test_ts2po.py
@@ -162,8 +162,15 @@ new line</translation>
 </TS>
 """
         pofile = self.ts2po(tssource)
-        assert pofile.units[1].source == "Since we come from abroad, we thought the best thing we could do was to learn the local language and integrate ourselves."
-        assert pofile.units[1].target == "Com que venim de fora vam pensar que el millor que podíem fer era aprendre la llengua d'aquí i integrar-nos."
+        assert (
+            pofile.units[1].source
+            == "Since we come from abroad, we thought the best thing we could do was to learn the local language and integrate ourselves."
+        )
+        assert (
+            pofile.units[1].target
+            == "Com que venim de fora vam pensar que el millor que podíem fer era aprendre la llengua d'aquí i integrar-nos."
+        )
+
 
 class TestTS2POCommand(test_convert.TestConvertCommand, TestTS2PO):
     """Tests running actual ts2po commands on files"""

--- a/translate/convert/ts2po.py
+++ b/translate/convert/ts2po.py
@@ -67,7 +67,11 @@ class ts2po:
         for inputunit in tsfile.units:
             contexts = inputunit.getcontext().split("\n")
 
-            context = contexts[0]
+            context = contexts[0].strip()
+            # skip the unit if the context is empty
+            if not context:
+                continue
+
             if context != previouscontext:
                 previouscontext = context
                 messagenum = 0


### PR DESCRIPTION
`ts2po` crashes if the first context name is empty. For example, in these files:

- https://raw.githubusercontent.com/MythTV/mythtv/master/mythtv/i18n/mythfrontend_ca.ts
- https://raw.githubusercontent.com/MythTV/mythtv/master/mythtv/i18n/mythfrontend_es.ts

```
> ts2po mythfrontend_ca.ts
processing 1 files...
ts2po.py: WARNING: Error processing: input mythfrontend_ca.ts, output None, template None: cannot access local variable 'messagenum' where it is not associated with a value
[###########################################] 100%
```

The PR skips the unit if the context is empty, rather than crash. Another approach could be setting a default context and initializing `messagenum = 0`, but I understand the context should not be empty in normal circumstances (as it is automatically generated)