### PR TITLE
lisa: strip characters which lxml will refuse to serialize

### DIFF
--- a/tests/translate/storage/test_xliff.py
+++ b/tests/translate/storage/test_xliff.py
@@ -71,20 +71,8 @@ class TestXLIFFUnit(test_base.TestTranslationUnit):
 
         Source: :wp:`Valid_characters_in_XML#XML_1.0`
         """
-        for code in xliff.ASCII_CONTROL_CODES:
-            self.unit.target = "Een&#x%s;" % code.lstrip("0") or "0"
-            assert self.unit.target == "Een%s" % chr(int(code, 16))
-            self.unit.target = "Een%s" % chr(int(code, 16))
-            assert self.unit.target == "Een%s" % chr(int(code, 16))
-
-    def test_unaccepted_control_chars_escapes_roundtrip(self):
-        """Test control characters go ok on escaping roundtrip."""
-        for code in xliff.ASCII_CONTROL_CODES:
-            special = "Een%s" % chr(int(code, 16))
-            self.unit.source = special
-            print("unit.source:", repr(self.unit.source))
-            print("special:", repr(special))
-            assert self.unit.source == special
+        self.unit.target = "Een\x00"
+        assert self.unit.target == "Een"
 
 
 class TestXLIFFfile(test_base.TestTranslationStore):

--- a/translate/storage/flatxml.py
+++ b/translate/storage/flatxml.py
@@ -20,7 +20,7 @@
 
 from lxml import etree
 
-from translate.misc.xml_helpers import getText, namespaced, reindent
+from translate.misc.xml_helpers import getText, namespaced, reindent, safely_set_text
 from translate.storage import base
 
 
@@ -69,7 +69,7 @@ class FlatXMLUnit(base.TranslationUnit):
         """Updates the translated string of this unit."""
         if self.target == target:
             return
-        self.xmlelement.text = target
+        safely_set_text(self.xmlelement, target)
 
     def namespaced(self, name):
         """Returns name in Clark notation."""

--- a/translate/storage/qph.py
+++ b/translate/storage/qph.py
@@ -34,6 +34,7 @@ provides the reference implementation for the Qt Linguist product.
 from lxml import etree
 
 from translate.lang import data
+from translate.misc.xml_helpers import safely_set_text
 from translate.storage import lisa
 
 
@@ -49,7 +50,7 @@ class QphUnit(lisa.LISAunit):
         """Returns an xml Element setup with given parameters."""
         assert purpose
         langset = etree.Element(self.namespaced(purpose))
-        langset.text = text
+        safely_set_text(langset, text)
         return langset
 
     def _getsourcenode(self):
@@ -69,7 +70,7 @@ class QphUnit(lisa.LISAunit):
         current_notes = self.getnotes(origin)
         self.removenotes(origin)
         note = etree.SubElement(self.xmlelement, self.namespaced("definition"))
-        note.text = "\n".join(filter(None, [current_notes, text.strip()]))
+        safely_set_text(note, "\n".join(filter(None, [current_notes, text.strip()])))
 
     def getnotes(self, origin=None):
         # TODO: consider only responding when origin has certain values

--- a/translate/storage/resx.py
+++ b/translate/storage/resx.py
@@ -21,7 +21,10 @@
 
 from lxml import etree
 
-from translate.misc.xml_helpers import setXMLspace
+from translate.misc.xml_helpers import (
+    safely_set_text,
+    setXMLspace,
+)
 from translate.storage import lisa
 from translate.storage.placeables import general
 
@@ -39,7 +42,7 @@ class RESXUnit(lisa.LISAunit):
         """Returns an xml Element setup with given parameters."""
         langset = etree.Element(self.namespaced(self.languageNode))
 
-        langset.text = text
+        safely_set_text(langset, text)
         return langset
 
     def _gettargetnode(self):
@@ -66,7 +69,7 @@ class RESXUnit(lisa.LISAunit):
             return
         targetnode = self._gettargetnode()
         targetnode.clear()
-        targetnode.text = target or ""
+        safely_set_text(targetnode, target or "")
 
     def addnote(self, text, origin=None, position="append"):
         """Add a note specifically in the appropriate "comment" tag."""
@@ -77,11 +80,13 @@ class RESXUnit(lisa.LISAunit):
         if position == "append":
             if current_notes.strip() in text_stripped:
                 # Don't add duplicate comments
-                note.text = text_stripped
+                safely_set_text(note, text_stripped)
             else:
-                note.text = "\n".join(filter(None, [current_notes, text_stripped]))
+                safely_set_text(
+                    note, "\n".join(filter(None, [current_notes, text_stripped]))
+                )
         else:
-            note.text = text_stripped
+            safely_set_text(note, text_stripped)
         if note.text:
             # Correct the indent of <comment> by updating the tail of
             # the preceding <value> element

--- a/translate/storage/tbx.py
+++ b/translate/storage/tbx.py
@@ -20,7 +20,11 @@
 
 from lxml import etree
 
-from translate.misc.xml_helpers import getXMLspace, setXMLlang
+from translate.misc.xml_helpers import (
+    getXMLspace,
+    safely_set_text,
+    setXMLlang,
+)
 from translate.storage import lisa
 
 
@@ -42,7 +46,7 @@ class tbxunit(lisa.LISAunit):
         term = etree.SubElement(tig, self.textNode)
         # probably not what we want:
         # lisa.setXMLspace(term, "preserve")
-        term.text = text
+        safely_set_text(term, text)
         return langset
 
     def getid(self):
@@ -75,7 +79,7 @@ class tbxunit(lisa.LISAunit):
         if not text:
             return
         note = etree.SubElement(self.xmlelement, self._get_origin_element(origin))
-        note.text = text
+        safely_set_text(note, text)
         if origin and origin not in ("pos", "definition"):
             note.set("from", origin)
 

--- a/translate/storage/tmx.py
+++ b/translate/storage/tmx.py
@@ -21,7 +21,7 @@
 from lxml import etree
 
 from translate import __version__
-from translate.misc.xml_helpers import setXMLlang, valid_chars_only
+from translate.misc.xml_helpers import safely_set_text, setXMLlang
 from translate.storage import lisa
 
 
@@ -39,11 +39,7 @@ class tmxunit(lisa.LISAunit):
         seg = etree.SubElement(langset, self.textNode)
         # implied by the standard:
         # setXMLspace(seg, "preserve")
-        try:
-            seg.text = text
-        except ValueError:
-            # Prevents "All strings must be XML compatible" when string contains a control characters
-            seg.text = valid_chars_only(text)
+        safely_set_text(seg, text)
 
         return langset
 
@@ -66,7 +62,7 @@ class tmxunit(lisa.LISAunit):
         The origin parameter is ignored
         """
         note = etree.SubElement(self.xmlelement, self.namespaced("note"))
-        note.text = text.strip()
+        safely_set_text(note, text.strip())
 
     def _getnotelist(self, origin=None):
         """

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -36,6 +36,7 @@ from lxml import etree
 
 from translate.lang import data
 from translate.misc.multistring import multistring
+from translate.misc.xml_helpers import safely_set_text
 from translate.storage import lisa
 from translate.storage.placeables import general
 from translate.storage.workflow import StateEnum as state
@@ -121,7 +122,7 @@ class tsunit(lisa.LISAunit):
         # TODO: check language
         # lisa.setXMLlang(langset, lang)
 
-        langset.text = text
+        safely_set_text(langset, text)
         return langset
 
     def _getsourcenode(self):
@@ -185,9 +186,9 @@ class tsunit(lisa.LISAunit):
             self.xmlelement.set("numerus", "yes")
             for string in strings:
                 numerus = etree.SubElement(targetnode, self.namespaced("numerusform"))
-                numerus.text = string or ""
+                safely_set_text(numerus, string or "")
         else:
-            targetnode.text = target or ""
+            safely_set_text(targetnode, target or "")
 
     def hasplural(self):
         return self.xmlelement.get("numerus") == "yes"
@@ -203,11 +204,11 @@ class tsunit(lisa.LISAunit):
                 self.xmlelement, self.namespaced("translatorcomment")
             )
         if position == "append":
-            note.text = "\n".join(
-                item for item in [current_notes, text.strip()] if item
+            safely_set_text(
+                note, "\n".join(item for item in [current_notes, text.strip()] if item)
             )
         else:
-            note.text = text.strip()
+            safely_set_text(note, text.strip())
 
     def getnotes(self, origin=None):
         # TODO: consider only responding when origin has certain values
@@ -494,10 +495,10 @@ class tsfile(lisa.LISAfile):
             self.document.getroot(), self.namespaced(self.bodyNode)
         )
         name = etree.SubElement(context, self.namespaced("name"))
-        name.text = contextname
+        safely_set_text(name, contextname)
         if comment:
             comment_node = etree.SubElement(context, "comment")
-            comment_node.text = comment
+            safely_set_text(comment_node, comment)
         return context
 
     def _getcontextname(self, contextnode):


### PR DESCRIPTION
This consolidates behavior for all lxml based formats to strip characters which would be rejected by lxml.

The previous behavior was:

- TMX stripped some of these since #4219 (issue #4183)
- XLIFF double escaped these as XML entities what is non-standard and not handled by any other XLIFF tools (introduced by #3551 and #3555)
- all other formats just crashed with ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters

This can be a breaking change in case somebody relied on the present handling of control characters in XLIFF in translate-toolkit.

Fixes #3561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to ensure only valid characters are present in XML elements, enhancing data integrity and safety.

- **Bug Fixes**
	- Simplified control character handling in tests to improve reliability and maintainability.
	- Updated various storage modules to use a safer method for setting text, preventing potential data corruption due to invalid characters.

- **Refactor**
	- Centralized character validation logic to reduce redundancy and improve code quality across different modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->