### PR TITLE
pypo: update line wrapping on adding unit

### DIFF
--- a/tests/translate/storage/test_pypo.py
+++ b/tests/translate/storage/test_pypo.py
@@ -655,3 +655,21 @@ msgstr ""\r
             POT_Creation_Date="2023-10-24 10:19+0200",
         )
         assert bytes(pofile) == poexpected
+
+    def test_wrap_custom(self):
+        posource = 'msgid "HELLO"\nmsgstr ""\n'
+
+        # Instance with default wraps
+        store = self.StoreClass()
+        store.parse(posource.encode())
+        assert len(store.units) == 1
+
+        store.units[0].target = " ".join(["Hello world"] * 20)
+
+        assert max(len(line) for line in bytes(store).decode().splitlines()) <= 77
+
+        outstore = self.StoreClass()
+        outstore.wrapper.width = -1
+        outstore.addunit(store.units[0])
+
+        assert max(len(line) for line in bytes(outstore).decode().splitlines()) > 77

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -1040,5 +1040,10 @@ class pofile(pocommon.pofile):
                 yield unit
 
     def addunit(self, unit):
+        needs_update = (
+            unit.wrapper and self.wrapper and (unit.wrapper.width != self.wrapper.width)
+        )
         unit.wrapper = self.wrapper
         super().addunit(unit)
+        if needs_update:
+            unit.target = unit.target


### PR DESCRIPTION
This ensures that newly added unit is using storage configured line wrapping.

Fixes https://github.com/WeblateOrg/weblate/issues/10392