### PR TITLE
tests: Avoid fiddling with sys.path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ ignore = [
   "PT013",  # TODO: Found incorrect import of pytest, use simple `import pytest` instead
   "ISC001",  # TODO: Implicitly concatenated string literals on one line
   "PLR0124",  # TODO: Name compared with itself, consider replacing `unit1 == unit1`
-  "E402",  # TODO: Module level import not at top of file
   "PT009",  # TODO: Use a regular `assert` instead of unittest-style `assertCountEqual`
   "B015",  # TODO: Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it
   "PGH003",  # TODO: Use specific rule codes when ignoring type issues

--- a/tests/odf_xliff/test_odf_xliff.py
+++ b/tests/odf_xliff/test_odf_xliff.py
@@ -19,21 +19,13 @@
 
 import difflib
 import os
-import sys
 import zipfile
 from os import path
 
 from lxml import etree
 
-# get directory of this test
-dir = os.path.dirname(os.path.abspath(__file__))
-# get top-level directory (moral equivalent of ../..)
-dir = os.path.dirname(os.path.dirname(dir))
-# load python modules from top-level
-sys.path.insert(0, dir)
-
-from translate.convert import odf2xliff, xliff2odf  # isort:skip
-from translate.storage import factory, xliff  # isort:skip
+from translate.convert import odf2xliff, xliff2odf
+from translate.storage import factory, xliff
 
 
 def args(src, tgt, **kwargs):


### PR DESCRIPTION
The tests are supposed to be executed with module installed now.