### PR TITLE
feat(subtitles): automatically sort subtitle files on saving

### DIFF
--- a/tests/translate/storage/test_subtitles.py
+++ b/tests/translate/storage/test_subtitles.py
@@ -5,7 +5,27 @@ from translate.storage import subtitles
 from . import test_monolingual
 
 
-class TestSubtitleUnit(test_monolingual.TestMonolingualUnit):
+class TestSubRipFile(test_monolingual.TestMonolingualStore):
+    StoreClass = subtitles.SubRipFile
+
+    def test_ordering(self):
+        store = self.StoreClass()
+        unit = store.UnitClass("Second")
+        unit.settime("00:01:00.000", "00:01:01.000", 1)
+        store.addunit(unit)
+        unit = store.UnitClass("First")
+        unit.settime("00:00:00.000", "00:00:01.000", 1)
+        store.addunit(unit)
+        content = bytes(store)
+
+        newstore = self.StoreClass()
+        newstore.parse(content)
+        assert len(newstore.units) == 2
+        assert newstore.units[0].source == "First"
+        assert newstore.units[1].source == "Second"
+
+
+class TestSubtitleUnit(TestSubRipFile):
     UnitClass = subtitles.SubtitleUnit
 
     @pytest.mark.xfail(reason="Not Implemented")
@@ -13,17 +33,13 @@ class TestSubtitleUnit(test_monolingual.TestMonolingualUnit):
         super().test_note_sanity()
 
 
-class TestSubRipFile(test_monolingual.TestMonolingualStore):
-    StoreClass = subtitles.SubRipFile
-
-
-class TestMicroDVDFile(test_monolingual.TestMonolingualStore):
+class TestMicroDVDFile(TestSubRipFile):
     StoreClass = subtitles.MicroDVDFile
 
 
-class TestAdvSubStationAlphaFile(test_monolingual.TestMonolingualStore):
+class TestAdvSubStationAlphaFile(TestSubRipFile):
     StoreClass = subtitles.AdvSubStationAlphaFile
 
 
-class TestSubStationAlphaFile(test_monolingual.TestMonolingualStore):
+class TestSubStationAlphaFile(TestSubRipFile):
     StoreClass = subtitles.SubStationAlphaFile

--- a/translate/storage/subtitles.py
+++ b/translate/storage/subtitles.py
@@ -22,6 +22,8 @@ Class that manages subtitle files for translation.
 This class makes use of the subtitle functionality of ``aeidon``.
 """
 
+from __future__ import annotations
+
 import os
 from io import StringIO
 from tempfile import NamedTemporaryFile
@@ -42,7 +44,7 @@ class SubtitleUnit(base.TranslationUnit):
 
     init_time = "00:00:00.000"
 
-    def __init__(self, source=None, **kwargs):
+    def __init__(self, source: str | None = None, **kwargs):
         self._start = self.init_time
         self._end = self.init_time
         self._duration = 0.0
@@ -50,6 +52,11 @@ class SubtitleUnit(base.TranslationUnit):
             self.source = source
             self.target = source
         super().__init__(source)
+
+    def settime(self, start: str, end: str, duration: float):
+        self._start = start
+        self._end = end
+        self._duration = duration
 
     def getnotes(self, origin=None):
         if origin in {"programmer", "developer", "source code", None}:
@@ -84,7 +91,7 @@ class SubtitleFile(base.TranslationStore):
 
     def serialize(self, out):
         subtitles = []
-        for unit in self.units:
+        for unit in sorted(self.units, key=lambda unit: unit._start):
             subtitle = Subtitle()
             subtitle.main_text = unit.target or unit.source
             subtitle.start = unit._start


### PR DESCRIPTION
This is how subtitles are rendered, so make sure the strings are in the right order and not in the order they have been added to the file.