### PR TITLE
fix(android): inject whole XML element to keep CDATA

### DIFF
--- a/tests/translate/storage/test_aresource.py
+++ b/tests/translate/storage/test_aresource.py
@@ -909,8 +909,7 @@ files</strong> on the storage.</p>
         assert store.units[0].target == body
         assert bytes(store).decode() == content
         store.units[0].target = body
-        # TODO: this fails for now:
-        # assert bytes(store).decode() == content
+        assert bytes(store).decode() == content
 
     def test_prefix(self):
         body = "&lt; <b>body</b>"


### PR DESCRIPTION
Avoid manually manipulating with inner XML elements when setting rich content. This allows to keep things like CDATA which are not exposed as childer in lxml.

Fixes #5374