### PR TITLE
fix: avoid depreciation warnings

### DIFF
--- a/docs/developers/testing.rst
+++ b/docs/developers/testing.rst
@@ -41,7 +41,7 @@ to skip a test module if a dependency cannot be imported:
 .. code-block:: python
 
     from pytest import importorskip
-    importorskip("vobject")
+    importorskip("vobject", exc_type=ImportError)
 
 If *vobject* can be imported, it will be; otherwise it raises an exception
 that causes pytest to skip the entire module rather than failing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,6 +249,10 @@ ignore = [
   "translate/storage/debug.properties"  # TODO: this should be converted to tests
 ]
 
+[tool.coverage.run]
+# C Tracer not available in quemu testing
+disable_warnings = ["no-ctracer"]
+
 [tool.isort]
 known_third_party = [
   "bs4",
@@ -323,6 +327,16 @@ disable = [
 ]
 
 [tool.pytest.ini_options]
+filterwarnings = [
+  # Treat all unfiltered warnings as errors
+  "error",
+  # translate-toolkit warning for accesskeys
+  "ignore:Could not find accesskey:UserWarning:translate.convert",
+  # warning in a third-party library
+  "ignore:The 'u' type code is deprecated:DeprecationWarning:enchant.checker",
+  # TODO: these might be worth investigating
+  'default:unclosed:ResourceWarning'
+]
 norecursedirs = ".git build docs"
 
 [tool.ruff.lint]

--- a/tests/translate/convert/test_ini2po.py
+++ b/tests/translate/convert/test_ini2po.py
@@ -6,7 +6,7 @@ from translate.convert import ini2po
 
 from . import test_convert
 
-importorskip("iniparse")
+importorskip("iniparse", exc_type=ImportError)
 
 
 class TestIni2PO:

--- a/tests/translate/convert/test_po2ini.py
+++ b/tests/translate/convert/test_po2ini.py
@@ -6,7 +6,7 @@ from translate.convert import po2ini
 
 from . import test_convert
 
-importorskip("iniparse")
+importorskip("iniparse", exc_type=ImportError)
 
 
 class TestPO2Ini:

--- a/tests/translate/convert/test_po2sub.py
+++ b/tests/translate/convert/test_po2sub.py
@@ -7,7 +7,7 @@ from translate.storage import po
 
 from . import test_convert
 
-importorskip("aeidon")
+importorskip("aeidon", exc_type=ImportError)
 
 
 class TestPO2Sub:

--- a/tests/translate/storage/test_cpo.py
+++ b/tests/translate/storage/test_cpo.py
@@ -12,7 +12,7 @@ pytestmark = mark.skipif(
 )
 
 
-cpo = importorskip("translate.storage.cpo")
+cpo = importorskip("translate.storage.cpo", exc_type=ImportError)
 
 
 class TestCPOUnit(test_po.TestPOUnit):

--- a/tests/translate/storage/test_trados.py
+++ b/tests/translate/storage/test_trados.py
@@ -1,6 +1,6 @@
 from pytest import importorskip
 
-trados = importorskip("translate.storage.trados")
+trados = importorskip("translate.storage.trados", exc_type=ImportError)
 
 
 def test_unescape():

--- a/translate/storage/xliff2.py
+++ b/translate/storage/xliff2.py
@@ -127,7 +127,8 @@ class Xliff2Unit(XliffUnit):
                     self.xmlelement.remove(notes_container)
 
     def getunitelement(self) -> etree._Element:
-        if unit_element := self.xmlelement.getparent():
+        unit_element = self.xmlelement.getparent()
+        if unit_element is not None:
             return unit_element
 
         unit_element = etree.Element(self.namespaced("unit"))
@@ -159,7 +160,7 @@ class Xliff2Unit(XliffUnit):
                 unit_id = value
             self.getunitelement().set("id", unit_id)
             if segment_id and not segment_id.startswith(SEGMENT_AUTO_ID):
-                self.xmlelement.sedid(segment_id)
+                self.xmlelement.set("id", segment_id)
 
     def isfuzzy(self) -> bool:
         return bool(self.target) and self.xmlelement.get("state", None) == "initial"


### PR DESCRIPTION
- treat warnings as errors while running tests
- fix depreciation warning in XLIFF 2.0