### PR TITLE
feat(json): strip comments from webextension

### DIFF
--- a/tests/translate/storage/test_jsonl10n.py
+++ b/tests/translate/storage/test_jsonl10n.py
@@ -843,6 +843,34 @@ class TestWebExtensionStore(test_monolingual.TestMonolingualStore):
 
         assert out.getvalue() == DATA
 
+    def test_comments(self):
+        DATA = """{
+    "test": {
+        // Comment
+        "message": "Message //"
+    },
+    "test//": { // Comment
+        "message": "Message // Other"
+    }
+}
+"""
+        store = self.StoreClass()
+        store.parse(DATA)
+        assert len(store.units) == 2
+        # Any comments will be stripped
+        assert (
+            bytes(store).decode()
+            == """{
+    "test": {
+        "message": "Message //"
+    },
+    "test//": {
+        "message": "Message // Other"
+    }
+}
+"""
+        )
+
 
 class TestI18NextStore(test_monolingual.TestMonolingualStore):
     StoreClass = jsonl10n.I18NextFile


### PR DESCRIPTION
The format is allowed to contain (only) // style comments. Strip these while parsing. This will make them being discarded on round trip.

Fixes #3811
Fixes https://github.com/WeblateOrg/weblate/issues/2043