### PR TITLE
Add GitHub sponsors configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: WeblateOrg
+liberapay: Weblate
+open_collective: weblate


### PR DESCRIPTION
Nearly all maintenance on translate-toolkit is currently done by me, so I think it is reasonable to add sponsorship links to Weblate.