### PR TITLE
fix(yaml): gracefully handle blank plural values

### DIFF
--- a/tests/translate/storage/test_yaml.py
+++ b/tests/translate/storage/test_yaml.py
@@ -598,3 +598,35 @@ class TestRubyYAMLResourceStore(test_monolingual.TestMonolingualStore):
         unit.setid("days_on[1]")
         store.addunit(unit)
         assert bytes(store).decode("ascii") == changed
+
+    def test_ruby_plural_blank(self):
+        data = """en:
+  string:
+  message:
+    one:
+    other:
+"""
+        store = self.StoreClass()
+        store.parse(data)
+        assert len(store.units) == 0
+        assert bytes(store).decode() == data
+
+    def test_ruby_plural_partial(self):
+        data = """en:
+  string:
+  message:
+    one: ''
+    other:
+"""
+        store = self.StoreClass()
+        store.parse(data)
+        assert len(store.units) == 1
+        assert (
+            bytes(store).decode()
+            == """en:
+  string:
+  message:
+    one: ''
+    other: ''
+"""
+        )

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -222,7 +222,12 @@ class RubyYAMLFile(YAMLFile):
         if data and all(x in cldr_plural_categories for x in data):
             # Ensure we have correct plurals ordering.
             values = [data[item] for item in cldr_plural_categories if item in data]
-            yield (prev, multistring(values))
+
+            # Skip blank values (all plurals are None)
+            if not all(value is None for value in values):
+                # Use blank string insted of None here
+                yield (prev, multistring([value or "" for value in values]))
+
             return
 
         # Handle normal dict


### PR DESCRIPTION
We can not use them as None as that makes us later serialize as "None" string.

See https://github.com/WeblateOrg/weblate/discussions/13441