### PR TITLE
fix(mo): fixed parsing

### DIFF
--- a/tests/translate/storage/test_mo.py
+++ b/tests/translate/storage/test_mo.py
@@ -539,3 +539,7 @@ class TestMOFile(test_base.TestTranslationStore):
             print(repr(mo_pocompile))
 
             assert mo_msgfmt == mo_pocompile
+
+            # Verify parsing of generated files
+            self.StoreClass.parsefile(MO_POCOMPILE)
+            self.StoreClass.parsefile(MO_MSGFMT)

--- a/translate/storage/mo.py
+++ b/translate/storage/mo.py
@@ -291,7 +291,7 @@ class mofile(poheader.poheader, base.TranslationStore):
                     b"charset=([^\\s]+)", input[voffset : voffset + vlength]
                 )
                 if charset:
-                    self.encoding = charset.group(1)
+                    self.encoding = charset.group(1).decode()
             source = multistring([s.decode(self.encoding) for s in source.split(b"\0")])
             target = multistring(
                 [


### PR DESCRIPTION
The #5392 uncovered a bug in charset parsing from MO file - it was never parsed before becase bytes were compared to string. Now we properly decode the charset so that it can be properly used.