### PR TITLE
`md2po`: Add line numbers, remove block token names, add recursive options.

### DIFF
--- a/translate/convert/md2po.py
+++ b/translate/convert/md2po.py
@@ -40,6 +40,7 @@ class MD2POOptionParser(convert.ConvertOptionParser):
         super().__init__(formats, usetemplates=False, usepots=True, description=__doc__)
         self.add_duplicates_option()
         self.add_multifile_option()
+        self.add_options(["--allowrecursiveoutput", "--allowrecursiveinput"])
 
     def _extract_translation_units(
         self,

--- a/translate/storage/markdown.py
+++ b/translate/storage/markdown.py
@@ -116,7 +116,8 @@ class MarkdownFile(base.TranslationStore):
 
         # emit a translation unit. The PO store takes care of the escaping.
         unit = self.addsourceunit(text)
-        unit.addlocation("{}+{}".format(self.filename or "", ".".join(path)))
+        # Index path to avoid duplicate location on list items.
+        unit.addlocation(f"{self.filename or ''}{''.join(path[0])}")
 
         # return translated text
         return self.callback(text)
@@ -272,7 +273,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     def render_heading(
         self, token: block_token.Heading, max_line_length: int
     ) -> Iterable[str]:
-        self.path.append("heading")
+        self.path.append(f":{token.line_number}")
         content = list(super().render_heading(token, max_line_length=max_line_length))
         self.path.pop()
         return content
@@ -280,7 +281,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     def render_setext_heading(
         self, token: block_token.SetextHeading, max_line_length: int
     ) -> Iterable[str]:
-        self.path.append("heading")
+        self.path.append(f":{token.line_number}")
         content = list(
             super().render_setext_heading(token, max_line_length=max_line_length)
         )
@@ -290,7 +291,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     def render_quote(
         self, token: block_token.Quote, max_line_length: int
     ) -> Iterable[str]:
-        self.path.append("quote")
+        self.path.append(f":{token.line_number}")
         content = list(super().render_quote(token, max_line_length=max_line_length))
         self.path.pop()
         return content
@@ -298,7 +299,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     def render_paragraph(
         self, token: block_token.Paragraph, max_line_length: int
     ) -> Iterable[str]:
-        self.path.append("p")
+        self.path.append(f":{token.line_number}")
         content = list(super().render_paragraph(token, max_line_length=max_line_length))
         self.path.pop()
         return content
@@ -306,7 +307,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     def render_list_item(
         self, token: block_token.ListItem, max_line_length: int
     ) -> Iterable[str]:
-        self.path.append("list-item")
+        self.path.append(f":{token.line_number}")
         content = list(super().render_list_item(token, max_line_length=max_line_length))
         self.path.pop()
         return content
@@ -314,7 +315,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     def render_table(
         self, token: block_token.Table, max_line_length: int
     ) -> Iterable[str]:
-        self.path.append("table-cell")
+        self.path.append(f":{token.line_number}")
         content = list(super().render_table(token, max_line_length=max_line_length))
         self.path.pop()
         return content
@@ -322,7 +323,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     def render_link_reference_definition_block(
         self, token: LinkReferenceDefinitionBlock, max_line_length: int
     ) -> Iterable[str]:
-        self.path.append("linkref")
+        self.path.append(f":{token.line_number}")
         content = list(
             super().render_link_reference_definition_block(
                 token, max_line_length=max_line_length


### PR DESCRIPTION
This PR includes the following changes to `md2po`:
- Removes block token names in favor of line numbers for locations.
- Updates `unit.addlocation()` to f-string, and to accommodate line number change.
- Enables `--allowrecursiveoutput` and `--allowrecursiveinput` to allow for providing directories of files for conversion purposes. I may be missing something obvious here to make this work without these options, but after a significant amount of digging into the code and trying various things. I'm relatively sure this is necessary to make this work.

I'm currently figuring out whether switching our project documentation from Sphinx to MkDocs is viable, and this tool is a critical piece to ensure I can do translations via Weblate. These changes will make that process more straightforward, and allow for easier conversion of larger numbers of existing documentation files.

Fixes #5174