### PR TITLE
fix(ci): disable progress for qemu build

### DIFF
--- a/.github/workflows/test-qemu.yml
+++ b/.github/workflows/test-qemu.yml
@@ -48,6 +48,7 @@ jobs:
 
         dockerRunArgs: |
           --volume "/tmp/setup-uv-cache:/tmp/setup-uv-cache"
+          --tty=false
 
         install: |
           apt-get update -q -y


### PR DESCRIPTION
The docker is executed with --tty what makes uv think it is actually running on a terminal and makes it produce progress bars which are unusable in the logs of GitHub actions.