### PR TITLE
fix(docs): bring back libgettextpo0 to readthedocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install apt dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgettextpo0
+        sudo apt-get install -y libgettextpo-dev
     - name: Install dependencies
       run: uv pip install --system -r requirements/docs.txt
     - name: Build docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,13 +11,10 @@ formats: all
 build:
   os: ubuntu-22.04
   tools:
-    python: '3.11'
+    python: '3.12'
   apt_packages:
   - libgettextpo0
-  commands:
-  - asdf plugin add uv
-  - asdf install uv latest
-  - asdf global uv latest
-  - uv venv
-  - uv pip install -r ./requirements/docs.txt
-  - .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+
+python:
+  install:
+  - requirements: requirements/docs.txt


### PR DESCRIPTION
Apparently apt_packages is not applied when using commands.