### PR TITLE
fix(aresource): swallow invalid u escapes same as we do with others

### DIFF
--- a/tests/translate/storage/test_aresource.py
+++ b/tests/translate/storage/test_aresource.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 
-import pytest
 from lxml import etree
 
 from translate.misc.multistring import multistring
@@ -474,8 +473,7 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
         self.__check_parse(string, xml)
 
     def test_parse_unicode(self):
-        with pytest.raises(ValueError):
-            self.__check_parse("", r'<string name="test">\utest</string>')
+        self.__check_parse("test", r'<string name="test">\utest</string>')
         self.__check_parse("\u0230", r'<string name="test">\u0230</string>')
 
     def test_single_unescaped(self):

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -38,7 +38,7 @@ ESCAPE_TAB = {"t", "T"}
 ESCAPE_PLAIN = {" ", '"', "'", "@", "?"}
 MULTIWHITESPACE = re.compile(r"[ \n\t]{2}(?!\\n)")
 QUOTED_STRING = re.compile(r'("[^"]*")')
-UNICODE_ESCAPE = re.compile(r"\\u(.{4})")
+UNICODE_ESCAPE = re.compile(r"\\u([a-fA-F0-9]{4})")
 CHAR_ESCAPE = re.compile(r"\\(.)")
 
 ESCAPE_TRANSLATE = str.maketrans(


### PR DESCRIPTION
This makes \u behavior consistent with otheru unknown escape sequences.