### PR TITLE
Faster and more concise way of adding headers

### DIFF
--- a/translate/storage/poheader.py
+++ b/translate/storage/poheader.py
@@ -460,10 +460,6 @@ class poheader:
         headerpo._store = self
         headerpo.markfuzzy()
         headeritems = self.makeheaderdict(**kwargs)
-        headervalue = ""
-        for key, value in headeritems.items():
-            if value is None:
-                continue
-            headervalue += f"{key}: {value}\n"
+        headervalue = "\n".join([f"{key}: {value}" for key, value in headeritems.items() if value is not None])
         headerpo.target = headervalue
         return headerpo

--- a/translate/storage/poheader.py
+++ b/translate/storage/poheader.py
@@ -460,6 +460,6 @@ class poheader:
         headerpo._store = self
         headerpo.markfuzzy()
         headeritems = self.makeheaderdict(**kwargs)
-        headervalue = "\n".join([f"{key}: {value}" for key, value in headeritems.items() if value is not None])
+        headervalue = "".join([f"{key}: {value}\n" for key, value in headeritems.items() if value is not None])
         headerpo.target = headervalue
         return headerpo


### PR DESCRIPTION
Using `join` is usually faster than `+=` for strings.
During a dynamic analysis, it became evident that for some tests, many concatenations happen here, which the new implementation would handle them faster. It is also more concise, with the same readability.
I used the following code to compare the two:
```python
import random
import string
import time

def random_string(length):
    return ''.join(random.choice(string.ascii_letters) for i in range(length))

def random_dict(size):
    return {random_string(10): random_string(10) for i in range(size)}

def main():
    d = random_dict(10000)
    res = ""
    start_time = time.time()
    for key, value in d.items():
        if value is None:
            continue
        res += f"{key}: {value}\n"
    t1 = time.time() - start_time
    res = ""
    start_time = time.time()
    res = "\n".join([f"{key}: {value}" for key, value in d.items() if value is not None])
    t2 = time.time() - start_time
    print(f"Diff = {t2 - t1}")

if __name__ == "__main__":
    for _ in range(10):
        main()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the implementation of header value construction for enhanced performance and readability.
	- Concealed internal details of the code changes for confidentiality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->