### PR TITLE
fix(pypo): use wcwidth for calculating unicode string width

### DIFF
--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -1,2 +1,4 @@
 # lxml - for XML processing (XLIFF, TMX, TBX, ts, Android)
 lxml>=4.6.3
+# wcwidth for unicode width
+wcwidth>=0.2.10

--- a/tests/translate/storage/test_po.py
+++ b/tests/translate/storage/test_po.py
@@ -1049,7 +1049,6 @@ msgstr ""
 """
         assert self.poreflow(posource) == posource
 
-    @mark.xfail(reason="Incompatible wrapping with gettext, see #5251")
     def test_wrap_emoji(self):
         posource = r"""msgid ""
 msgstr "Content-Type: text/plain; charset=utf-8\n"


### PR DESCRIPTION
This covers more use-cases than simple builtin cjklen which focused on CJK letters only.

Issue #5251