### PR TITLE
feat(android): serialize additional decimal plural

### DIFF
--- a/tests/translate/storage/test_aresource.py
+++ b/tests/translate/storage/test_aresource.py
@@ -711,7 +711,43 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
                 '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu',
             ]
         )
-        assert bytes(store) == content
+        # Additional entry for many (decimal) is present
+        assert (
+            bytes(store).decode()
+            == """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="teststring">
+        <item quantity="one"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> den</item>
+        <item quantity="few"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dny</item>
+        <item quantity="many"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu</item>
+        <item quantity="other"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu</item>
+    </plurals>
+</resources>
+"""
+        )
+
+    def test_parse_decimal_plurals(self):
+        content = b"""<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="teststring">
+        <item quantity="one"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> den</item>
+        <item quantity="few"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dny</item>
+        <item quantity="many"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dni</item>
+        <item quantity="other"><xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu</item>
+    </plurals>
+</resources>
+"""
+        # Resulting parsed plurals are still the same
+        store = self.StoreClass()
+        store.targetlanguage = "cs"
+        store.parse(content)
+        store.units[0].target = multistring(
+            [
+                '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> den',
+                '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dny',
+                '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu',
+            ]
+        )
 
     def entity_add(self, *, edit: bool):
         content = """<?xml version="1.0" encoding="utf-8"?>

--- a/translate/lang/data.py
+++ b/translate/lang/data.py
@@ -1008,6 +1008,17 @@ qt_plural_tags = {
     "zu": ["one", "other"],
 }
 
+DECIMAL_EXTRA_TAGS = {
+    "be": ["other"],
+    "cs": ["many"],
+    "gv": ["many"],
+    "lt": ["many"],
+    "pl": ["other"],
+    "ru": ["other"],
+    "sk": ["many"],
+    "uk": ["other"],
+}
+
 
 def simplercode(code):
     """


### PR DESCRIPTION
The content is taken from other/many and the output is sorted again for consistency.

This is a workaround, proper solution will be to allow editing this plural directly.

See https://github.com/WeblateOrg/weblate/issues/7520