### PR TITLE
Add translateable marking to units

### DIFF
--- a/tests/translate/storage/test_aresource.py
+++ b/tests/translate/storage/test_aresource.py
@@ -938,17 +938,17 @@ files</strong> on the storage.</p>
 </resources>"""
         store = self.StoreClass()
         store.parse(data.encode())
-        store.units[1].marktranslateable("false")
+        store.units[1].marktranslatable(False)
         assert store.units[1].getid() == "test2"
         assert not store.units[1].istranslatable()
-        store.units[1].marktranslateable("true")
+        store.units[1].marktranslatable(True)
         assert store.units[1].istranslatable()
 
-        store.units[2].marktranslateable("true")
+        store.units[2].marktranslatable(True)
         assert store.units[2].getid() == "test3"
         assert store.units[2].istranslatable()
 
-        store.units[0].marktranslateable("false")
+        store.units[0].marktranslatable(False)
         assert store.units[0].getid() == "test1"
         assert not store.units[0].istranslatable()
 

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -178,8 +178,8 @@ class AndroidResourceUnit(base.TranslationUnit):
     def istranslatable(self):
         return bool(self.getid()) and self.xmlelement.get("translatable") != "false"
 
-    def marktranslateable(self, value):
-        return self.xmlelement.set("translatable", value)
+    def marktranslatable(self, value: bool) -> None:
+        return self.xmlelement.set("translatable", "true" if value else "false")
 
     def isblank(self):
         return not bool(self.getid())

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -408,7 +408,7 @@ class TranslationUnit:
         """
         return bool(self.source)
 
-    def marktranslateable(self, value):
+    def marktranslatable(self, value: bool) -> None:
         """Marks the unit as translateable or not."""
 
     @staticmethod


### PR DESCRIPTION
## Proposed changes

This adds a `marktranslateable` function to the `TranslationUnit` and `AndroidResourceUnit` to enable the translateable marking to units.