### PR TITLE
fix(xliff): mark fuzzy strings only when qualify as fuzzy

### DIFF
--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -442,8 +442,9 @@ class xliffunit(lisa.LISAunit):
 
     def isfuzzy(self):
         targetnode = self.getlanguageNode(lang=None, index=1)
-        return not targetnode is None and \
-                (targetnode.get("state-qualifier") == "fuzzy-match")
+        return targetnode is not None and (
+            targetnode.get("state-qualifier") == "fuzzy-match"
+        )
 
     def markfuzzy(self, value=True):
         state_id = self.get_state_id()


### PR DESCRIPTION
I found that most XLIFF files available in the wild get 100% fuzzy strings when converted using `xliff2po`.

For example:

- https://raw.githubusercontent.com/Chocobozzz/PeerTube/develop/client/src/locale/angular.ca-ES.xlf
- https://raw.githubusercontent.com/sonata-project/SonataAdminBundle/master/src/Resources/translations/SonataAdminBundle.ca.xliff
- https://raw.githubusercontent.com/mihaelamj/openfoodfacts-ios/master/xliff/ca.xliff
- https://raw.githubusercontent.com/KnpLabs/KnpTimeBundle/master/translations/time.ca.xliff
- https://raw.githubusercontent.com/ONLYOFFICE/desktop-apps/master/macos/Localization/ca.xliff

As per http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html, the `state-qualifier` attribute should be used to determine when a string is fuzzy. Additionally, and contrary to what can be seen in the commented code, I think the presence of the 'needs-review-translation' status alone does not indicate that the string is fuzzy.

This will probably break tests. Please let me know if this direction is acceptable, and I'll fix the existing tests and provide additional ones.