### PR TITLE
feat(ci): actually enable typos spellchecker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,10 @@ repos:
   rev: v1.0.0
   hooks:
   - id: sphinx-lint
+- repo: https://github.com/crate-ci/typos
+  rev: v1.36.0
+  hooks:
+  - id: typos
+    args: []
+    require_serial: true
+    pass_filenames: false

--- a/tests/translate/convert/test_rc2po.py
+++ b/tests/translate/convert/test_rc2po.py
@@ -3,7 +3,7 @@ from translate.storage.po import pofile
 
 from . import test_convert
 
-# spellcheck:off
+# spellchecker:off
 RC_SOURCE = r"""
 #include "other_file.h" // This must be ignored
 
@@ -69,7 +69,7 @@ BEGIN
    END
 END
 """
-# spellcheck:on
+# spellchecker:on
 
 
 class TestRC2POCommand(test_convert.TestConvertCommand):

--- a/tests/translate/storage/test_po.py
+++ b/tests/translate/storage/test_po.py
@@ -637,7 +637,7 @@ msgstr[1] "Koeie"
         assert str(unit) == poexpected
 
     def test_multiline_obsolete(self):
-        """Tests for correct output of mulitline obsolete messages."""
+        """Tests for correct output of multiline obsolete messages."""
         posource = '#~ msgid ""\n#~ "Old thing\\n"\n#~ "Second old thing"\n#~ msgstr ""\n#~ "Ou ding\\n"\n#~ "Tweede ou ding"\n'
         pofile = self.poparse(posource)
         assert pofile.isempty()
@@ -878,7 +878,7 @@ msgstr "b"
         assert header_dict["Last-Translator"] == "Tránslátór"
 
     def test_final_slash(self):
-        r"""Test that \\ as last character is correcly interpreted (bug 960)."""
+        r"""Test that \\ as last character is correctly interpreted (bug 960)."""
         posource = r"""
 msgid ""
 msgstr ""

--- a/tests/translate/storage/test_wordfast.py
+++ b/tests/translate/storage/test_wordfast.py
@@ -57,8 +57,9 @@ class TestWFUnit(test_base.TestTranslationUnit):
         # Real world cases
         unit = self.UnitClass("Open &File. ’n Probleem.")  # codespell:ignore
         assert (
-            unit.dict["source"] == "Open &'26;File. &'92;n Probleem."
-        )  # codespell:ignore
+            unit.dict["source"]
+            == "Open &'26;File. &'92;n Probleem."  # codespell:ignore
+        )
 
     def test_newlines(self):
         """Wordfast does not like real newlines."""

--- a/translate/storage/qm.py
+++ b/translate/storage/qm.py
@@ -154,9 +154,7 @@ class qmfile(base.TranslationStore):
                 # numerusrules_data = struct.unpack(">%db" % length, input[startsection + sectionheader:startsection + sectionheader + length])
                 pass
             else:
-                section_debug(
-                    "Unkown", section_type, startsection, length
-                )  # codespell:ignore=Unkown
+                section_debug("Unknown", section_type, startsection, length)
             startsection = startsection + sectionheader + length
         pos = messages_start
         source = target = None


### PR DESCRIPTION
I forgot to enable this in the pre-commit configuration in #5679. Meanwhile new typos version was released detecting some additional issues.