### PR TITLE
fix(misc): implement pop for cidict

### DIFF
--- a/tests/translate/misc/test_dictutils.py
+++ b/tests/translate/misc/test_dictutils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from translate.misc import dictutils
 
 
@@ -8,3 +10,35 @@ def test_cidict_has_key():
     assert "Lower" in cid
     assert "LOWER" in cid
     assert "upper" not in cid
+
+
+def test_cidict_pop():
+    cid = dictutils.cidict()
+    cid["lower"] = "lowercase"
+    assert cid.pop("LOWER")
+    with pytest.raises(KeyError):
+        assert cid.pop("upper")
+
+
+def test_cidict_getitem():
+    cid = dictutils.cidict()
+    cid["lower"] = "lowercase"
+    assert cid["lower"] == "lowercase"
+    assert cid["LOWER"] == "lowercase"
+    assert cid["Lower"] == "lowercase"
+    with pytest.raises(KeyError):
+        assert cid["upper"]
+
+
+def test_cidict_setitem():
+    cid = dictutils.cidict()
+    cid["lower"] = "lowercase"
+    cid["Lower"] = "other"
+    assert cid["lower"] == "other"
+
+
+def test_cidict_delitem():
+    cid = dictutils.cidict()
+    cid["lower"] = "lowercase"
+    del cid["Lower"]
+    assert "lower" not in cid

--- a/translate/misc/dictutils.py
+++ b/translate/misc/dictutils.py
@@ -31,7 +31,7 @@ class cidict(dict):
         for akey in self.keys():
             if akey.lower() == lkey:
                 return super().__getitem__(akey)
-        raise IndexError
+        raise KeyError
 
     def __setitem__(self, key, value):
         if not isinstance(key, str):
@@ -53,7 +53,7 @@ class cidict(dict):
         for akey in self.keys():
             if akey.lower() == lkey:
                 return super().__delitem__(akey)
-        raise IndexError
+        raise KeyError
 
     def __contains__(self, key):
         if not isinstance(key, str):
@@ -62,3 +62,14 @@ class cidict(dict):
             )
         lkey = key.lower()
         return any(akey.lower() == lkey for akey in self.keys())
+
+    def pop(self, key):
+        if not isinstance(key, str):
+            raise TypeError(
+                f"cidict can only have str or unicode as key (got {type(key)!r})"
+            )
+        lkey = key.lower()
+        for akey in self.keys():
+            if akey.lower() == lkey:
+                return super().pop(akey)
+        raise KeyError


### PR DESCRIPTION
It is used in the poheader and is broken for some time (perhaps since Python 3?).