### PR TITLE
chore: do not provide default value for required argument

### DIFF
--- a/translate/storage/flatxml.py
+++ b/translate/storage/flatxml.py
@@ -187,7 +187,7 @@ class FlatXMLFile(base.TranslationStore):
             # ensure trailing EOL for VCS
             self.root.tail = "\n"
 
-    def serialize(self, out=None):
+    def serialize(self, out):
         self.reindent()
         self.document.write(
             out, xml_declaration=self.XML_DECLARATION, encoding=self.encoding

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -330,7 +330,7 @@ class LISAfile(base.TranslationStore):
     def serialize_hook(self, treestring: str) -> bytes:
         return treestring.encode(self.encoding)
 
-    def serialize(self, out=None):
+    def serialize(self, out):
         """Converts to a string containing the file's XML."""
         root = self.document.getroot()
         xml_quote_format = "'"


### PR DESCRIPTION
The code does not work with None, so there is no reason to make it default.