### PR TITLE
chore: annotate security not related usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -352,8 +352,6 @@ ignore = [
   "RUF012",  # TODO: Mutable class attributes should be annotated with `typing.ClassVar`
   "S101",  # CONFIG: Use of `assert` detected
   "S301",  # TODO: `pickle` and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue
-  "S311",  # TODO: Standard pseudo-random generators are not suitable for cryptographic purposes
-  "S324",  # TODO: Probable use of insecure hash functions in `hashlib`: `md5`
   "S403",  # TODO: `pickle`, `cPickle`, `dill`, and `shelve` modules are possibly insecure
   "S404",  # TODO: `subprocess` module is possibly insecure
   "S407",  # TODO: `xml.dom.expatbuilder` is vulnerable to XML attacks

--- a/translate/storage/benchmark.py
+++ b/translate/storage/benchmark.py
@@ -77,12 +77,12 @@ class TranslateBenchmarker:
                 sample_file = self.StoreClass()
                 for stringnum in range(strings_per_file):
                     source_string = " ".join(
-                        "word%d" % (random.randint(0, strings_per_file) * i)
+                        "word%d" % (random.randint(0, strings_per_file) * i)  # noqa: S311
                         for i in range(source_words_per_string)
                     )
                     sample_unit = sample_file.addsourceunit(source_string)
                     sample_unit.target = " ".join(
-                        "drow%d" % (random.randint(0, strings_per_file) * i)
+                        "drow%d" % (random.randint(0, strings_per_file) * i)  # noqa: S311
                         for i in range(target_words_per_string)
                     )
                 sample_file.savefile(

--- a/translate/tools/podebug.py
+++ b/translate/tools/podebug.py
@@ -313,7 +313,9 @@ class podebug:
             hashable = unit.getlocations()[0] if unit.getlocations() else unit.source
             prefix = prefix.replace(
                 "@hash_placeholder@",
-                md5(hashable.encode("utf-8")).hexdigest()[: self.hash_len],
+                md5(hashable.encode("utf-8"), usedforsecurity=False).hexdigest()[
+                    : self.hash_len
+                ],
             )
         rich_string = unit.rich_target if unit.istranslated() else unit.rich_source
         if not isinstance(rich_string, StringElem):


### PR DESCRIPTION
Annotate security unrelated usages of randint and md5.