### PR TITLE
Fix added spaces in XWikiPageProperties format XML output

### DIFF
--- a/tests/translate/storage/test_properties.py
+++ b/tests/translate/storage/test_properties.py
@@ -932,7 +932,7 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
     <language>%(language)s</language>
     <title/>
     <content>%(content)s</content>
-    </xwikidoc>"""
+</xwikidoc>"""
     )
 
     def getcontent(self, content, language="en"):
@@ -1152,7 +1152,7 @@ class TestXWikiPageProperties(test_monolingual.TestMonolingualStore):
             <content># Users Section
 test_me=Je peux coder !
 </content>
-            </xwikidoc>"""
+</xwikidoc>"""
         )
         assert (
             generatedcontent.getvalue().decode(propfile.encoding) == expected_xml + "\n"

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -1356,7 +1356,7 @@ class XWikiPageProperties(xwikifile):
         if not self.is_source_file():
             self.set_xwiki_xml_attributes(newroot)
             # We only want a single line break before the closing node.
-            newroot.find("content").tail = '\n'
+            newroot.find("content").tail = "\n"
         self.write_xwiki_xml(newroot, out)
 
 

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -1355,6 +1355,8 @@ class XWikiPageProperties(xwikifile):
         # if we are editing the source file we should not modify it.
         if not self.is_source_file():
             self.set_xwiki_xml_attributes(newroot)
+            # We only want a single line break before the closing node.
+            newroot.find("content").tail = '\n'
         self.write_xwiki_xml(newroot, out)
 
 


### PR DESCRIPTION
  * Ensure to clean up node after performing operation on the XML
  * Fix existing tests

See: https://github.com/WeblateOrg/weblate/issues/11896