### PR TITLE
doc: add context to csv2po/po2csv CLI reference

### DIFF
--- a/docs/commands/csv2po.rst
+++ b/docs/commands/csv2po.rst
@@ -48,7 +48,7 @@ Options (csv2po):
 -S, --timestamp       skip conversion if the output file has newer timestamp
 -P, --pot             output PO Templates (.pot) rather than PO files (.po)
 --charset=CHARSET     set charset to decode from csv files
---columnorder=COLUMNORDER   specify the order and position of columns (location,source,target)
+--columnorder=COLUMNORDER   specify the order and position of columns (location,source,target,context)
 --duplicates=DUPLICATESTYLE
                       what to do with duplicate strings (identical source
                       text): :doc:`merge, msgctxt <option_duplicates>`
@@ -68,7 +68,7 @@ Options (po2csv):
 -x EXCLUDE, --exclude=EXCLUDE   exclude names matching EXCLUDE from input paths
 -o OUTPUT, --output=OUTPUT   write to OUTPUT in csv format
 -S, --timestamp       skip conversion if the output file has newer timestamp
---columnorder=COLUMNORDER    specify the order and position of columns (location,source,target)
+--columnorder=COLUMNORDER    specify the order and position of columns (location,source,target,context)
 
 
 .. _csv2po#csv_file_layout:

--- a/translate/convert/csv2po.py
+++ b/translate/convert/csv2po.py
@@ -285,7 +285,7 @@ def main(argv=None):
         callback=columnorder_callback,
         type="str",
         default=None,
-        help="specify the order and position of columns (location,source,target)",
+        help="specify the order and position of columns (location,source,target,context)",
     )
     parser.add_duplicates_option()
     parser.passthrough.append("charset")

--- a/translate/convert/po2csv.py
+++ b/translate/convert/po2csv.py
@@ -103,7 +103,7 @@ def main(argv=None):
         callback=columnorder_callback,
         type="str",
         default=None,
-        help="specify the order and position of columns (location,source,target)",
+        help="specify the order and position of columns (location,source,target,context)",
     )
     parser.passthrough.append("columnorder")
     parser.run(argv)


### PR DESCRIPTION
While context ("msgctxt") parsing was supported for `csv2po`/`po2csv`, it wasn't mentioned in the command line documentation.