### PR TITLE
fix(ruby yaml): improved serialization of incomplete plurals

### DIFF
--- a/tests/translate/storage/test_yaml.py
+++ b/tests/translate/storage/test_yaml.py
@@ -619,22 +619,14 @@ class TestRubyYAMLResourceStore(test_monolingual.TestMonolingualStore):
         data = """en:
   string:
   message:
-    one: ''
+    one: hello
     other:
 """
         store = self.StoreClass()
         store.parse(data)
-        assert store.units[0].target == multistring(["", ""])
+        assert store.units[0].target == multistring(["hello", ""])
         assert len(store.units) == 1
-        assert (
-            bytes(store).decode()
-            == """en:
-  string:
-  message:
-    one: ''
-    other: ''
-"""
-        )
+        assert bytes(store).decode() == data
 
     def test_bug_ruby_remove_zero_few_and_mix_others(self):
         data = """en:

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -190,6 +190,9 @@ class RubyYAMLUnit(YAMLUnit):
 
         # Sync plural_strings elements to plural_tags count.
         strings = self.sync_plural_count(self.target, tags)
+        if any(strings):
+            # Replace blank strings by None to distinguish not completed translations
+            strings = [string or None for string in strings]
 
         return CommentedMap(zip(tags, strings))
 


### PR DESCRIPTION
Use None instead of blank string for partially translated plurals.

Fixes #5536