### PR TITLE
subtitles: drop gaupol module support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,12 +139,9 @@ simply appear in English. It is therefore recommended you install the
 
 The package vobject is needed for ical2po and po2ical.
 
-The aeidon package (or gaupol if aeidon is not available) is needed for sub2po
+The aeidon package is needed for sub2po
 and po2sub. Some Unicode encoded files (including most files from
 <http://dotsub.com/>) require version 0.14 or later.
-<http://home.gna.org/gaupol/>
-Gaupol might need the 'Universal Encoding Detector'
-<http://pypi.python.org/pypi/chardet>
 
 Trados TXT TM support requires the BeautifulSoup parser
 <http://www.crummy.com/software/BeautifulSoup/>

--- a/docs/commands/sub2po.rst
+++ b/docs/commands/sub2po.rst
@@ -102,5 +102,5 @@ Bugs
 ----
 There might be some issues with encodings, since the srt files don't specify
 them. We assume files to be encoded in UTF-8, so a conversion should solve this
-easily. Note that most of the handling of the srt files come from gaupol.
+easily. Note that most of the handling of the srt files come from aeidon.
 

--- a/docs/formats/subtitles.rst
+++ b/docs/formats/subtitles.rst
@@ -28,8 +28,8 @@ YouTube supports `a number of formats
 Implementation details
 ======================
 
-Format support is provided by `Gaupol <https://otsaloma.io/gaupol/>`_ a
-subtitling tool.  Further enhancement of format support in Gaupol will directly
+Format support is provided by `aeidon <https://pypi.org/project/aeidon/>`_ library.
+Further enhancement of format support in aeidon will directly
 benefit our conversion ability.
 
 .. _subtitles#usage:

--- a/tests/translate/convert/test_po2sub.py
+++ b/tests/translate/convert/test_po2sub.py
@@ -7,7 +7,6 @@ from translate.storage import po
 
 from . import test_convert
 
-# Technically subtitles can also use an older gaupol
 importorskip("aeidon")
 
 

--- a/translate/storage/subtitles.py
+++ b/translate/storage/subtitles.py
@@ -19,11 +19,7 @@
 """
 Class that manages subtitle files for translation.
 
-This class makes use of the subtitle functionality of ``gaupol``.
-
-.. seealso:: gaupol/agents/open.py::open_main
-
-A patch to gaupol is required to open utf-8 files successfully.
+This class makes use of the subtitle functionality of ``aeidon``.
 """
 
 import os
@@ -36,25 +32,9 @@ try:
     from aeidon import Subtitle, documents, newlines
     from aeidon.encodings import detect
     from aeidon.files import AdvSubStationAlpha, MicroDVD, SubRip, SubStationAlpha, new
-    from aeidon.util import detect_format as determine
+    from aeidon.util import detect_format
 except ImportError:
-    try:
-        from gaupol import FormatDeterminer, documents
-        from gaupol.encodings import detect
-        from gaupol.files import (
-            AdvSubStationAlpha,
-            MicroDVD,
-            SubRip,
-            SubStationAlpha,
-            new,
-        )
-        from gaupol.newlines import newlines
-        from gaupol.subtitle import Subtitle
-
-        _determiner = FormatDeterminer()
-        determine = _determiner.determine
-    except ImportError:
-        raise ImportError("\naeidon or gaupol package required for Subtitle support")
+    raise ImportError("\naeidon package required for Subtitle support")
 
 
 class SubtitleUnit(base.TranslationUnit):
@@ -119,7 +99,7 @@ class SubtitleFile(base.TranslationStore):
     def _parse(self):
         try:
             self.encoding = detect(self.filename)
-            self._format = determine(self.filename, self.encoding)
+            self._format = detect_format(self.filename, self.encoding)
             self._subtitlefile = new(self._format, self.filename, self.encoding)
             for subtitle in self._subtitlefile.read():
                 newunit = self.addsourceunit(subtitle.main_text)


### PR DESCRIPTION
Aiedon is available for years and gaupol uses it to parse subtitles, so there is no reason to import from gaupol anymore.