### PR TITLE
fix(po): improve text wrapping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ test = [
 ]
 types = [
   "setuptools>=61.2",
-  "types-lxml==2025.3.30"
+  "types-lxml==2025.3.30",
+  "wcwidth-stubs==0.2.14.0"
 ]
 
 [project]
@@ -61,8 +62,8 @@ classifiers = [
   "Topic :: Software Development :: Localization"
 ]
 dependencies = [
-  "cwcwidth>=0.1.10,<0.2",
-  "lxml>=5.2.0,<6.1"
+  "lxml>=5.2.0,<6.1",
+  "wcwidth>=0.2.14,<0.3"
 ]
 description = "Tools and API for translation and localization engineering."
 dynamic = [

--- a/tests/translate/storage/test_po.py
+++ b/tests/translate/storage/test_po.py
@@ -1198,7 +1198,6 @@ msgstr ""
         assert self.poreflow(gettext_0_23) == expected
         assert self.poreflow(gettext_0_20) == expected
 
-    @mark.xfail(reason="Incompatible wrapping with gettext, see #5661")
     def test_wrap_wide_stop(self):
         posource = r"""msgid ""
 msgstr "Content-Type: text/plain; charset=utf-8\n"

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -105,7 +105,7 @@ def escapeforpo(line: str) -> str:
 def unicode_width(text: str) -> int:
     result = wcswidth(text)
     if result == -1:
-        raise ValueError("Unprintable character in a string")
+        raise ValueError("String contains control characters or non-displayable characters")
     return result
 
 

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -31,6 +31,7 @@ import re
 import textwrap
 from functools import lru_cache
 from itertools import chain
+from warnings import warn
 
 from wcwidth import wcswidth
 
@@ -105,7 +106,10 @@ def escapeforpo(line: str) -> str:
 def unicode_width(text: str) -> int:
     result = wcswidth(text)
     if result == -1:
-        raise ValueError("String contains control characters or non-displayable characters")
+        warn(
+            f"String contains control characters or non-displayable characters: {text!r}"
+        )
+        return len(text)
     return result
 
 


### PR DESCRIPTION
- switch to wcwidth from cwcwidth for newer Unicode support and locale idendependency (fixes #5722)
- do not perform wcwidth on characters only, that doesn't work well for compositing characters
- wrap wcwidth with a safety wrapper to avoid using -1 length and to cache the calculations
- implement breaking of wide strings inside lines for gettext compatibility (fixes #5661)