### PR TITLE
chore: remove unnecessary str conversion for logging

### DIFF
--- a/tests/translate/services/test_tmserver.py
+++ b/tests/translate/services/test_tmserver.py
@@ -53,7 +53,9 @@ msgstr "Ahoj"
         thread.start()
 
         # Run test
-        response = urlopen(f"http://localhost:{server_port}/en/cs/unit/Hello/")
+        response = urlopen(
+            f"http://localhost:{server_port}/en/cs/unit/Hello/", timeout=1
+        )
         payload = json.loads(response.read().decode("utf-8"))
         assert payload[0]["target"] == "Ahoj"
 

--- a/translate/services/tmserver.py
+++ b/translate/services/tmserver.py
@@ -88,7 +88,7 @@ class TMServer:
     def translate_unit(self, environ, start_response, uid, slang, tlang):
         start_response("200 OK", [("Content-type", "text/plain")])
         candidates = self.tmdb.translate_unit(uid, slang, tlang)
-        logger.debug("candidates: %s", str(candidates))
+        logger.debug("candidates: %s", candidates)
         response = json.dumps(candidates, indent=4).encode("utf-8")
         params = parse.parse_qs(environ.get("QUERY_STRING", ""))
         try:

--- a/translate/storage/tmdb.py
+++ b/translate/storage/tmdb.py
@@ -322,7 +322,7 @@ DROP TRIGGER IF EXISTS sources_delete_trig;
                 )
         results.sort(key=operator.itemgetter("quality"), reverse=True)
         results = results[: self.max_candidates]
-        logger.debug("results: %s", str(results))
+        logger.debug("results: %s", results)
         return results
 
 

--- a/translate/tools/pomerge.py
+++ b/translate/tools/pomerge.py
@@ -45,9 +45,7 @@ def mergestores(store1, store2, mergeblanks, mergefuzzy, mergecomments):
         if unit1 is None:
             unit1 = store1.findunit(unit2.source)
         if unit1 is None:
-            logger.error(
-                "The template does not contain the following unit:\n%s", str(unit2)
-            )
+            logger.error("The template does not contain the following unit:\n%s", unit2)
         else:
             if not mergeblanks and len(unit2.target.strip()) == 0:
                 continue

--- a/translate/tools/poterminology.py
+++ b/translate/tools/poterminology.py
@@ -152,7 +152,7 @@ class TerminologyExtractor:
                     "%s:%d - bad stopword entry starts with '%s'",
                     self.stopfile,
                     line,
-                    str(character),
+                    character,
                 )
                 logger.warning(
                     "%s:%d all lines after error ignored", self.stopfile, line + 1


### PR DESCRIPTION
It already has the %s format string, so explicit conversion is not needed.