### PR TITLE
fix(json): better handle non-nested formats

### DIFF
--- a/tests/translate/storage/test_jsonl10n.py
+++ b/tests/translate/storage/test_jsonl10n.py
@@ -252,7 +252,8 @@ JSON_GOI18N_V2_SIMPLE = """{
         "other": "{{.count}} tags"
     },
     "nested.key.hello": "world",
-    "nested.key.world": "hello"
+    "nested.key.world": "hello",
+    ".world": "hello"
 }
 """
 
@@ -273,6 +274,9 @@ JSON_GOI18N_V2_COMPLEXE = """{
         "other": "world"
     },
     "nested.key.world": {
+        "other": "hello"
+    },
+    ".world": {
         "other": "hello"
     }
 }
@@ -1275,6 +1279,20 @@ class TestGoI18NJsonFile(test_monolingual.TestMonolingualStore):
         with raises(ValueError):
             store.parse(JSON_I18NEXT_PLURAL)
 
+    def test_dot_keys(self):
+        jsontext = """[
+    {
+        "id": ".table",
+        "translation": "message"
+    }
+]
+"""
+        store = self.StoreClass()
+        store.parse(jsontext)
+        # Edit target
+        store.units[0].target = "message"
+        assert bytes(store).decode() == jsontext
+
 
 class TestGoI18NV2JsonFile(test_monolingual.TestMonolingualStore):
     StoreClass = jsonl10n.GoI18NV2JsonFile
@@ -1283,7 +1301,7 @@ class TestGoI18NV2JsonFile(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         store.parse(JSON_GOI18N_V2_SIMPLE)
 
-        assert len(store.units) == 5
+        assert len(store.units) == 6
         assert store.units[0].target == "value"
         assert store.units[1].target == "Table"
         assert store.units[2].target == multistring(
@@ -1339,6 +1357,11 @@ class TestGoI18NV2JsonFile(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         store.parse(JSON_GOI18N_V2_SIMPLE)
 
+        assert len(store.units) == 6
+
+        store.units[2].target = multistring(["{{.count}} tag", "{{.count}} tags"])
+        assert bytes(store).decode() == JSON_GOI18N_V2_SIMPLE
+
         store.units[2].target = multistring(["{{.count}} tag"])
 
         assert '"other": "{{.count}} tag"' in bytes(store).decode()
@@ -1347,7 +1370,7 @@ class TestGoI18NV2JsonFile(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         store.parse(JSON_GOI18N_V2_COMPLEXE)
 
-        assert len(store.units) == 5
+        assert len(store.units) == 6
         assert store.units[0].target == "value"
         assert store.units[1].target == "Table"
         assert store.units[2].target == multistring(
@@ -1362,6 +1385,17 @@ class TestGoI18NV2JsonFile(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         with raises(ValueError):
             store.parse(JSON_I18NEXT_PLURAL)
+
+    def test_dot_keys(self):
+        jsontext = """{
+    ".table": "message"
+}
+"""
+        store = self.StoreClass()
+        store.parse(jsontext)
+        # Edit target
+        store.units[0].target = "message"
+        assert bytes(store).decode() == jsontext
 
 
 class TestARBJsonFile(test_monolingual.TestMonolingualStore):

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -980,7 +980,11 @@ class UnitId:
         return self.__class__([*self.parts, (key, value)])
 
     @classmethod
-    def from_string(cls, text):
+    def from_key(cls, text: str) -> UnitId:
+        return cls([("key", text)])
+
+    @classmethod
+    def from_string(cls, text: str) -> UnitId:
         result = []
         # Strip possible leading separator
         text = text.removeprefix(cls.KEY_SEPARATOR)

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -297,7 +297,7 @@ class WebExtensionJsonFile(JsonFile):
                 value.get("description", ""),
                 value.get("placeholders", None),
             )
-            unit.setid(item, unitid=self.UnitClass.IdClass([("key", item)]))
+            unit.setid(item, unitid=self.UnitClass.IdClass.from_key(item))
             yield unit
 
 
@@ -670,7 +670,7 @@ class GoTextJsonFile(JsonFile):
         out.write(b"\n")
 
 
-class GoI18NJsonUnit(BaseJsonUnit):
+class GoI18NJsonUnit(FlatJsonUnit):
     ID_FORMAT = "{}"
 
     def getvalue(self):
@@ -734,7 +734,8 @@ class GoI18NJsonFile(JsonFile):
                 value.get("id", ""),
                 value.get("description", ""),
             )
-            unit.setid(value.get("id", ""))
+            item = value.get("id", "")
+            unit.setid(item, unitid=self.UnitClass.IdClass.from_key(item))
             yield unit
 
     def serialize(self, out):
@@ -806,7 +807,7 @@ class GoI18NV2JsonFile(JsonFile):
                     id,
                     value.get("description", ""),
                 )
-            unit.setid(id)
+            unit.setid(id, unitid=self.UnitClass.IdClass.from_key(id))
             yield unit
 
 
@@ -887,11 +888,11 @@ class ARBJsonFile(JsonFile):
                 metadata.get("placeholders", None),
                 metadata=metadata,
             )
-            unit.setid(item, unitid=self.UnitClass.IdClass([("key", item)]))
+            unit.setid(item, unitid=self.UnitClass.IdClass.from_key(item))
             yield unit
 
 
-class FormatJSJsonUnit(BaseJsonUnit):
+class FormatJSJsonUnit(FlatJsonUnit):
     def storevalues(self, output):
         value = {"defaultMessage": self.target}
         if self.notes:
@@ -905,7 +906,7 @@ class FormatJSJsonFile(JsonFile):
 
     See following URLs for doc:
 
-    https://formatjs.io/docs/getting-started/message-extraction/
+    https://formatjs.github.io/docs/getting-started/message-extraction/
     """
 
     UnitClass = FormatJSJsonUnit
@@ -925,5 +926,5 @@ class FormatJSJsonFile(JsonFile):
                 item,
                 value.get("description", ""),
             )
-            unit.setid(item, unitid=self.UnitClass.IdClass([("key", item)]))
+            unit.setid(item, unitid=self.UnitClass.IdClass.from_key(item))
             yield unit


### PR DESCRIPTION
These need to avoid parsing unitid upon parsing key.

See #5471