### PR TITLE
pypo: fixed DOS newline handling in getnotes()

### DIFF
--- a/tests/translate/storage/test_pypo.py
+++ b/tests/translate/storage/test_pypo.py
@@ -466,11 +466,14 @@ msgstr[1] "toetse"
 
     def test_dos_newlines(self):
         """Checks that dos newlines are properly parsed."""
-        posource = b'#: File1\r\n#: File2\r\nmsgid "test me"\r\nmsgstr ""\r\n'
+        posource = (
+            b'# Note!\r\n#: File1\r\n#: File2\r\nmsgid "test me"\r\nmsgstr ""\r\n'
+        )
         pofile = self.poparse(posource)
         assert len(pofile.units) == 1
         assert pofile.units[0].source == "test me"
         assert pofile.units[0].getlocations() == ["File1", "File2"]
+        assert pofile.units[0].getnotes() == "Note!"
         assert bytes(pofile) == posource
 
     def test_mac_newlines(self):

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -30,6 +30,7 @@ import logging
 import re
 import textwrap
 import unicodedata
+from itertools import chain
 
 from translate.misc import quote
 from translate.misc.multistring import multistring
@@ -460,33 +461,25 @@ class pounit(pocommon.pounit):
             return [unit]
         return []
 
-    def getnotes(self, origin=None):
+    def getnotes(self, origin: str | None = None) -> str:
         """
         Return comments based on origin value.
 
         :param origin: programmer, developer, source code, translator or None
         """
-        if origin is None:
-            comments = "".join(
-                comment[2:] or self.newline for comment in self.othercomments
-            )
-            comments += "".join(
-                comment[3:] or self.newline for comment in self.automaticcomments
-            )
-        elif origin == "translator":
-            comments = "".join(
-                comment[2:] or self.newline for comment in self.othercomments
-            )
-        elif origin in ["programmer", "developer", "source code"]:
-            comments = "".join(
-                comment[3:] or self.newline for comment in self.automaticcomments
-            )
-        else:
+        parts = []
+        newline = self.newline
+        if origin == "translator" or origin is None:
+            parts.append(comment[2:] or newline for comment in self.othercomments)
+        if origin in ["programmer", "developer", "source code", None]:
+            parts.append(comment[3:] or newline for comment in self.automaticcomments)
+        if not parts:
             raise ValueError("Comment type not valid")
+        comments = "".join(chain.from_iterable(parts))
         # Let's drop the last newline
-        return comments[:-1]
+        return comments[: -len(newline)]
 
-    def addnote(self, text, origin=None, position="append"):
+    def addnote(self, text: str, origin: str | None = None, position: str = "append"):
         """
         This is modeled on the XLIFF method.
 


### PR DESCRIPTION
- strip actual length of the newline instead of hardcoding one character
- avoid duplicite generating of comments from different scopes
- avoid string concatenation