### PR TITLE
ini: do not treat rem as a comment start

### DIFF
--- a/tests/translate/storage/test_ini.py
+++ b/tests/translate/storage/test_ini.py
@@ -20,3 +20,13 @@ class TestINIStore(test_monolingual.TestMonolingualStore):
         store.serialize(out)
 
         assert out.getvalue() == content
+
+    def test_rem(self):
+        content = b"[default]\nremaining=None"
+        store = self.StoreClass()
+        store.parse(content)
+        assert len(store.units) == 1
+        out = BytesIO()
+        store.serialize(out)
+
+        assert out.getvalue() == content

--- a/translate/storage/ini.py
+++ b/translate/storage/ini.py
@@ -36,10 +36,14 @@ from io import StringIO
 from translate.storage import base
 
 try:
-    from iniparse import INIConfig
+    from iniparse import INIConfig, change_comment_syntax
 except ImportError:
     raise ImportError("Missing iniparse library.")
 
+
+# Disable treating anything starting with rem as a comment, this changes
+# global iniparse state
+change_comment_syntax(allow_rem=False)
 
 dialects = {}
 


### PR DESCRIPTION
These are typically valid INI keys, this iniparse behavior seems weird.

Other iniparse consumers seem to do this as well (for example crudini).

Fixes https://github.com/WeblateOrg/weblate/issues/10561