### PR TITLE
chore: annotate print() usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ ignore = [
   "RUF001",  # WONTFIX: String contains ambiguous unicode character, we are using Unicode
   "RUF002",  # WONTFIX: Docstring contains ambiguous
   "RUF003",  # WONTFIX: Comment contains ambiguous
-  "T201",  # TODO: `print` found
   "A001",  # TODO: Variable is shadowing a Python builtin
   "A002",  # TODO: overriding builtins (might need noqa tags)
   "A003",  # TODO: Class attribute `map` is shadowing a Python builtin
@@ -126,3 +125,10 @@ ignore = [
   "PTH"  # TODO: Not using pathlib for now
 ]
 select = ["ALL"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**.py" = ["T201"]
+"translate/misc/progressbar.py" = ["T201"]
+"translate/storage/benchmark.py" = ["T201"]
+"translate/storage/placeables/strelem.py" = ["T201"]
+"translate/tools/**.py" = ["T201"]

--- a/translate/convert/ini2po.py
+++ b/translate/convert/ini2po.py
@@ -47,7 +47,7 @@ class ini2po:
     ):
         """Initialize the converter."""
         if ini.INIConfig is None:
-            print("Missing iniparse library!")
+            print("Missing iniparse library!")  # noqa: T201
             sys.exit()
 
         self.blank_msgstr = blank_msgstr

--- a/translate/convert/odf2xliff.py
+++ b/translate/convert/odf2xliff.py
@@ -23,6 +23,7 @@ See: http://docs.translatehouse.org/projects/translate-toolkit/en/latest/command
 for examples and usage instructions.
 """
 
+import sys
 from io import BytesIO
 
 from translate.convert import convert
@@ -39,7 +40,8 @@ def convertodf(inputfile, outputfile, templates):
     try:
         store.setfilename(store.getfilenode("NoName"), inputfile.name)
     except Exception:
-        print("couldn't set origin filename")
+        print("couldn't set origin filename")  # noqa: T201
+        sys.exit()
 
     contents = open_odf(inputfile)
     for data in contents.values():

--- a/translate/convert/po2ini.py
+++ b/translate/convert/po2ini.py
@@ -48,7 +48,7 @@ class po2ini:
     ):
         """Initialize the converter."""
         if ini.INIConfig is None:
-            print("Missing iniparse library!")
+            print("Missing iniparse library!")  # noqa: T201
             sys.exit()
 
         if template_file is None:

--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -2863,6 +2863,7 @@ class StandardUnitChecker(UnitChecker):
         return not bool(suggestions)
 
 
+# TODO: convert these to proper unit tests
 def runtests(str1, str2, ignorelist=()):
     """Verifies that the tests pass for a pair of strings."""
     from translate.storage import base
@@ -2875,7 +2876,7 @@ def runtests(str1, str2, ignorelist=()):
     failures = checker.run_filters(unit)
 
     for test in failures:
-        print(
+        print(  # noqa: T201
             "failure: {}: {}\n  {!r}\n  {!r}".format(
                 test, failures[test]["message"], str1, str2
             )
@@ -2892,7 +2893,7 @@ def batchruntests(pairs):
         if runtests(str1, str2):
             passed += 1
 
-    print("\ntotal: %d/%d pairs passed" % (passed, numpairs))
+    print("\ntotal: %d/%d pairs passed" % (passed, numpairs))  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/translate/filters/pofilter.py
+++ b/translate/filters/pofilter.py
@@ -168,7 +168,7 @@ class FilterOptionParser(optrecurse.RecursiveOptionParser):
             self.error("No valid filters were specified")
 
         if options.listfilters:
-            print(options.checkfilter.getfilterdocs())
+            print(options.checkfilter.getfilterdocs())  # noqa: T201
         else:
             self.recursiveprocess(options)
 

--- a/translate/lang/identify.py
+++ b/translate/lang/identify.py
@@ -141,4 +141,4 @@ if __name__ == "__main__":
     identifier = LanguageIdentifier()
     with open(argv[1]) as fh:
         text = fh.read()
-    print("Language detected:", identifier.identify_lang(text))
+    print("Language detected:", identifier.identify_lang(text))  # noqa: T201

--- a/translate/lang/ngram.py
+++ b/translate/lang/ngram.py
@@ -168,4 +168,4 @@ if __name__ == "__main__":
     from translate.misc.file_discovery import get_abs_data_filename
 
     lm = NGram(get_abs_data_filename("langmodels"))
-    print(lm.classify(text))
+    print(lm.classify(text))  # noqa: T201

--- a/translate/lang/team.py
+++ b/translate/lang/team.py
@@ -781,4 +781,4 @@ if __name__ == "__main__":
 
     for fname in argv[1:]:
         store = factory.getobject(fname)
-        print(fname, guess_language(store.parseheader().get("Language-Team", "")))
+        print(fname, guess_language(store.parseheader().get("Language-Team", "")))  # noqa: T201

--- a/translate/search/lshtein.py
+++ b/translate/search/lshtein.py
@@ -170,4 +170,4 @@ if __name__ == "__main__":
     from sys import argv
 
     comparer = LevenshteinComparer()
-    print(f"Similarity:\n{comparer.similarity(argv[1], argv[2], 50)}")
+    print(f"Similarity:\n{comparer.similarity(argv[1], argv[2], 50)}")  # noqa: T201

--- a/translate/storage/mo.py
+++ b/translate/storage/mo.py
@@ -54,7 +54,7 @@ def mounpack(filename="messages.mo"):
     """Helper to unpack Gettext MO files into a Python string."""
     with open(filename, "rb") as fh:
         s = fh.read()
-        print("\\x%02x" * len(s) % tuple(map(ord, s)))
+        return "\\x%02x" * len(s) % tuple(map(ord, s))
 
 
 def my_swap4(result):

--- a/translate/storage/qm.py
+++ b/translate/storage/qm.py
@@ -73,7 +73,7 @@ def qmunpack(file_="messages.qm"):
     """Helper to unpack Qt .qm files into a Python string."""
     with open(file_, "rb") as fh:
         s = fh.read()
-        print("\\x%02x" * len(s) % tuple(map(ord, s)))
+        return "\\x%02x" * len(s) % tuple(map(ord, s))
 
 
 class qmunit(base.TranslationUnit):
@@ -118,7 +118,7 @@ class qmfile(base.TranslationStore):
         sectionheader = 5
 
         def section_debug(name, section_type, startsection, length):
-            print(
+            print(  # noqa: T201
                 "Section: %s (type: %#x, offset: %#x, length: %d)"
                 % (name, section_type, startsection, length)
             )


### PR DESCRIPTION
- turn on ruff T201 rule to make sure no print() is used in storage code
- annotate valid print() usage
- turn some print usage into return (these are unused functions)