### PR TITLE
android: improve string escaping

### DIFF
--- a/tests/translate/storage/test_aresource.py
+++ b/tests/translate/storage/test_aresource.py
@@ -75,8 +75,8 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
         self.__check_escape(string, xml)
 
     def test_escape_question(self):
-        string = "question?"
-        xml = '<string name="teststring">question\\?</string>\n'
+        string = "?question?"
+        xml = '<string name="teststring">\\?question?</string>\n'
         self.__check_escape(string, xml)
 
     def test_escape_double_space(self):


### PR DESCRIPTION
- use str.maketrans for more effective string replacements
- escape ? only at the beginning of the string (fixes #5064)