### PR TITLE
fix(android): gracefully handle invalid escape sequences

### DIFF
--- a/tests/translate/storage/test_aresource.py
+++ b/tests/translate/storage/test_aresource.py
@@ -514,6 +514,18 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
             """<string name="cmd_camera_response_success">You can view it here soon: %s"</string>""",
         )
 
+    def test_parse_escape_slash(self):
+        self.__check_parse(
+            """Přechod na novější verzi databáze účtu \\<g id="account">%s</g>\\""",
+            r"""<string name="upgrade_database_format">Přechod na novější verzi databáze účtu \\<g id="account">%s</g>\\</string>""",
+        )
+
+    def test_parse_escape_ignored(self):
+        self.__check_parse(
+            """Přechod na novější verzi databáze účtu \\<g id="account">%s</g>""",
+            r"""<string name="upgrade_database_format">Přechod na novější verzi databáze účtu \\<g id="account">%s</g>\x</string>""",
+        )
+
 
 class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
     StoreClass = aresource.AndroidResourceFile

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -35,7 +35,7 @@ from translate.storage import base, lisa
 WHITESPACE = {" ", "\n", "\t"}  # Whitespace that we collapse.
 ESCAPE_NEWLINE = {"n", "N"}
 ESCAPE_TAB = {"t", "T"}
-ESCAPE_PLAIN = {" ", '"', "'", "@", "?"}
+ESCAPE_PLAIN = {" ", '"', "'", "@", "?", "\\"}
 MULTIWHITESPACE = re.compile(r"[ \n\t]{2}(?!\\n)")
 QUOTED_STRING = re.compile(r'((?<!\\)"(?:\\"|[^"])*(?<!\\)")')
 UNICODE_ESCAPE = re.compile(r"\\u([a-fA-F0-9]{4})")
@@ -139,9 +139,9 @@ class DecodingXMLParser:
 
         # Detect escaping at the start and end of a string (we actually care only for
         # whitespace escapes, but detecting more does not matter)
-        if text and text[0] != unescaped_text[0]:
+        if text and unescaped_text and text[0] != unescaped_text[0]:
             cleanup_start = False
-        if text and text[-1] != unescaped_text[-1]:
+        if text and unescaped_text and text[-1] != unescaped_text[-1]:
             cleanup_end = False
 
         return unescaped_text, cleanup_start, cleanup_end


### PR DESCRIPTION
These are stripped and can cause later when processing the string as it can become blank after removing escape sequences.