### PR TITLE
storage: fix parsing blank unit id

### DIFF
--- a/tests/translate/storage/test_jsonl10n.py
+++ b/tests/translate/storage/test_jsonl10n.py
@@ -686,6 +686,7 @@ class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):
             ("[test]selection", [("key", "[test]selection")]),
             ("[test][0]selection", [("key", "[test][0]selection")]),
             ("[0][test]selection", [("index", 0), ("key", "[test]selection")]),
+            ("", [("key", "")]),
         ],
     )
     def test_from_string(self, id_string, expected):

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -966,6 +966,8 @@ class UnitId:
                 item = item[endbracepos + 1 :]
             if item:
                 result.append(("key", item))
+        if not result:
+            result.append(("key", ""))
         return cls(result)
 
     def __eq__(self, other):


### PR DESCRIPTION
This is a regression in 2a9c3253a9e013d34ccf1a07984730f9cfff25f4.