### PR TITLE
Fix: Polish are missing a plural form

### DIFF
--- a/translate/lang/data.py
+++ b/translate/lang/data.py
@@ -689,7 +689,7 @@ plural_tags = {
     "per": ["one", "other"],
     "pes": ["one", "other"],
     "pk": ["one", "other"],
-    "pl": ["one", "few", "many"],
+    "pl": ["one", "few", "many", "other"],
     "plk": ["one", "few", "many"],
     "plt": ["one", "other"],
     "pnb": ["one", "other"],


### PR DESCRIPTION
Hello,

There is currently a problem with the polish plural, which are missing a form : "other" as we can see on the CLDR 44 (which is the version used according to the comment)

https://www.unicode.org/cldr/charts/44/supplemental/language_plural_rules.html
![image](https://github.com/user-attachments/assets/1ff2bb37-db49-49ed-a87b-3701ec7c2852)

Edit: 
After double checking, i think it is mostly ruby frameworks which force the usage of this key. But it cause problem for the weblate usage.. :/
![image](https://github.com/user-attachments/assets/5cb703e3-58cc-4059-b08d-4d434ff38339)
