### PR TITLE
chore: improve multistring implementation

### DIFF
--- a/tests/translate/misc/test_multistring.py
+++ b/tests/translate/misc/test_multistring.py
@@ -1,95 +1,95 @@
 import pytest
 
-from translate.misc import multistring
+from translate.misc.multistring import multistring
 
 
 class TestMultistring:
     def test_constructor(self):
-        t = multistring.multistring
-        s1 = t("test")
-        assert type(s1) is t
+        s1 = multistring("test")
+        assert type(s1) is multistring
         assert s1 == "test"
         assert s1.strings == ["test"]
-        s2 = t(["test", "mé"])
-        assert type(s2) is t
+        s2 = multistring(["test", "mé"])
+        assert type(s2) is multistring
         assert s2 == "test"
         assert s2.strings == ["test", "mé"]
         assert s2 != s1
+
+    def test_constructor_validation(self):
         with pytest.raises(ValueError):
-            t([])
+            multistring([])
+        with pytest.raises(TypeError):
+            multistring([1])
+        with pytest.raises(TypeError):
+            multistring(["one", None])
 
     def test_repr(self):
-        t = multistring.multistring
-        s1 = t("test")
+        s1 = multistring("test")
         assert repr(s1) == "multistring(['test'])"
-        assert eval(f"multistring.{s1!r}") == s1
+        assert eval(f"{s1!r}") == s1
 
-        s2 = t(["test", "mé"])
+        s2 = multistring(["test", "mé"])
         assert repr(s2) == "multistring(['test', 'mé'])"
-        assert eval(f"multistring.{s2!r}") == s2
+        assert eval(f"{s2!r}") == s2
 
     def test_replace(self):
-        t = multistring.multistring
-        s1 = t(["abcdef", "def"])
+        s1 = multistring(["abcdef", "def"])
 
         result = s1.replace("e", "")
-        assert type(result) is t
-        assert result == t(["abcdf", "df"])
+        assert type(result) is multistring
+        assert result == multistring(["abcdf", "df"])
 
         result = s1.replace("e", "xx")
-        assert result == t(["abcdxxf", "dxxf"])
+        assert result == multistring(["abcdxxf", "dxxf"])
 
         result = s1.replace("e", "\xe9")
-        assert result == t(["abcd\xe9f", "d\xe9f"])
+        assert result == multistring(["abcd\xe9f", "d\xe9f"])
 
         result = s1.replace("e", "\n")
-        assert result == t(["abcd\nf", "d\nf"])
+        assert result == multistring(["abcd\nf", "d\nf"])
 
         result = result.replace("\n", "\\n")
-        assert result == t(["abcd\\nf", "d\\nf"])
+        assert result == multistring(["abcd\\nf", "d\\nf"])
 
         result = result.replace("\\n", "\n")
-        assert result == t(["abcd\nf", "d\nf"])
+        assert result == multistring(["abcd\nf", "d\nf"])
 
-        s2 = t(["abcdeef", "deef"])
+        s2 = multistring(["abcdeef", "deef"])
 
         result = s2.replace("e", "g")
-        assert result == t(["abcdggf", "dggf"])
+        assert result == multistring(["abcdggf", "dggf"])
 
         result = s2.replace("e", "g", 1)
-        assert result == t(["abcdgef", "dgef"])
+        assert result == multistring(["abcdgef", "dgef"])
 
     def test_comparison(self):
-        t = multistring.multistring
-        assert t("test") == "test"
-        assert t("test").__cmp__("test") == 0
+        assert multistring("test") == "test"
+        assert multistring("test") == multistring("test")
 
-        assert t("téßt") > "test"
-        assert t("téßt") > "test"
-        assert t("téßt").__cmp__("test") > 0
+        assert multistring("téßt") > "test"
+        assert multistring("téßt") > multistring("test")
+
+        assert multistring("téßt") > "test"
+        assert multistring("test") < multistring("téßt")
 
     def test_coercion(self):
-        t = multistring.multistring
-        assert str(t("test")) == "test"
-        assert str(t("téßt")) == "téßt"
+        assert str(multistring("test")) == "test"
+        assert str(multistring("téßt")) == "téßt"
 
     def test_unicode_coercion(self):
-        t = multistring.multistring
-        assert str(t("test")) == "test"
-        assert str(t("test")) == "test"
-        assert str(t("téßt")) == "téßt"
-        assert str(t("téßt")) == "téßt"
-        assert str(t(["téßt", "blāh"])) == "téßt"
-        assert str(t(["téßt"])) == "téßt"
+        assert str(multistring("test")) == "test"
+        assert str(multistring("test")) == "test"
+        assert str(multistring("téßt")) == "téßt"
+        assert str(multistring("téßt")) == "téßt"
+        assert str(multistring(["téßt", "blāh"])) == "téßt"
+        assert str(multistring(["téßt"])) == "téßt"
 
     def test_list_coercion(self):
-        t = multistring.multistring
-        assert str([t("test")]) == "[multistring(['test'])]"
-        assert str([t("tést")]) == "[multistring(['tést'])]"
+        assert str([multistring("test")]) == "[multistring(['test'])]"
+        assert str([multistring("tést")]) == "[multistring(['tést'])]"
 
     def test_multistring_hash(self):
-        t = multistring.multistring
-        foo = t(["foo", "bar"])
+        foo = multistring(["foo", "bar"])
         foodict = {foo: "baz"}
         assert "foo" in foodict
         foodict2 = {"foo": "baz"}

--- a/tests/translate/storage/test_properties.py
+++ b/tests/translate/storage/test_properties.py
@@ -158,9 +158,9 @@ class TestGwtProp(test_monolingual.TestMonolingualStore):
         propunit = propfile.units[0]
         assert propunit.name == "test_me"
         assert propunit.source.strings == ["I can code single!", "I can code!"]
-        assert propunit.value == ["I can code!", "I can code single!"]
+        assert propunit.value == ["I can code!"]
         propunit.value = ["I can code double!", "I can code single!"]
-        assert propunit.value == ["I can code double!", "I can code single!"]
+        assert propunit.value == ["I can code double!"]
         assert propunit.source.strings == ["I can code single!", "I can code double!"]
         # propunit.value = ["I can code single!", "I can code!" ]
         # assert propunit.value == ["I can code single!", "I can code!"]

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -439,7 +439,7 @@ class pounit(pocommon.pounit):
                 pluralform = (
                     gpo_decode(gpo.po_message_msgid_plural(self._gpo_message)) or ""
                 )
-                multi.strings.append(pluralform)
+                multi.extra_strings.append(pluralform)
                 return multi
             return singular
         return ""

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -350,8 +350,8 @@ class I18NextUnit(JsonNestedUnit):
             super().storevalues(output)
         else:
             if len(self.target.strings) > len(self._store.plural_tags):
-                self.target.strings = self.target.strings[
-                    : len(self._store.plural_tags)
+                self.target.extra_strings = self.target.extra_strings[
+                    : len(self._store.plural_tags) - 1
                 ]
             self._fixup_item()
             for i, value in enumerate(self.target.strings):

--- a/translate/storage/qm.py
+++ b/translate/storage/qm.py
@@ -178,7 +178,7 @@ class qmfile(base.TranslationStore):
                     )
                     string, templen = codecs.utf_16_be_decode(raw)
                     if target:
-                        target.strings.append(string)
+                        target.extra_strings.append(string)
                     else:
                         target = multistring(string)
                     pos = pos + 4 + length


### PR DESCRIPTION
- do not implement __cmp__ which is no longer used in Python 3
- simplify some implementation details
- validate multistring strings when constructing
- remove confusing aliases from tests