### PR TITLE
Allow po2rc output encoding to be specified

### DIFF
--- a/tests/translate/convert/test_convert.py
+++ b/tests/translate/convert/test_convert.py
@@ -47,6 +47,7 @@ class TestConvertCommand:
         kwoptions = getattr(self, "defaultoptions", {}).copy()
         kwoptions.update(kwargs)
         for key, value in kwoptions.items():
+            key = key.replace("_", "-")
             if value is True:
                 argv.append(f"--{key}")
             else:

--- a/tests/translate/convert/test_po2rc.py
+++ b/tests/translate/convert/test_po2rc.py
@@ -77,6 +77,7 @@ class TestPO2RCCommand(test_convert.TestConvertCommand):
         "-t TEMPLATE, --template=TEMPLATE",
         "-l LANG, --lang=LANG",
         "--charset=CHARSET",
+        "--charset-output=CHARSET",
         "--sublang=SUBLANG",
         "--threshold=PERCENT",
         "--fuzzy",

--- a/tests/translate/convert/test_po2rc.py
+++ b/tests/translate/convert/test_po2rc.py
@@ -433,3 +433,15 @@ msgstr "Zkopirovano"
             rc_result = rcfile(handle)
         assert len(rc_result.units) == 1
         assert rc_result.units[0].target == "Zkopirovano"
+
+    def test_output_encoding(self):
+        self.create_testfile("simple.rc", RC_SOURCE)
+        self.create_testfile("simple.po", POFILE)
+
+        self.run_command(
+            template="simple.rc",
+            i="simple.po",
+            o="output.rc",
+            l="LANG_CZECH",
+            charset_output="utf-8",
+        )

--- a/translate/convert/po2rc.py
+++ b/translate/convert/po2rc.py
@@ -355,6 +355,7 @@ def convertrc(
     lang=None,
     sublang=None,
     outputthreshold=None,
+    output_charset=None,
 ):
     inputstore = po.pofile(inputfile)
 
@@ -367,11 +368,14 @@ def convertrc(
         raise ValueError("must have template file for rc files")
     convertor = rerc(templatefile, charset, lang, sublang)
     outputrclines = convertor.convertstore(inputstore, includefuzzy)
-    try:
-        outputfile.write(outputrclines.encode("cp1252"))
-    except UnicodeEncodeError:
-        outputfile.write(codecs.BOM_UTF16_LE)
-        outputfile.write(outputrclines.encode("utf-16-le"))
+    if output_charset == "auto":
+        try:
+            outputfile.write(outputrclines.encode("cp1252"))
+        except UnicodeEncodeError:
+            outputfile.write(codecs.BOM_UTF16_LE)
+            outputfile.write(outputrclines.encode("utf-16-le"))
+    else:
+        outputfile.write(outputrclines.encode(output_charset))
     outputfile.close()
     templatefile.close()
     return 1
@@ -389,7 +393,15 @@ def main(argv=None):
         "--charset",
         dest="charset",
         default=defaultcharset,
-        help=f"charset to use to decode the RC files (default: {defaultcharset})",
+        help=f"charset to use to decode the template RC files (default: {defaultcharset})",
+        metavar="CHARSET",
+    )
+    parser.add_option(
+        "",
+        "--charset-output",
+        dest="output_charset",
+        default="auto",
+        help="charset to use to encode the RC file (default: auto)",
         metavar="CHARSET",
     )
     parser.add_option(
@@ -405,6 +417,7 @@ def main(argv=None):
         metavar="SUBLANG",
     )
     parser.passthrough.append("charset")
+    parser.passthrough.append("output_charset")
     parser.passthrough.append("lang")
     parser.passthrough.append("sublang")
     parser.add_threshold_option()


### PR DESCRIPTION
Allow po2rc output encoding to be specified with the '--charset-output' option, defaulting to automatically choosing cp1252 if possible, otherwise utf-16-le, as before.