### PR TITLE
fix(aresource): avoid using tail when extracting inner markup

### DIFF
--- a/tests/translate/storage/test_aresource.py
+++ b/tests/translate/storage/test_aresource.py
@@ -914,6 +914,18 @@ files</strong> on the storage.</p>
             == "<i>{app_name}</i> צרכה רשות לגשת ליומן שלך, על מנת ליצור תוכניות עבור עסקאות עתידיות חוזרות."
         )
 
+    def test_tail(self):
+        content = """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="one"><b>One</b></string>in
+    <string name="two"><b>Two</b></string>
+</resources>"""
+        store = self.StoreClass()
+        store.parse(content.encode())
+        assert len(store.units) == 2
+        assert store.units[0].target == "<b>One</b>"
+        assert store.units[1].target == "<b>Two</b>"
+
 
 class TestMOKOResourceUnit(test_monolingual.TestMonolingualUnit):
     UnitClass = aresource.MOKOResourceUnit

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -367,8 +367,10 @@ class AndroidResourceUnit(base.TranslationUnit):
         if len(xmltarget) == 0:
             # There are no html markups, so unescaping it as plain text.
             return self.unescape(xmltarget.text)
+        parser = DecodingXMLParser(
+            etree.tostring(xmltarget, encoding="unicode", with_tail=False)
+        )
 
-        parser = DecodingXMLParser(etree.tostring(xmltarget, encoding="unicode"))
         return parser.parse()
 
     def set_xml_text_plain(self, target, xmltarget):


### PR DESCRIPTION
The tail can make the processing invalid and we do not need it.