### PR TITLE
fix(json): add missing type annotation

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -79,6 +79,7 @@ from typing import (
     Any,
     BinaryIO,
     ClassVar,
+    NotRequired,
     TextIO,
     TypedDict,
     cast,
@@ -169,6 +170,7 @@ class DumpArgsType(TypedDict):
     separators: tuple[str, ...]
     indent: int
     ensure_ascii: bool
+    sort_keys: NotRequired[bool]
 
 
 class JsonFile(base.DictStore):


### PR DESCRIPTION
The sort_keys is not used by default, but is available.