### PR TITLE
xliff: improve indentation

### DIFF
--- a/tests/cli/data/test_po2flatxml_preserve/out.xml
+++ b/tests/cli/data/test_po2flatxml_preserve/out.xml
@@ -4,6 +4,6 @@
   <str key="two">Zwei-mod</str>
   <str key="three">Drei</str>
   <!-- not used as translated resource -->
-  <constant name="answer">42</constant>
+    <constant name="answer">42</constant>
   <str key="four">Vier-new</str>
 </root>

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -431,7 +431,7 @@ class tsfile(lisa.LISAfile):
 <TS>
 </TS>
 """
-    XMLindent = {"indent": "    ", "skip": ["TS"], "toplevel": False}
+    XMLindent = {"indent": "    ", "skip": {"TS"}, "toplevel": False}
     # For conformance with Qt output, write XML declaration with double quotes
     XMLuppercaseEncoding = False
     namespace = ""

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -657,7 +657,13 @@ class xlifffile(lisa.LISAfile):
 </body>
 </file>
 </xliff>"""
-    XMLindent = {"indent": "  ", "max_level": 4, "toplevel": False}
+    XMLindent = {
+        "indent": "  ",
+        "max_level": 8,
+        "leaves": {"note", "source", "target"},
+        "toplevel": False,
+        "ignore_preserve": {"trans-unit"},
+    }
     namespace = "urn:oasis:names:tc:xliff:document:1.1"
     unversioned_namespace = "urn:oasis:names:tc:xliff:document:"
 


### PR DESCRIPTION
- do not honor xml:space="preserve" on trans-unit as it is really important for childs only
- make reindent work on sets instead of lists for better performance