### PR TITLE
po: improve rewrapping when adding unit

### DIFF
--- a/tests/translate/storage/test_pypo.py
+++ b/tests/translate/storage/test_pypo.py
@@ -1,3 +1,4 @@
+from copy import copy
 from io import BytesIO
 
 from pytest import mark, raises
@@ -670,6 +671,31 @@ msgstr ""\r
 
         outstore = self.StoreClass()
         outstore.wrapper.width = -1
-        outstore.addunit(store.units[0])
+        unit = copy(store.units[0])
+        outstore.addunit(unit)
 
         assert max(len(line) for line in bytes(outstore).decode().splitlines()) > 77
+
+        outstore = self.StoreClass()
+        outstore.wrapper.width = -1
+        unit = copy(store.units[0])
+        unit.wrapper = None
+        outstore.addunit(unit)
+
+        assert max(len(line) for line in bytes(outstore).decode().splitlines()) > 77
+
+        outstore = self.StoreClass()
+        outstore.wrapper = None
+        unit = copy(store.units[0])
+        unit.wrapper = None
+        outstore.addunit(unit)
+
+        assert max(len(line) for line in bytes(outstore).decode().splitlines()) <= 77
+
+        outstore = self.StoreClass()
+        outstore.wrapper = None
+        unit = copy(store.units[0])
+        unit.wrapper.width = -1
+        outstore.addunit(unit)
+
+        assert max(len(line) for line in bytes(outstore).decode().splitlines()) <= 77

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -162,6 +162,11 @@ class PoWrapper(textwrap.TextWrapper):
             break_long_words=True,
         )
 
+    def __eq__(self, other):
+        if not isinstance(other, PoWrapper):
+            return False
+        return self.width == other.width
+
     def _handle_long_word(
         self, reversed_chunks: list[str], cur_line: list[str], cur_len: int, width: int
     ):
@@ -1034,9 +1039,7 @@ class pofile(pocommon.pofile):
                 yield unit
 
     def addunit(self, unit):
-        needs_update = (
-            unit.wrapper and self.wrapper and (unit.wrapper.width != self.wrapper.width)
-        )
+        needs_update = unit.wrapper != self.wrapper
         unit.wrapper = self.wrapper
         super().addunit(unit)
         if needs_update:


### PR DESCRIPTION
New instance can have wrapper None, so this case should be handled as needed rewrapping.