### PR TITLE
fix(json): gracefully handle when file changes from dict to list

### DIFF
--- a/tests/translate/storage/test_jsonl10n.py
+++ b/tests/translate/storage/test_jsonl10n.py
@@ -109,6 +109,12 @@ JSON_I18NEXT_PLURAL = b"""{
 }
 """
 
+JSON_I18NEXT_NESTED_ARRAY_BEFORE = """{
+    "apps": {
+        "legacy": "app1"
+    }
+}
+"""
 JSON_I18NEXT_NESTED_ARRAY = """{
     "apps": [
         {
@@ -1208,6 +1214,18 @@ class TestI18NextV4Store(test_monolingual.TestMonolingualStore):
         assert store.units[3].getid() == ".apps[1].description"
 
         assert bytes(store).decode() == JSON_I18NEXT_NESTED_ARRAY
+
+        newstore = self.StoreClass()
+        newstore.parse(JSON_I18NEXT_NESTED_ARRAY_BEFORE)
+
+        assert len(newstore.units) == 1
+
+        newstore.addunit(store.units[0])
+        newstore.addunit(store.units[1])
+        newstore.addunit(store.units[2])
+        newstore.addunit(store.units[3])
+
+        assert bytes(newstore).decode() == JSON_I18NEXT_NESTED_ARRAY
 
     def test_new_plural(self):
         EXPECTED = """{

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -1048,6 +1048,9 @@ class DictUnit(TranslationUnit):
             if not use_list and isinstance(target[key], list):
                 # Convert list to dict if needed
                 target[key] = dict(enumerate(target[key]))
+            elif use_list and isinstance(target[key], dict):
+                # Replace with an empty list if needed (this loses previous content)
+                target[key] = []
             # Handle placeholders
             if target[key] is None:
                 target[key] = default.copy()


### PR DESCRIPTION
We need to drop the old content in that case, but that is probably okay as this happens when the source file structure has changed.