### PR TITLE
commands can have arg --input several times

### DIFF
--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -328,6 +328,7 @@ class RecursiveOptionParser(optparse.OptionParser):
             "-i",
             "--input",
             dest="input",
+            action="append",
             default=None,
             metavar="INPUT",
             help=f"read from INPUT in {inputformathelp}",


### PR DESCRIPTION
fixes #4979

This is helpful to run pofilter or convert for several directories or several files (and there are not the only ones in the directory).