### PR TITLE
chore: drop support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         requirements: [latest]
         python-version:
-        - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'
@@ -31,7 +30,7 @@ jobs:
         - macos-latest
         include:
         - requirements: minimal
-          python-version: '3.9'
+          python-version: '3.10'
           os: ubuntu-latest
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the Translate Toolkit!
 
 ### Prerequisites
 - Git
-- Python 3.9 or newer
+- Python 3.10 or newer
 - [uv](https://docs.astral.sh/uv/) (recommended package manager)
 
 ### Setup

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ feature set. This cal be easily specified during pip installation::
 
 .. note:: Please check ``pyproject.toml``
 
-The Toolkit requires Python 3.9 or newer.
+The Toolkit requires Python 3.10 or newer.
 
 The package lxml is required. You should install version 4.6.3 or later.
 <http://lxml.de/> Depending on your platform, the easiest way to install might

--- a/docs/developers/contributing.rst
+++ b/docs/developers/contributing.rst
@@ -80,7 +80,7 @@ You will need some Python skills, this is a great way to learn.
 1. Install dependencies:
 
    * Git
-   * Python 3.9 or newer
+   * Python 3.10 or newer
    * `uv <https://docs.astral.sh/uv/>`_ (recommended package manager)
 
 2. Clone and setup:

--- a/docs/developers/developers.rst
+++ b/docs/developers/developers.rst
@@ -116,7 +116,7 @@ Setup
 **Prerequisites:**
 
 * Git
-* Python 3.9 or newer
+* Python 3.10 or newer
 * `uv <https://docs.astral.sh/uv/>`_ (recommended package manager)
 
 **Installation:**

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -60,7 +60,7 @@ Installing on Windows
 On Windows we recommend using `uv <https://docs.astral.sh/uv/>`_ to install
 Translate Toolkit. This automatically manages virtual environments for you.
 
-1. Install latest `Python 3.9+ <https://www.python.org/downloads/windows/>`_
+1. Install latest `Python 3.10+ <https://www.python.org/downloads/windows/>`_
 2. Install uv by running in PowerShell:
 
    .. code-block:: powershell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python",
   "Topic :: Software Development :: Internationalization",
   "Topic :: Software Development :: Libraries :: Python Modules",
@@ -76,7 +75,7 @@ keywords = [
 license = "GPL-2.0-or-later"
 license-files = ["COPYING"]
 name = "translate-toolkit"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 all = [

--- a/translate/misc/ourdom.py
+++ b/translate/misc/ourdom.py
@@ -209,8 +209,7 @@ class ExpatBuilderNS(expatbuilder.ExpatBuilderNS):
             del self._ns_ordered_prefixes[:]
 
         if attributes:
-            if hasattr(node, "_ensure_attributes"):
-                node._ensure_attributes()  # Python 3 only
+            node._ensure_attributes()
             attrs = node._attrs
             attrsNS = node._attrsNS
             for i in range(0, len(attributes), 2):


### PR DESCRIPTION
It is now EOL, so dropping support seems appropriate.