### PR TITLE
properties: fix mozila properties encoding space

### DIFF
--- a/tests/translate/convert/test_po2prop.py
+++ b/tests/translate/convert/test_po2prop.py
@@ -194,7 +194,7 @@ msgstr "م"
         proptemplate = """accesskey-accept=
 accesskey-help=H
 """
-        propexpected = """accesskey-accept=
+        propexpected = r"""accesskey-accept=\u0020
 accesskey-help=م
 """
         propfile = self.merge2prop(proptemplate, posource, personality="mozilla")

--- a/tests/translate/misc/test_quote.py
+++ b/tests/translate/misc/test_quote.py
@@ -127,10 +127,10 @@ class TestEncoding:
 
     @staticmethod
     def test_mozillaescapemarginspaces():
-        assert quote.mozillaescapemarginspaces(" ") == ""
+        assert quote.mozillaescapemarginspaces(" ") == r"\u0020"
         assert quote.mozillaescapemarginspaces("A") == "A"
-        assert quote.mozillaescapemarginspaces(" abc ") == "\\u0020abc\\u0020"
-        assert quote.mozillaescapemarginspaces("  abc ") == "\\u0020 abc\\u0020"
+        assert quote.mozillaescapemarginspaces(" abc ") == r"\u0020abc\u0020"
+        assert quote.mozillaescapemarginspaces("  abc ") == r"\u0020 abc\u0020"
 
     @staticmethod
     def test_mozilla_control_escapes():

--- a/tests/translate/storage/test_properties.py
+++ b/tests/translate/storage/test_properties.py
@@ -356,6 +356,19 @@ class TestProp(test_monolingual.TestMonolingualStore):
         propregen = self.propregen(propsource)
         assert propsource + "\n" == propregen
 
+    def test_space(self):
+        r"""Check that we preserve \n that appear at start and end of properties."""
+        propsource = r"""space=\u0020
+endspace=,\u0020
+"""
+        store = self.propparse(propsource, personality="mozilla")
+        assert len(store.units) == 2
+        assert store.units[0].source == " "
+        assert store.units[1].source == ", "
+        store.units[0].source = " "
+        store.units[1].source = ", "
+        assert bytes(store).decode("utf-8") == propsource
+
     def test_whitespace_handling(self):
         """Check that we remove extra whitespace around property."""
         whitespaces = (

--- a/translate/misc/quote.py
+++ b/translate/misc/quote.py
@@ -404,13 +404,6 @@ def mozillaescapemarginspaces(source: str) -> str:
     """Escape leading and trailing spaces for Mozilla .properties files."""
     if not source:
         return ""
-
-    if len(source) == 1 and source.isspace():
-        # FIXME: This is hack for people using white-space to mark empty
-        # Mozilla strings translated, drop this once we have better way to
-        # handle this in Pootle.
-        return ""
-
     if len(source) == 1:
         return escapespace(source)
     return escapespace(source[0]) + source[1:-1] + escapespace(source[-1])


### PR DESCRIPTION
This ancient workaround for Pootle is no longer needed.

Fixes #3232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Bug Fixes**
	- Improved handling of spaces and commas in properties to preserve `\n` at the start and end.
- **Refactor**
	- Simplified processing of single-character strings in translation functions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->