### PR TITLE
chore(ci): avoid ignoring workflows for doc paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,14 +2,10 @@ name: Tests
 
 on:
   push:
-    paths-ignore:
-    - docs/**
     branches-ignore:
     - dependabot/**
     - deepsource**
   pull_request:
-    paths-ignore:
-    - docs/**
 
 permissions:
   contents: read


### PR DESCRIPTION
This forces any documentation pull request to override branch protection.