### PR TITLE
fix(yaml): avoid crash on invalid Ruby YAML files

### DIFF
--- a/tests/translate/storage/test_yaml.py
+++ b/tests/translate/storage/test_yaml.py
@@ -520,6 +520,13 @@ class TestRubyYAMLResourceStore(test_monolingual.TestMonolingualStore):
         store.parse(data)
         assert bytes(store) == data.encode("ascii")
 
+    def test_ruby_wrong(self):
+        data = """no_data: No data
+"""
+        store = self.StoreClass()
+        store.parse(data)
+        assert bytes(store) == data.encode("ascii")
+
     def test_invalid_value(self):
         store = yaml.YAMLFile()
         with pytest.raises(base.ParseError):

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -202,10 +202,13 @@ class RubyYAMLFile(YAMLFile):
     def preprocess(self, data):
         if isinstance(data, CommentedMap) and len(data) == 1:
             lang = next(iter(data.keys()))
-            self.settargetlanguage(lang)
+            # Handle blank values
             if data[lang] is None:
                 data[lang] = CommentedMap()
-            return data[lang]
+            # Do not try to parse string only, CommentedMap is dict as well
+            if isinstance(data[lang], dict):
+                self.settargetlanguage(lang)
+                return data[lang]
         return data
 
     def get_root_node(self):


### PR DESCRIPTION
When the element is not a dictionary, this is not something we can gracefully parse.