### PR TITLE
chore(lint): use ruff github formatter only at GitHub

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,3 +24,6 @@ jobs:
       run: uv pip install --system -r requirements/lint.txt
     - name: pre-commit
       run: pre-commit run --all
+      env:
+        RUFF_OUTPUT_FORMAT: github
+        REUSE_OUTPUT_FORMAT: github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ known_third_party = [
 profile = "black"
 
 [tool.ruff]
-output-format = "github"
 target-version = "py38"
 
 [tool.ruff.lint]


### PR DESCRIPTION
This makes it much more friendly for an user.