### PR TITLE
fix(storage): return usable value from __hash__

### DIFF
--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -146,7 +146,7 @@ class TranslationUnit:
         return not self.__eq__(other)
 
     def __hash__(self):
-        return None
+        return hash((self.source, self.target, self.getid()))
 
     def __str__(self):
         """Converts to a string representation. Most often overriden by subclasses."""


### PR DESCRIPTION
Returning None here is invalid, this makes it compliant what __eq__ does.