### PR TITLE
pypo: avoid adding extra msgctxt if there are 3 or more same msgids

### DIFF
--- a/tests/translate/convert/test_json2po.py
+++ b/tests/translate/convert/test_json2po.py
@@ -1,3 +1,23 @@
+#
+# Copyright 2023 Stuart Prescott
+# Copyright 2023 Michal Čihař <michal@cihar.com>
+# Copyright 2024 gemmaro <gemmaro.dev@gmail.com>
+#
+# This file is part of translate.
+#
+# translate is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# translate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
 from io import BytesIO
 
 from translate.convert import json2po
@@ -31,6 +51,26 @@ msgstr ""
 """
         poresult = self.json2po(jsonsource)
         assert str(poresult.units[1]) == poexpected
+
+    def test_three_same_keys(self):
+        """Test that we can handle JSON with three (or more) same keys."""
+        jsonsource = """{
+    "a": {
+        "x": "X"
+    },
+    "b": {
+        "x": "X"
+    },
+    "c": {
+        "x": "X"
+    }
+}
+"""
+        poresult = self.json2po(jsonsource)
+        assert len(poresult.units) == 4
+        assert poresult.units[1].msgctxt == ['".a.x"']
+        assert poresult.units[2].msgctxt == ['".b.x"']
+        assert poresult.units[3].msgctxt == ['".c.x"']
 
     def test_filter(self):
         """Test basic json conversion with filter option."""

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -1,6 +1,7 @@
 #
 # Copyright 2002-2009 Zuza Software Foundation
 # Copyright 2013 F Wolff
+# Copyright 2024 gemmaro <gemmaro.dev@gmail.com>
 #
 # This file is part of the Translate Toolkit.
 #
@@ -987,8 +988,7 @@ class pofile(pocommon.pofile):
                         uniqueunits.append(thepo)
                 elif duplicatestyle == "msgctxt":
                     origpo = id_dict[id]
-                    if origpo not in markedpos and id:
-                        # if it doesn't have an id, we already added msgctxt
+                    if origpo not in markedpos and not origpo.msgctxt:
                         origpo.msgctxt.append(
                             '"%s"' % escapeforpo(" ".join(origpo.getlocations()))
                         )


### PR DESCRIPTION
Hello,

This make json2po avoids multiple msgctxt in the resulting PO file.
The cause was in the duplicate removal phase; the location of the first occurrence, among other two or more PO entries with the same keys, was added after the third time and later.

Close #4394.
This also adds a minimal example case as follows.
If we have the JSON source:

```json
{
    "a": {
        "x": "X"
    },
    "b": {
        "x": "X"
    },
    "c": {
        "x": "X"
    }
}
```

... then json2po produced PO content whose `.a.x`'s msgctxt was `".a.x\n.a.x"` (with `pypo.py`, not specifying `USECPO=2` or `USECPO=1`), not `".a.x"`:

```po
#: .a.x
msgctxt ".a.x"
".a.x"
msgid "X"
msgstr ""

#: .b.x
msgctxt ".b.x"
msgid "X"
msgstr ""

#: .c.x
msgctxt ".c.x"
msgid "X"
msgstr ""
```

Thank you,
gemmaro.