### PR TITLE
add filename in log

### DIFF
--- a/translate/tools/pocount.py
+++ b/translate/tools/pocount.py
@@ -153,7 +153,7 @@ def calcstats(filename):
     try:
         store = factory.getobject(filename)
     except ValueError as e:
-        logger.warning(f"Error in {filename}: {e}")
+        logger.warning("Error in %s: %s", filename, e)
         return {}
 
     units = [unit for unit in store.units if unit.istranslatable()]


### PR DESCRIPTION
when working Fedora Linux community stats, only for Fedora 43, there is 227 830 po files on which I use calstats
Having the filename saves me a bit of time to find issues ;)