### PR TITLE
json: output go-i18n-v2 as a flat json

### DIFF
--- a/tests/translate/storage/test_jsonl10n.py
+++ b/tests/translate/storage/test_jsonl10n.py
@@ -250,7 +250,9 @@ JSON_GOI18N_V2_SIMPLE = """{
         "description": "a piece or strip of strong paper, plastic, metal, leather, etc., for attaching by one end to something as a mark or label",
         "one": "{{.count}} tag",
         "other": "{{.count}} tags"
-    }
+    },
+    "nested.key.hello": "world",
+    "nested.key.world": "hello"
 }
 """
 
@@ -266,6 +268,12 @@ JSON_GOI18N_V2_COMPLEXE = """{
         "description": "a piece or strip of strong paper, plastic, metal, leather, etc., for attaching by one end to something as a mark or label",
         "one": "{{.count}} tag",
         "other": "{{.count}} tags"
+    },
+    "nested.key.hello": {
+        "other": "world"
+    },
+    "nested.key.world": {
+        "other": "hello"
     }
 }
 """
@@ -1275,12 +1283,14 @@ class TestGoI18NV2JsonFile(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         store.parse(JSON_GOI18N_V2_SIMPLE)
 
-        assert len(store.units) == 3
+        assert len(store.units) == 5
         assert store.units[0].target == "value"
         assert store.units[1].target == "Table"
         assert store.units[2].target == multistring(
             ["{{.count}} tag", "{{.count}} tags"]
         )
+        assert store.units[3].target == "world"
+        assert store.units[4].target == "hello"
 
         assert bytes(store).decode() == JSON_GOI18N_V2_SIMPLE
 
@@ -1337,12 +1347,14 @@ class TestGoI18NV2JsonFile(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         store.parse(JSON_GOI18N_V2_COMPLEXE)
 
-        assert len(store.units) == 3
+        assert len(store.units) == 5
         assert store.units[0].target == "value"
         assert store.units[1].target == "Table"
         assert store.units[2].target == multistring(
             ["{{.count}} tag", "{{.count}} tags"]
         )
+        assert store.units[3].target == "world"
+        assert store.units[4].target == "hello"
 
         assert bytes(store).decode() == JSON_GOI18N_V2_SIMPLE
 

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -743,7 +743,7 @@ class GoI18NJsonFile(JsonFile):
         out.write(b"\n")
 
 
-class GoI18NV2JsonUnit(BaseJsonUnit):
+class GoI18NV2JsonUnit(FlatJsonUnit):
     ID_FORMAT = "{}"
 
     def converttarget(self):


### PR DESCRIPTION
Currently the go-i18n-v2 is being serialized with nested structures, for example the following:

```json
{
	"repo.pulls.merged_title_desc": {
		"one": "слит %[1]d коммит из <code>%[2]s</code> в <code>%[3]s</code> %[4]s",
		"many": "слито %[1]d коммит(ов) из <code>%[2]s</code> в <code>%[3]s</code> %[4]s"
	},
	"repo.pulls.title_desc": {
		"one": "хочет влить %[1]d коммит из <code>%[2]s</code> в <code id=\"%[4]s\">%[3]s</code>",
		"many": "хочет влить %[1]d коммит(ов) из <code>%[2]s</code> в <code id=\"%[4]s\">%[3]s</code>"
	},
}
```

Will be serialized to the following by translate:
```json
{
    "repo": {
        "pulls": {
            "merged_title_desc": {
                "one": "слит %[1]d коммит из <code>%[2]s</code> в <code>%[3]s</code> %[4]s",
                "many": "слито %[1]d коммит(ов) из <code>%[2]s</code> в <code>%[3]s</code> %[4]s"
            },
            "title_desc": {
                "one": "хочет влить %[1]d коммит из <code>%[2]s</code> в <code id=\"%[4]s\">%[3]s</code>",
                "many": "хочет влить %[1]d коммитов из <code>%[2]s</code> в <code id=\"%[4]s\">%[3]s</code>"
            }
        }
    }
}
```

However the parsing such nested json file via this library is not allowed (this feels like a bug on its own, as this JSON can be parsed by go-i18n-v2):
`"repo" is an object but does not contain plurals. Maybe this is not a go-i18n v2 JSON file?`

So the output by this library cannot be parsed by this libray. Instead of trying to allow parsing of nested structures, _simply_ ensure that the output is flat which already can be parsed by this library. Test was adjusted to ensure the output is flat.