### PR TITLE
Change resx XMLIdent to respect Visual Studio formatting

### DIFF
--- a/translate/storage/resx.py
+++ b/translate/storage/resx.py
@@ -187,7 +187,7 @@ class RESXFile(lisa.LISAfile):
   </resheader>
 </root>
 """
-    XMLindent = {"indent": "  ", "max_level": 4}
+    XMLindent = {"indent": "    ", "max_level": 4}
     # Use same header as Visual Studio
     XMLuppercaseEncoding = False
     namespace = ""


### PR DESCRIPTION
Visual Studio uses 4 spaces instead of 2.