### PR TITLE
fix(android): correctly migrate to plural tags

### DIFF
--- a/tests/translate/storage/test_aresource.py
+++ b/tests/translate/storage/test_aresource.py
@@ -741,12 +741,44 @@ class TestAndroidResourceFile(test_monolingual.TestMonolingualStore):
         store = self.StoreClass()
         store.targetlanguage = "cs"
         store.parse(content)
-        store.units[0].target = multistring(
+        assert store.units[0].target == multistring(
             [
                 '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> den',
                 '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dny',
                 '<xliff:g xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" id="count">%d</xliff:g> dnu',
             ]
+        )
+
+    def test_edit_to_plurals(self):
+        content = """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="teststring">Test %d string</string>
+</resources>
+"""
+        # Resulting parsed plurals are still the same
+        store = self.StoreClass()
+        store.targetlanguage = "cs"
+        store.parse(content.encode())
+        assert store.units[0].target == "Test %d string"
+        store.units[0].target = multistring(
+            [
+                "Test %d string",
+                "Test %d strings",
+                "Test %d strings",
+            ]
+        )
+        assert (
+            bytes(store).decode()
+            == """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="teststring">
+        <item quantity="one">Test %d string</item>
+        <item quantity="few">Test %d strings</item>
+        <item quantity="many">Test %d strings</item>
+        <item quantity="other">Test %d strings</item>
+    </plurals>
+</resources>
+"""
         )
 
     def entity_add(self, *, edit: bool):

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -438,7 +438,11 @@ class AndroidResourceUnit(base.TranslationUnit):
             # Fix the root tag if mismatching
             if self.xmlelement.tag != self.PLURAL_TAG:
                 old_id = self.getid()
-                self.xmlelement = etree.Element(self.PLURAL_TAG)
+                newelement = etree.Element(self.PLURAL_TAG)
+                parent = self.xmlelement.getparent()
+                if parent is not None:
+                    parent.replace(self.xmlelement, newelement)
+                self.xmlelement = newelement
                 self.setid(old_id)
 
             plural_tags = self._store.get_plural_tags()
@@ -482,7 +486,11 @@ class AndroidResourceUnit(base.TranslationUnit):
             # Fix the root tag if mismatching
             if self.xmlelement.tag != self.SINGULAR_TAG:
                 old_id = self.getid()
-                self.xmlelement = etree.Element(self.SINGULAR_TAG)
+                newelement = etree.Element(self.SINGULAR_TAG)
+                parent = self.xmlelement.getparent()
+                if parent is not None:
+                    parent.replace(self.xmlelement, newelement)
+                self.xmlelement = newelement
                 self.setid(old_id)
 
             self.set_xml_text_value(target, self.xmlelement)


### PR DESCRIPTION
The document needs to be updated as well when replacing unit XML element.

Fixes https://github.com/WeblateOrg/weblate/issues/16536