### PR TITLE
fix: add type validation to WebExtension parsing

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -287,6 +287,10 @@ class WebExtensionJsonFile(JsonFile):
         last_node=None,
     ):
         for item, value in data.items():
+            if isinstance(value, str):
+                raise base.ParseError(
+                    ValueError("File is not a valid WebExtension JSON file!")
+                )
             unit = self.UnitClass(
                 value.get("message", ""),
                 item,


### PR DESCRIPTION
This produces easier to understand errors than str object has no attribute get