### PR TITLE
tests: add test for markdown tables escaping

### DIFF
--- a/tests/translate/convert/test_po2md.py
+++ b/tests/translate/convert/test_po2md.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 import os
+
+import pytest
 
 from translate.convert import po2md
 
@@ -35,9 +39,28 @@ class TestPO2MD(test_convert.TestConvertCommand):
         self.run_command("podir", "testout", template="mddir")
         self.then_directory_of_translated_markdown_files_is_written()
 
-    def given_markdown_file(self):
+    @pytest.mark.xfail(reason="https://github.com/miyuchina/mistletoe/issues/244")
+    def test_markdown_table(self):
+        self.given_markdown_file(r"""
+| Left column | Right column                   |
+|-------------|--------------------------------|
+| left baz    | right foo \| between pipes \|  |
+""")
+        self.given_translation_file(
+            lines=[
+                "#: test.md%2Btable-cell",
+                'msgid "right foo | between pipes |"',
+                'msgstr "right translated | between pixes |"',
+            ]
+        )
+        self.run_command("translation.po", "out.md", template="file.md")
+        self.then_translated_markdown_file_is_written(
+            "right translated \\| between pixes"
+        )
+
+    def given_markdown_file(self, content: str | None = None):
         self.create_testfile(
-            "file.md", "# Markdown\nYou are only coming through in waves."
+            "file.md", content or "# Markdown\nYou are only coming through in waves."
         )
 
     def given_directory_of_markdown_files(self):
@@ -45,20 +68,23 @@ class TestPO2MD(test_convert.TestConvertCommand):
         self.create_testfile("mddir/file1.md", "# Heading\nContent of file 1")
         self.create_testfile("mddir/file2.md", "# Heading\nContent of file 2")
 
-    def given_translation_file(self, filename="translation.po"):
-        lines = [
-            "#: 'ref'",
-            'msgid "You are only coming through in waves."',
-            'msgstr "Översatt innehåll"',
-            "",
-            "#: 'ref'",
-            'msgid "Content of file 1"',
-            'msgstr "Innehåll i fil 1"',
-            "",
-            "#: 'ref'",
-            'msgid "Content of file 2"',
-            'msgstr "Innehåll i fil 2"',
-        ]
+    def given_translation_file(
+        self, filename="translation.po", lines: list[str] | None = None
+    ):
+        if lines is None:
+            lines = [
+                "#: 'ref'",
+                'msgid "You are only coming through in waves."',
+                'msgstr "Översatt innehåll"',
+                "",
+                "#: 'ref'",
+                'msgid "Content of file 1"',
+                'msgstr "Innehåll i fil 1"',
+                "",
+                "#: 'ref'",
+                'msgid "Content of file 2"',
+                'msgstr "Innehåll i fil 2"',
+            ]
         self.create_testfile(filename, "\n".join(lines))
 
     def given_directory_of_po_files(self):
@@ -66,10 +92,13 @@ class TestPO2MD(test_convert.TestConvertCommand):
         for filename in ["podir/file1.po", "podir/file2.po"]:
             self.given_translation_file(filename=filename)
 
-    def then_translated_markdown_file_is_written(self):
+    def then_translated_markdown_file_is_written(
+        self, expected: str = "Översatt innehåll"
+    ) -> str:
         assert os.path.isfile(self.get_testfilename("out.md"))
         content = self.read_testfile("out.md").decode()
-        assert "Översatt innehåll" in content
+        assert expected in content
+        return content
 
     def then_directory_of_translated_markdown_files_is_written(self):
         assert os.path.isdir(self.get_testfilename("testout"))


### PR DESCRIPTION
This is currently broken, let's see if this is something mistletoe can fix (https://github.com/miyuchina/mistletoe/issues/244).