### PR TITLE
fix(android): avoid stripping possible extra closing quote

### DIFF
--- a/tests/translate/storage/test_aresource.py
+++ b/tests/translate/storage/test_aresource.py
@@ -510,7 +510,7 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
             """<string name="cmd_camera_response_success">"You can view it here soon: %s</string>""",
         )
         self.__check_parse(
-            """You can view it here soon: %s""",
+            'You can view it here soon: %s"',
             """<string name="cmd_camera_response_success">You can view it here soon: %s"</string>""",
         )
 
@@ -524,6 +524,12 @@ class TestAndroidResourceUnit(test_monolingual.TestMonolingualUnit):
         self.__check_parse(
             """Přechod na novější verzi databáze účtu \\<g id="account">%s</g>""",
             r"""<string name="upgrade_database_format">Přechod na novější verzi databáze účtu \\<g id="account">%s</g>\x</string>""",
+        )
+
+    def test_parse_escaped_quote_end(self):
+        self.__check_parse(
+            'No file %1$s found in archive "%2$s"',
+            r"""<string name="restore_backup_file_not_found">No file %1$s found in archive \"%2$s\"</string>""",
         )
 
 

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -110,8 +110,7 @@ class DecodingXMLParser:
         if text.startswith('"'):
             # Missing closing quote is gracefully ignored
             return text.removeprefix('"').removesuffix('"')
-        # Remove possible extra closing quote
-        text = text.removesuffix('"')
+        # Consolidate whitespace
         return WHITESPACE_RE.sub(" ", text)
 
     @classmethod


### PR DESCRIPTION
This is non-conforming string, so chose simpler approach to just leave the quote as it is instead of trying to detect if it is actually extra quote or escaped one.

Fixes https://github.com/WeblateOrg/weblate/issues/13655