### PR TITLE
chore: drop support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         requirements: [latest]
         python-version:
-        - '3.10'
         - '3.11'
         - '3.12'
         - '3.13'
@@ -29,7 +28,7 @@ jobs:
         - macos-latest
         include:
         - requirements: minimal
-          python-version: '3.10'
+          python-version: '3.11'
           os: ubuntu-latest
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ classifiers = [
   "Operating System :: Unix",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -80,7 +79,7 @@ keywords = [
 license = "GPL-2.0-or-later"
 license-files = ["COPYING"]
 name = "translate-toolkit"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [project.optional-dependencies]
 all = [

--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -584,7 +584,7 @@ class TranslationChecker(UnitChecker):
                 try:
                     if not test(self.str1, str(pluralform)):
                         filterresult = False
-                except FilterFailure as e:  # noqa: PERF203
+                except FilterFailure as e:
                     filterresult = False
                     filtermessages.extend(e.messages)
 

--- a/translate/storage/tiki.py
+++ b/translate/storage/tiki.py
@@ -146,7 +146,7 @@ class TikiStore(base.TranslationStore):
     @staticmethod
     def _tiki_header():
         """Returns a tiki-file header string."""
-        return f"<?php // -*- coding:utf-8 -*-\n// Generated from po2tiki on {datetime.datetime.now(tz=datetime.timezone.utc)}\n\n$lang=Array(\n"
+        return f"<?php // -*- coding:utf-8 -*-\n// Generated from po2tiki on {datetime.datetime.now(tz=datetime.UTC)}\n\n$lang=Array(\n"
 
     @staticmethod
     def _tiki_footer():


### PR DESCRIPTION
This allows to use modern type annotation features in the code base.