### PR TITLE
fix(po): import only interface classess

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,13 +333,11 @@ disable = [
   "unsubscriptable-object",  # TODO
   "unsupported-assignment-operation",  # TODO
   "unused-argument",
-  "unused-wildcard-import",  # TODO
   "use-implicit-booleaness-not-comparison",  # TODO
   "use-implicit-booleaness-not-len",  # TODO
   "use-maxsplit-arg",  # TODO
   "use-yield-from",  # TODO
   "used-before-assignment",  # TODO
-  "wildcard-import",  # TODO
   "wrong-import-position"  # TODO
 ]
 

--- a/translate/storage/po.py
+++ b/translate/storage/po.py
@@ -30,20 +30,22 @@ import logging
 import os
 import platform
 
+__all__ = ("lsep", "pofile", "pounit")
+
 logger = logging.getLogger(__name__)
 usecpo = os.getenv("USECPO")
 
 if platform.python_implementation() == "CPython":
     if usecpo == "1":
-        from translate.storage.cpo import *  # noqa: F403
+        from translate.storage.cpo import lsep, pofile, pounit
     elif usecpo == "2":
-        from translate.storage.fpo import *  # noqa: F403
+        from translate.storage.fpo import lsep, pofile, pounit
     else:
-        from translate.storage.pypo import *  # noqa: F403
+        from translate.storage.pypo import lsep, pofile, pounit
 else:
     if usecpo:
         logger.error(
             "cPO and fPO do not work on %s defaulting to PyPO",
             platform.python_implementation(),
         )
-    from translate.storage.pypo import *  # noqa: F403
+    from translate.storage.pypo import lsep, pofile, pounit


### PR DESCRIPTION
Rest of the module content differs between the implementations, so there is no good reason to try to reuse these.