### PR TITLE
po2rc: Correctly escape double-quotes embedded in a string in a RC file

### DIFF
--- a/translate/convert/po2rc.py
+++ b/translate/convert/po2rc.py
@@ -23,6 +23,7 @@ for examples and usage instructions.
 """
 
 import codecs
+import re
 from collections.abc import Iterable
 
 from translate.convert import convert
@@ -131,9 +132,14 @@ class rerc:
             # append translation if available, otherwise use as is
             if msgid in self.inputdict:
                 if name in self.inputdict[msgid]:
-                    tmp.append('"' + self.inputdict[msgid][name] + '"')
+                    t = self.inputdict[msgid][name]
                 elif EMPTY_LOCATION in self.inputdict[msgid]:
-                    tmp.append('"' + self.inputdict[msgid][EMPTY_LOCATION] + '"')
+                    t = self.inputdict[msgid][EMPTY_LOCATION]
+
+                # escape any embedded double quotes as two double quotes
+                t = re.sub(r'(?<!")"(?!")', r'""', t)
+
+                tmp.append('"' + t + '"')
             elif i > 1:
                 tmp.append(" ".join(c[1:i]))
 
@@ -183,9 +189,14 @@ class rerc:
             tmp = c[1:]
             if msgid in self.inputdict:
                 if name in self.inputdict[msgid]:
-                    tmp = ['"' + self.inputdict[msgid][name] + '"']
+                    tmp = self.inputdict[msgid][name]
                 elif EMPTY_LOCATION in self.inputdict[msgid]:
-                    tmp = ['"' + self.inputdict[msgid][EMPTY_LOCATION] + '"']
+                    tmp = self.inputdict[msgid][EMPTY_LOCATION]
+
+                if isinstance(tmp, str):
+                    # escape any embedded double quotes as two double quotes
+                    tmp = re.sub(r'(?<!")"(?!")', r'""', tmp)
+                    tmp = ['"' + tmp + '"']
 
             for part in tmp[:-1]:
                 yield part


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/windows/win32/menurc/stringtable-resource

> To embed quotes in the string, use the following sequence: "".

Because we may have some already translated strings which contain a literal "" (i.e. \"\" in a .po file) to work-around po2rc not doing this correctly so far, for backwards compatibility look around the " and only escape it if it isn't already part of a "" escape.

Future work: This doesn't do anything for untranslated strings. That's hard because those are passed through verbatim, including their existing formatting and linebreaks.