### PR TITLE
docs: modernize documentation build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-- package-ecosystem: gitsubmodule
-  directory: /
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
     - name: Setup Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -19,8 +19,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/_themes"]
-	path = docs/_themes
-	url = https://github.com/translate/sphinx-themes.git

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,12 +15,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: '3.11'
+  apt_packages:
+  - libgettextpo-dev
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:
   - requirements: requirements/dev.txt
-
-# submodules for doc theme
-submodules:
-  include: all

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-# Needs manual listing until setuptools_scm support submodules
-# See https://github.com/pypa/setuptools_scm/issues/206
-include docs/_themes/README.rst
-include docs/_themes/sphinx-bootstrap/*.html
-include docs/_themes/sphinx-bootstrap/theme.conf
-recursive-include docs/_themes/sphinx-bootstrap/static/ *.*

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,8 @@ build: docs
 	python -m build
 
 docs:
-	# Make sure that the submodule with docs theme is pulled and up-to-date.
-	git submodule update --init
 	# The following creates the HTML docs.
-	# NOTE: cd and make must be in the same line.
-	cd ${DOCS_DIR}; make SPHINXOPTS="-T -W -q" html ${TAIL}
+	make -C ${DOCS_DIR} SPHINXOPTS="-T -W -q" html ${TAIL}
 
 docs-review: docs
 	python -mwebbrowser file://$(shell pwd)/${DOCS_DIR}/_build/html/index.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 
 project = "Translate Toolkit"
-copyright = "2002-2023, Translate"
+copyright = "Translate Toolkit authors"
 
 # The short X.Y version.
 version = "3.13.3"
@@ -40,6 +40,8 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
+    "sphinx_copybutton",
+    "sphinxext.opengraph",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -49,6 +51,11 @@ templates_path = ["_templates"]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "_themes/README.rst", "releases/README.rst"]
+
+ogp_social_cards = {
+    "line_color": "#144d3f",
+    "site_url": "docs.translatehouse.org",
+}
 
 # The master toctree document.
 master_doc = "index"
@@ -71,7 +78,16 @@ autodoc_mock_imports = [
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx-bootstrap"
+html_theme = "furo"
+
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -80,13 +96,16 @@ html_theme_options = {
     "nosidebar": True,
 }
 
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = ["_themes"]
-
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+html_theme_options = {
+    "source_repository": "https://github.com/translate/translate/",
+    "source_branch": "main",
+    "source_directory": "docs/",
+}
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "TranslateToolkitdoc"
@@ -197,12 +216,12 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "pytest": ("https://docs.pytest.org/en/latest/", None),
     "django": (
-        "https://docs.djangoproject.com/en/stable/",
-        "https://docs.djangoproject.com/en/stable/_objects/",
+        "https://docs.djangoproject.com/en/stable",
+        "https://docs.djangoproject.com/en/stable/_objects",
     ),
-    "pootle": ("https://docs.translatehouse.org/projects/pootle/en/latest/", None),
+    "pootle": ("https://docs.translatehouse.org/projects/pootle/en/latest", None),
     "guide": (
-        "https://docs.translatehouse.org/projects/localization-guide/en/latest/",
+        "https://docs.translatehouse.org/projects/localization-guide/en/latest",
         None,
     ),
 }

--- a/requirements/dist.txt
+++ b/requirements/dist.txt
@@ -1,7 +1,7 @@
+-r docs.txt
 build==1.2.1
 pip==24.2
 setuptools==74.1.2
 setuptools-scm==8.1.0
-Sphinx==8.0.2
 twine==5.1.1
 virtualenv==20.26.3

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,0 +1,5 @@
+furo==2024.8.6
+matplotlib==3.9.2
+Sphinx==8.0.2
+sphinx-copybutton==0.5.2
+sphinxext-opengraph==0.9.1


### PR DESCRIPTION
- switch to Furo theme instead of using own one (fixes #5336)
- add copy button to code samples
- add opengraph previews to all pages
- update for upcoming readthedocs.org changes (see https://about.readthedocs.com/blog/2024/07/addons-by-default/)
- dropped all submodule logic as the only submodule is now gone
- avoid redirects in intersphinx caused by trailing slash
- use separate requirements for docs
- add libgettext to doc build for cpo docs
