### PR TITLE
chore(docs): mock Levenshtein import

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,6 +76,7 @@ autodoc_mock_imports = [
     "phply",
     "ruamel",
     "cheroot",
+    "Levenshtein",
 ]
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
This avoids unnecessary warning.