### PR TITLE
gotext: preserve unit IDs as stored in the JSON files

### DIFF
--- a/tests/translate/storage/test_jsonl10n.py
+++ b/tests/translate/storage/test_jsonl10n.py
@@ -986,6 +986,39 @@ class TestGoTextJsonFile(test_monolingual.TestMonolingualStore):
 """
         )
 
+    def test_complex_id(self):
+        text = """{
+    "language": "en-US",
+    "messages": [
+        {
+            "id": [
+                "msgOutOfOrder",
+                "{Device} is out of order!"
+            ],
+            "message": "{Device} is out of order!",
+            "key": "%s is out of order!",
+            "translation": ""
+        },
+        {
+            "id": "[DEBUG] msg",
+            "message": "[DEBUG] msg",
+            "key": "[DEBUG] msg",
+            "translation": ""
+        }
+    ]
+}
+"""
+        store = self.StoreClass()
+        store.parse(text)
+
+        assert len(store.units) == 2
+        assert (
+            store.units[0].getid() == "['msgOutOfOrder', '{Device} is out of order!']"
+        )
+        assert store.units[1].getid() == "[DEBUG] msg"
+
+        assert bytes(store).decode() == text
+
 
 class TestI18NextV4Store(test_monolingual.TestMonolingualStore):
     StoreClass = jsonl10n.I18NextV4File

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -502,8 +502,23 @@ class I18NextV4File(JsonNestedFile):
             )
 
 
+class GoTextUnitId(base.UnitId):
+    """Preserves id as stored in the JSON file."""
+
+    def __str__(self):
+        return str(self.parts)
+
+    def extend(self, key, value):
+        raise ValueError("Extend is not supported")
+
+    @classmethod
+    def from_string(cls, text):
+        return cls(text)
+
+
 class GoTextJsonUnit(BaseJsonUnit):
     ID_FORMAT = "{}"
+    IdClass = GoTextUnitId
 
     def __init__(
         self,
@@ -544,7 +559,7 @@ class GoTextJsonUnit(BaseJsonUnit):
                 plural: {"msg": strings[offset]}
                 for offset, plural in enumerate(self._store.plural_tags)
             }
-        value = {"id": self.getid()}
+        value = {"id": self._unitid.parts if self._unitid else self.getid()}
         if self.message:
             value["message"] = self.message
         if self.notes:
@@ -561,6 +576,12 @@ class GoTextJsonUnit(BaseJsonUnit):
         if self.placeholders:
             value["placeholders"] = self.placeholders
         return value
+
+    def setid(self, value, unitid=None):
+        if unitid is None:
+            unitid = self.IdClass(value)
+        # Skip BaseJsonUnit.setid override
+        super(BaseJsonUnit, self).setid(str(unitid), unitid)
 
 
 class GoTextJsonFile(JsonFile):


### PR DESCRIPTION
- avoid parsing them as keys
- use UnitId to preserve types in round-trip

Fixes #4867