### PR TITLE
Fixes `--timestamp` check failing when `--multifile=onefile` is enabled

### DIFF
--- a/translate/convert/convert.py
+++ b/translate/convert/convert.py
@@ -229,7 +229,12 @@ class ConvertOptionParser(optrecurse.RecursiveOptionParser):
     def processfile(
         self, fileprocessor, options, fullinputpath, fulloutputpath, fulltemplatepath
     ):
-        if options.timestamp and _output_is_newer(fullinputpath, fulloutputpath):
+        if options.multifilestyle == "onefile":
+            timecheck_output_path = options.output
+        else:
+            timecheck_output_path = fulloutputpath
+
+        if options.timestamp and _output_is_newer(fullinputpath, timecheck_output_path):
             return False
 
         return super().processfile(

--- a/translate/convert/convert.py
+++ b/translate/convert/convert.py
@@ -229,6 +229,11 @@ class ConvertOptionParser(optrecurse.RecursiveOptionParser):
     def processfile(
         self, fileprocessor, options, fullinputpath, fulloutputpath, fulltemplatepath
     ):
+        # The `fulloutputpath`s parsed when `onefile` is enabled don't exist, which causes
+        # the `_output_is_newer` check to return False. This means that even if there is
+        # no content update, the POT/PO files are regenerated. When `onefile` is enabled,
+        # This check sets the output  path used by `_output_is_newer` to the output file
+        # provided to the command, which will exist. It remains `fulloutputpath` otherwise.
         if options.multifilestyle == "onefile":
             timecheck_output_path = options.output
         else:


### PR DESCRIPTION
It seems the way that `onefile` works is to generate a series of files, the paths for which are concatenated onto the provided `output` file path and name. As those `fulloutputpath`s don't exist by the time `_output_is_newer` is run, the `.exists` checks in `_output_is_newer` fail and return `False`. Therefore, regardless of a content update, the POT/PO files are regenerated with a new `POT-creation-date` in the header. 

The added check sets the output path used by `_output_is_newer` to the provided output file if `onefile` is enabled, and leaves it as `fulloutputpath` otherwise. 

I tested it with `md2po` which is the tool I am using that brought the issue to light.

I don't see relevant tests in `test_convert.py`, so I didn't add anything there. I am uncertain whether I need to update the tests for every tool that allows `--timestamp` or not. I am creating this PR with the knowledge that I may still need to deal with test updates. If the situation is not clear to me, I will let you know. 