### PR TITLE
fix(tiki): make the regexp non-greedy

### DIFF
--- a/translate/storage/tiki.py
+++ b/translate/storage/tiki.py
@@ -165,7 +165,7 @@ class TikiStore(base.TranslationStore):
         if isinstance(input, bytes):
             input = BytesIO(input)
 
-        split_regex = re.compile(r"^(?:// )?\"(.*)\" => \"(.*)\",$", re.UNICODE)
+        split_regex = re.compile(r"^(?:// )?\"(.*?)\" => \"(.*?)\",$", re.UNICODE)
 
         try:
             location = "translated"


### PR DESCRIPTION
This is the intended behavior and makes redos less likely.