### PR TITLE
xliff: preserve whitespace for rich target as well

### DIFF
--- a/tests/translate/storage/test_xliff.py
+++ b/tests/translate/storage/test_xliff.py
@@ -834,3 +834,13 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert unit.target == target
 
         assert bytes(xlifffile).decode() == xlfsource_preserve
+
+        xlifffile = xliff.xlifffile.parsestring(xlfsource_plain)
+
+        assert len(xlifffile.units) == 1
+        unit = xlifffile.units[0]
+
+        assert unit.target == target.replace("\n", " ")
+        unit.rich_target = [target]
+
+        assert bytes(xlifffile).decode() == xlfsource_preserve

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -214,6 +214,7 @@ class xliffunit(lisa.LISAunit):
             self.set_target_dom(self.createlanguageNode(lang, "", "target"))
             return
 
+        self._ensure_xml_space_preserve()
         languageNode = self.get_target_dom()
         if languageNode is None:
             languageNode = self.createlanguageNode(lang, "", "target")
@@ -460,12 +461,15 @@ class xliffunit(lisa.LISAunit):
             if state_id < self.S_UNREVIEWED:
                 self.set_state_n(self.S_UNREVIEWED)
 
+    def _ensure_xml_space_preserve(self):
+        if getXMLspace(self.xmlelement) != "preserve":
+            setXMLspace(self.xmlelement, "preserve")
+
     def settarget(self, target, lang="xx", append=False):
         """Sets the target string to the given value."""
         super().settarget(target, lang, append)
         if target:
-            if getXMLspace(self.xmlelement) != "preserve":
-                setXMLspace(self.xmlelement, "preserve")
+            self._ensure_xml_space_preserve()
             self.marktranslated()
 
     # This code is commented while this will almost always return false.


### PR DESCRIPTION
There is no reason to differentiate plain and rich targets here, both can contain significant whitespace.

Fixes https://github.com/WeblateOrg/weblate/issues/10811