### PR TITLE
chore: drop LICENSES

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -1,5 +1,0 @@
-==================================
-Licenses of Toolkit and Other Code
-==================================
-
-The Translate Toolkit is released the license listed in COPYING.


### PR DESCRIPTION
It is no longer useful since there is just one license.