### PR TITLE
Use flat structure for Webextension JSON files

### DIFF
--- a/tests/translate/storage/test_jsonl10n.py
+++ b/tests/translate/storage/test_jsonl10n.py
@@ -753,6 +753,17 @@ class TestWebExtensionStore(test_monolingual.TestMonolingualStore):
             == b'{\n    "key": {\n        "message": "value",\n        "description": "note"\n    }\n}\n'
         )
 
+    def test_dot_keys(self):
+        store = self.StoreClass()
+        store.parse('{"key.dot": {"message": "value", "description": "note"}}')
+        out = BytesIO()
+        store.serialize(out)
+
+        assert (
+            out.getvalue()
+            == b'{\n    "key.dot": {\n        "message": "value",\n        "description": "note"\n    }\n}\n'
+        )
+
     def test_serialize_no_description(self):
         store = self.StoreClass()
         store.parse('{"key": {"message": "value"}}')

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -256,6 +256,8 @@ class JsonNestedFile(JsonFile):
 
 
 class WebExtensionJsonUnit(BaseJsonUnit):
+    IdClass = FlatUnitId
+
     def storevalues(self, output):
         value = {"message": self.target}
         if self.notes:


### PR DESCRIPTION
I noticed on Weblate that WebExtension JSON keys are pulled apart. I don't believe this is supported in Chrome or Firefox. This PR uses flat unit ids instead.