### PR TITLE
getlocations should return a list instead of string

### DIFF
--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -748,7 +748,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         xlifffile = xliff.xlifffile.parsestring(xlfsource)
         xlifffile.units[0].addlocation("some-directory/on-some-test/test.file2:333")
         locations = xlifffile.units[0].getlocations()
-        locations = ", ".join(x for x in locations if x is not None)
+        locations = ", ".join(locations)
         assert (
             locations
             == "some-directory/on-some-test/test.file:222, some-directory/on-some-test/test.file2:333"

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -721,6 +721,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 """
         xlifffile = xliff.xlifffile.parsestring(xlfsource)
         locations = xlifffile.units[0].getlocations()
+        locations = ", ".join(x for x in locations if x is not None)
 
         assert locations == "some-directory/on-some-test/test.file:222"
 
@@ -746,9 +747,8 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 """
         xlifffile = xliff.xlifffile.parsestring(xlfsource)
         xlifffile.units[0].addlocation("some-directory/on-some-test/test.file2:333")
-
         locations = xlifffile.units[0].getlocations()
-
+        locations = ", ".join(x for x in locations if x is not None)
         assert (
             locations
             == "some-directory/on-some-test/test.file:222, some-directory/on-some-test/test.file2:333"

--- a/translate/storage/test_xliff.py
+++ b/translate/storage/test_xliff.py
@@ -721,7 +721,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 """
         xlifffile = xliff.xlifffile.parsestring(xlfsource)
         locations = xlifffile.units[0].getlocations()
-        locations = ", ".join(x for x in locations if x is not None)
+        locations = ", ".join(locations)
 
         assert locations == "some-directory/on-some-test/test.file:222"
 

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -526,7 +526,7 @@ class xliffunit(lisa.LISAunit):
                 if sourceFile is not None and lineNumber is not None:
                     locations.append(sourceFile[1] + ":" + lineNumber[1])
 
-        return locations
+        return [x for x in locations if x is not None]
 
     def createcontextgroup(self, name, contexts=None, purpose=None):
         """Add the context group to the trans-unit with contexts a list with

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -526,7 +526,7 @@ class xliffunit(lisa.LISAunit):
                 if sourceFile is not None and lineNumber is not None:
                     locations.append(sourceFile[1] + ":" + lineNumber[1])
 
-        return [x for x in locations if x is not None]
+        return locations
 
     def createcontextgroup(self, name, contexts=None, purpose=None):
         """Add the context group to the trans-unit with contexts a list with

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -513,7 +513,7 @@ class xliffunit(lisa.LISAunit):
         self.createcontextgroup("", contexts, "location")
 
     def getlocations(self):
-        """Return comma separated list of locations."""
+        """Returns a list of locations."""
         locations = []
         for contextGroup in self.getcontextgroupsbyattribute("purpose", "location"):
             if len(contextGroup) == 2:
@@ -526,7 +526,7 @@ class xliffunit(lisa.LISAunit):
                 if sourceFile is not None and lineNumber is not None:
                     locations.append(sourceFile[1] + ":" + lineNumber[1])
 
-        return ", ".join(x for x in locations if x is not None)
+        return locations
 
     def createcontextgroup(self, name, contexts=None, purpose=None):
         """Add the context group to the trans-unit with contexts a list with


### PR DESCRIPTION
Hello. A bit of background on why I'm proposing this change.

In commit 9061cac1db35a98f2196c14546a456b98ce0b15f, the method _xliffunit.getlocations_ changed its return type from a Python list to a string.

Consider that xliffunit._getlocations_ inherits from class lisa.LISAunit which inherits from class base.TranslationUnit in which _getlocations_ is defined as:

```
    def getlocations():
        ...
        return []
```

3 reasons why I'm proposing this change: consistency with base class, consistency with the rest of inhered classes which use a list and for consistency in how we expose the API.




