### PR TITLE
quote: handle all control chars equally

### DIFF
--- a/tests/translate/misc/test_quote.py
+++ b/tests/translate/misc/test_quote.py
@@ -138,7 +138,7 @@ class TestEncoding:
         prefix, suffix = "bling", "blang"
         for control in ("\u0005", "\u0006", "\u0007", "\u0011"):
             string = prefix + control + suffix
-            assert quote.escapecontrols(string) == string
+            assert quote.escapecontrols(string) != string
 
     @staticmethod
     def test_propertiesdecode():
@@ -148,6 +148,15 @@ class TestEncoding:
         assert quote.propertiesdecode("abc\N{LEFT CURLY BRACKET}") == "abc{"
         assert quote.propertiesdecode("abc\\") == "abc\\"
         assert quote.propertiesdecode("abc\\") == "abc\\"
+
+    @staticmethod
+    def test_controlchars():
+        assert quote.javapropertiesencode(quote.propertiesdecode("\u0001")) == r"\u0001"
+        assert quote.javapropertiesencode(quote.propertiesdecode("\\u01")) == r"\u0001"
+        assert quote.javapropertiesencode("\\") == "\\\\"
+        assert quote.javapropertiesencode("\x01") == "\\u0001"
+        assert quote.propertiesdecode("\x01") == "\x01"
+        assert quote.propertiesdecode("\\u0001") == "\x01"
 
     @staticmethod
     def test_properties_decode_slashu():

--- a/translate/misc/quote.py
+++ b/translate/misc/quote.py
@@ -429,20 +429,47 @@ propertyescapes = {
 }
 
 controlchars = {
-    # the reverse of the above...
-    "\\": "\\\\",
-    "\f": "\\f",
-    "\n": "\\n",
-    "\r": "\\r",
-    "\t": "\\t",
+    # complement of the above with all control chars
+    "\\": r"\\",
+    "\x00": r"\u0000",
+    "\x01": r"\u0001",
+    "\x02": r"\u0002",
+    "\x03": r"\u0003",
+    "\x04": r"\u0004",
+    "\x05": r"\u0005",
+    "\x06": r"\u0006",
+    "\x07": r"\u0007",
+    "\x08": r"\u0008",
+    "\t": r"\t",
+    "\n": r"\n",
+    "\x0b": r"\u000b",
+    "\f": r"\f",
+    "\r": r"\r",
+    "\x0e": r"\u000e",
+    "\x0f": r"\u000f",
+    "\x10": r"\u0010",
+    "\x11": r"\u0011",
+    "\x12": r"\u0012",
+    "\x13": r"\u0013",
+    "\x14": r"\u0014",
+    "\x15": r"\u0015",
+    "\x16": r"\u0016",
+    "\x17": r"\u0017",
+    "\x18": r"\u0018",
+    "\x19": r"\u0019",
+    "\x1a": r"\u001a",
+    "\x1b": r"\u001b",
+    "\x1c": r"\u001c",
+    "\x1d": r"\u001d",
+    "\x1e": r"\u001e",
+    "\x1f": r"\u001f",
 }
+controlchars_trans = str.maketrans(controlchars)
 
 
 def escapecontrols(source: str) -> str:
     """Escape control characters in the given string."""
-    for key, value in controlchars.items():
-        source = source.replace(key, value)
-    return source
+    return source.translate(controlchars_trans)
 
 
 def propertiesdecode(source: str) -> str:


### PR DESCRIPTION
This makes the behavior consistent for all control characters, not just to these few defined.

Fixes #5199

I'd really like to get this reviewed because I could not find reasoning for the previous behavior and I might have missed something.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Updated control character escaping logic for improved efficiency and readability.
- **Tests**
	- Modified an assertion to check for inequality in control escape tests.
	- Added new tests for control character encoding and decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->