### PR TITLE
feat(po): support for #= as new flags in PO file

### DIFF
--- a/tests/translate/storage/test_pypo.py
+++ b/tests/translate/storage/test_pypo.py
@@ -317,6 +317,35 @@ msgstr ""
         assert unit.typecomments == ["#, fuzzy, max-length:10\n"]
         assert unit.hastypecomment("max-length:10") is True
 
+    def test_future_flags(self):
+        """
+        Test future sticky/workflow flags handling.
+
+        See https://lists.gnu.org/archive/html/bug-gettext/2025-06/msg00018.html
+        """
+        posource = """#, max-length:10
+#= fuzzy
+msgid "Aurora"
+msgstr ""
+"""
+        expected = """#, fuzzy, max-length:10
+msgid "Aurora"
+msgstr ""
+"""
+        pofile = self.poparse(posource)
+        print(pofile)
+        assert len(pofile.units) == 1
+        assert bytes(pofile).decode("utf-8") == expected
+        unit = pofile.units[0]
+        assert unit.typecomments == ["#, fuzzy, max-length:10\n"]
+        assert unit.hastypecomment("fuzzy") is True
+        assert unit.hastypecomment("max-length:10") is True
+        unit.target = "Aurora"
+        unit.markfuzzy(False)
+        assert unit.typecomments == ["#, max-length:10\n"]
+        assert unit.hastypecomment("max-length:10") is True
+        assert unit.hastypecomment("fuzzy") is False
+
     def test_unassociated_comments(self):
         """Tests behaviour of unassociated comments."""
         oldsource = '# old lonesome comment\n\nmsgid "one"\nmsgstr "een"\n'

--- a/translate/storage/poparser.py
+++ b/translate/storage/poparser.py
@@ -26,6 +26,7 @@ From the GNU gettext manual:
      #| PREVIOUS MSGID                 (Gettext 0.16 - check if this is the correct position - not yet implemented)
      #: REFERENCE...
      #, FLAG...
+     #= FLAG...
      msgctxt CONTEXT                   (Gettext 0.15)
      msgid UNTRANSLATED-STRING
      msgstr TRANSLATED-STRING.
@@ -152,8 +153,10 @@ def parse_comment(parse_state, unit):
             return parse_state.next_line
         elif next_char == ":":
             append(unit.sourcecomments, next_line)
-        elif next_char == ",":
-            append(unit.typecomments, next_line)
+        elif next_char in {",", "="}:
+            # One of these will be workflow flags and one sticky flags in the future,
+            # normalize to #, for now
+            append(unit.typecomments, f"#,{next_line[2:]}")
         elif next_char == "~":
             # Special case: we refuse to parse obsoletes: they are done
             # elsewhere to ensure we reuse the normal unit parsing code


### PR DESCRIPTION
There will be two fields for flags in the PO file, this implements the first step as described in
https://lists.gnu.org/archive/html/bug-gettext/2025-06/msg00018.html

- both #, and #= lines are parsed
- only #, lines are emitted upon serializing