### PR TITLE
fix(android): gracefully handle unparied double quotes

### DIFF
--- a/tests/translate/storage/test_aresource.py
+++ b/tests/translate/storage/test_aresource.py
@@ -509,6 +509,16 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
             r"""<string name="remove_manga">You are about to "remove \"%s\" from" your library</string>""",
         )
 
+    def test_parse_unparied_quote(self):
+        self.__check_parse(
+            """You can view it here soon: %s""",
+            """<string name="cmd_camera_response_success">"You can view it here soon: %s</string>""",
+        )
+        self.__check_parse(
+            """You can view it here soon: %s""",
+            """<string name="cmd_camera_response_success">You can view it here soon: %s"</string>""",
+        )
+
 
 class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
     StoreClass = aresource.AndroidResourceFile


### PR DESCRIPTION
This behavior is not not specified in the documentation, but Android apparently removes such double quotes (see
https://github.com/WeblateOrg/weblate/issues/13437).

The behavior implemented by us:

- opening quote without a closing quote will treat the string as quoted
- closing quote without an opening quote will be just ignored

Such a quote will be removed on round-trip as it is syntactically invalid.