### PR TITLE
feat: add funding.json location

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://weblate.org/funding.json


### PR DESCRIPTION
This is an attempt to formalize funding information on the project, see https://fundingjson.org/

This follows the current practice that funding goes via Weblate.