### PR TITLE
fix(misc): implement bool for multistring

### DIFF
--- a/tests/translate/misc/test_multistring.py
+++ b/tests/translate/misc/test_multistring.py
@@ -95,3 +95,9 @@ class TestMultistring:
         foodict2 = {"foo": "baz"}
         assert foo in foodict2
         assert hash(str(foo)) == hash(foo)
+
+    def test_bool(self):
+        assert bool(multistring(["foo", "bar"])) is True
+        assert bool(multistring(["", "bar"])) is True
+        assert bool(multistring(["foo", ""])) is True
+        assert bool(multistring(["", ""])) is False

--- a/translate/misc/multistring.py
+++ b/translate/misc/multistring.py
@@ -53,6 +53,9 @@ class multistring(str):
     def __hash__(self) -> int:
         return super().__hash__()
 
+    def __bool__(self) -> bool:
+        return len(self) > 0 or any(self.extra_strings)
+
     def __ne__(self, other) -> bool:
         return not self.__eq__(other)
 


### PR DESCRIPTION
We want non-empty test to be performed on all the strings, not only on the first one. Without that it wrongly detects partial plural strings as not translated.