### PR TITLE
fix(yaml): use language tags when parsing plurals

### DIFF
--- a/tests/translate/storage/test_yaml.py
+++ b/tests/translate/storage/test_yaml.py
@@ -635,3 +635,26 @@ class TestRubyYAMLResourceStore(test_monolingual.TestMonolingualStore):
     other: ''
 """
         )
+
+    def test_bug_ruby_remove_zero_few_and_mix_others(self):
+        data = """en:
+  string:
+  message:
+    one: value 1
+    other: value 2
+    zero: value 3
+    few: value 4
+"""
+        store = self.StoreClass()
+        store.parse(data)
+        assert len(store.units) == 1
+        assert store.units[0].target == multistring(["value 1", "value 2"])
+        assert (
+            bytes(store).decode()
+            == """en:
+  string:
+  message:
+    one: value 1
+    other: value 2
+"""
+        )

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -219,9 +219,10 @@ class RubyYAMLFile(YAMLFile):
 
     def _parse_dict(self, data, prev):
         # Does this look like a plural?
+        tags = plural_tags.get(self.targetlanguage, plural_tags["en"])
         if data and all(x in cldr_plural_categories for x in data):
             # Ensure we have correct plurals ordering.
-            values = [data[item] for item in cldr_plural_categories if item in data]
+            values = [data[item] for item in tags if item in data]
 
             # Skip blank values (all plurals are None)
             if not all(value is None for value in values):


### PR DESCRIPTION
This makes the parsing code match serializing avoiding mixing up the tags.

Fixes #5536