### PR TITLE
feat(android): separate Compose Multiplatform Resources

### DIFF
--- a/tests/translate/storage/test_aresource.py
+++ b/tests/translate/storage/test_aresource.py
@@ -1131,3 +1131,11 @@ class TestMOKOResourceFile(test_monolingual.TestMonolingualStore):
 </resources>
 """
         )
+
+
+class TestCMPResourceUnit(TestMOKOResourceUnit):
+    UnitClass = aresource.CMPResourceUnit
+
+
+class TestCMPResourceFile(test_monolingual.TestMonolingualStore):
+    StoreClass = aresource.CMPResourceFile

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -622,8 +622,7 @@ class AndroidResourceFile(lisa.LISAfile):
         super().removeunit(unit)
 
 
-class MOKOResourceUnit(AndroidResourceUnit):
-    PLURAL_TAG = "plural"
+class CMPResourceUnit(AndroidResourceUnit):
     ESCAPE_TRANSLATE = str.maketrans(
         {
             "\\": "\\\\",
@@ -633,6 +632,15 @@ class MOKOResourceUnit(AndroidResourceUnit):
     )
 
 
+class CMPResourceFile(AndroidResourceFile):
+    UnitClass = CMPResourceUnit
+    Name = "Compose Multiplatform Resources"
+
+
+class MOKOResourceUnit(CMPResourceUnit):
+    PLURAL_TAG = "plural"
+
+
 class MOKOResourceFile(AndroidResourceFile):
     UnitClass = MOKOResourceUnit
-    Name = "Compose Multiplatform Resources"
+    Name = "Mobile Kotlin Resources"


### PR DESCRIPTION
There are actually two libraries and thus formats:

Compose Multiplatform Resources are like Android, just does not escape quotes.

Mobile Kotlin Resources also does not escape quotes (see https://github.com/icerockdev/moko-resources/issues/337) and differ in plural tag.