### PR TITLE
resx: Use Windows newlines

### DIFF
--- a/tests/translate/convert/test_po2resx.py
+++ b/tests/translate/convert/test_po2resx.py
@@ -112,7 +112,7 @@ msgstr "Some translated text"'''
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_basic(self):
         po_source = r"""# Afrikaans translation of program ABC
@@ -146,7 +146,7 @@ msgstr "Toepassings"
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_multiline(self):
         """Test multiline po entry."""
@@ -168,7 +168,7 @@ msgstr "Eerste deel "
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_escapednewlines(self):
         """Test the escaping of newlines."""
@@ -190,7 +190,7 @@ Tweede lyn</value>
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_escapedtabs(self):
         """Test the escaping of tabs."""
@@ -211,7 +211,7 @@ msgstr "Eerste kolom\tTweede kolom"
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_escapedquotes(self):
         """Test the escaping of quotes (and slash)."""
@@ -235,7 +235,7 @@ msgstr "Gebruik \\\"."
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_exclusions(self):
         """Test that empty and fuzzy messages are excluded."""
@@ -277,7 +277,7 @@ msgstr "Drie"
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_automaticcomments(self):
         """Tests that automatic comments are imported."""
@@ -300,7 +300,7 @@ msgstr "Bézier-kurwe"
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_automaticcomments_existingcomment(self):
         """Tests a differing automatic comment is added if there is an existing automatic comment."""
@@ -325,7 +325,7 @@ This is a new comment</comment>
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_automaticcomments_existingduplicatecomment(self):
         """Tests there is no duplication of automatic comments if it already exists and hasn't changed."""
@@ -349,7 +349,7 @@ msgstr "Bézier-kurwe"
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_automaticcomments_existingduplicatecommentwithwhitespace(self):
         """
@@ -376,7 +376,7 @@ msgstr "Bézier-kurwe"
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_translatorcomments(self):
         """Tests that translator comments are imported."""
@@ -399,7 +399,7 @@ msgstr "Bézier-kurwe"
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_translatorcomments_existingcomment(self):
         """Tests a differing translator comment is added if there is an existing translator comment."""
@@ -424,7 +424,7 @@ msgstr "Bézier-kurwe"
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_translatorcomments_existingduplicatecomment(self):
         """Tests there is no duplication of translator comments if it already exists and hasn't changed."""
@@ -448,7 +448,7 @@ msgstr "Bézier-kurwe"
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_combocomments(self):
         """Tests that translator comments and automatic comments are imported."""
@@ -473,7 +473,7 @@ msgstr "Bézier-kurwe"
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_combocomments_existingduplicatecomment(self):
         """
@@ -502,7 +502,7 @@ msgstr "Bézier-kurwe"
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_combocomments_existingcomment(self):
         """
@@ -532,7 +532,7 @@ This is a new comment
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
     def test_existingcomments(self):
         """Tests that no extra space is added when there are no changes to existing comments."""
@@ -559,7 +559,7 @@ msgstr "Bézier-kurwe"
   </data>"""
         )
         resx_file = self.po2resx(resx_template, po_source)
-        assert resx_file == expected_output
+        assert resx_file == expected_output.replace("\n", "\r\n")
 
 
 class TestPO2RESXCommand(test_convert.TestConvertCommand, TestPO2RESX):

--- a/tests/translate/storage/test_resx.py
+++ b/tests/translate/storage/test_resx.py
@@ -94,10 +94,7 @@ class TestRESXUnitFromParsedString(TestRESXUnit):
         self.unit = self.store.units[0]
 
     def _assert_store(self, expected_resx):
-        output_file = BytesIO()
-        self.store.serialize(output_file)
-        actual_resx = output_file.getvalue().decode("utf-8")
-        assert actual_resx == expected_resx
+        assert bytes(self.store).decode() == expected_resx.replace("\n", "\r\n")
 
     def test_newunit(self):
         new_unit = resx.RESXUnit("New translated value")

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -345,7 +345,7 @@ class LISAfile(base.TranslationStore):
 
         xml_declaration = f"<?xml version={xml_quote_format}1.0{xml_quote_format} encoding={xml_quote_format}{xml_encoding}{xml_quote_format}?>\n"
 
-        out.write(xml_declaration.encode(self.encoding))
+        out.write(self.serialize_hook(xml_declaration.encode(self.encoding)))
 
         if self.XMLindent:
             reindent(root, **self.XMLindent)

--- a/translate/storage/resx.py
+++ b/translate/storage/resx.py
@@ -224,4 +224,4 @@ class RESXFile(lisa.LISAfile):
 
     def serialize_hook(self, treestring):
         # Additional space on empty tags same as Visual Studio
-        return treestring.replace(b"/>", b" />")
+        return treestring.replace(b"/>", b" />").replace(b"\n", b"\r\n")


### PR DESCRIPTION
This makes the output consistent with native tooling.

Fixes #5119