### PR TITLE
chore: sync default encoding with Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ ignore = [
   "PT013",  # TODO: Found incorrect import of pytest, use simple `import pytest` instead
   "PT009",  # TODO: Use a regular `assert` instead of unittest-style `assertCountEqual`
   "PLE0604",  # TODO: Invalid object in `__all__`, must contain only strings
-  "B008",  # TODO: Do not perform function call `sys.getdefaultencoding` in argument defaults
   "PLW1510",  # TODO: `subprocess.run` without explicit `check` argument
   "SLOT000",  # TODO: Subclasses of `str` should define `__slots__`
   "B028",  # TODO: No explicit `stacklevel` keyword argument found

--- a/translate/storage/placeables/strelem.py
+++ b/translate/storage/placeables/strelem.py
@@ -24,7 +24,6 @@ parsed rich-string tree. It is the base class of all placeables.
 
 import contextlib
 import logging
-import sys
 
 
 def filter_all(e):
@@ -418,7 +417,7 @@ class StringElem:
                 elems.extend(sub.depth_first(filter))
         return elems
 
-    def encode(self, encoding=sys.getdefaultencoding()):
+    def encode(self, encoding="utf-8"):
         """More ``unicode`` class emulation."""
         return str(self).encode(encoding)
 


### PR DESCRIPTION
encode() defaults to utf-8 in Python 3.