### PR TITLE
chore: add type checking ignores

### DIFF
--- a/docs/_ext/translate_docs.py
+++ b/docs/_ext/translate_docs.py
@@ -23,6 +23,6 @@ import docutils
 
 def setup(app):
     # :opt: to mark options -P --pot and options values --progress=dots
-    app.add_generic_role(name="opt", nodeclass=docutils.nodes.literal)
+    app.add_generic_role(name="opt", nodeclass=docutils.nodes.literal)  # ty:ignore[possibly-missing-attribute]
 
     return {"parallel_read_safe": True}

--- a/tests/odf_xliff/test_odf_xliff.py
+++ b/tests/odf_xliff/test_odf_xliff.py
@@ -46,7 +46,7 @@ def xliff___eq__(self, other):
     return self.units == other.units
 
 
-xliff.xlifffile.__eq__ = xliff___eq__
+xliff.xlifffile.__eq__ = xliff___eq__  # ty:ignore[invalid-assignment]
 
 
 def print_diff(store1, store2) -> None:

--- a/tests/translate/convert/test_convert.py
+++ b/tests/translate/convert/test_convert.py
@@ -110,7 +110,7 @@ class TestConvertCommand:
         print(help_lines)
 
         # summary documentation
-        convertsummary = self.convertmodule.__doc__.split("\n", maxsplit=1)[0]
+        convertsummary = self.convertmodule.__doc__.split("\n", maxsplit=1)[0]  # ty:ignore[possibly-missing-attribute]
         # the convertsummary might be wrapped. this will probably unwrap it
         assert convertsummary in " ".join(help_lines)
 

--- a/tests/translate/convert/test_dtd2po.py
+++ b/tests/translate/convert/test_dtd2po.py
@@ -345,7 +345,7 @@ Some other text
 <!ENTITY useAutoScroll.accesskey         "a">"""
         pofile = self.dtd2po(dtdlanguage, dtdtemplate)
         print(pofile)
-        expected_target = "使用自動捲動(&Autoscrolling)".decode("utf-8")
+        expected_target = "使用自動捲動(&Autoscrolling)".decode("utf-8")  # ty:ignore[unresolved-attribute]
         assert pofile.units[1].target == expected_target
         # We assume that accesskeys with no associated key should be done as follows "XXXX (&A)"
         # TODO - check that we can unfold this from PO -> DTD
@@ -353,7 +353,7 @@ Some other text
 <!ENTITY useAutoScroll.accesskey         "a">"""
         pofile = self.dtd2po(dtdlanguage, dtdtemplate)
         print(pofile)
-        assert pofile.units[1].target == "使用自動捲動 (&A)".decode("utf-8")
+        assert pofile.units[1].target == "使用自動捲動 (&A)".decode("utf-8")  # ty:ignore[unresolved-attribute]
 
     def test_exclude_entity_includes(self) -> None:
         """Test that we don't turn an include into a translatable string."""

--- a/tests/translate/convert/test_po2php.py
+++ b/tests/translate/convert/test_po2php.py
@@ -14,7 +14,7 @@ class TestPO2Php:
         """Helper that converts po source to .php source without requiring files."""
         inputfile = BytesIO(posource.encode())
         inputpo = po.pofile(inputfile)
-        convertor = po2php.po2php()
+        convertor = po2php.po2php()  # ty:ignore[unresolved-attribute]
         return convertor.convertstore(inputpo)
 
     @staticmethod
@@ -427,7 +427,7 @@ return array(
         posource = ""
         proptemplate = "# A comment\n"
         propexpected = proptemplate
-        propfile = self.merge2prop(proptemplate, posource)
+        propfile = self.merge2prop(proptemplate, posource)  # ty:ignore[unresolved-attribute]
         print(propfile)
         assert propfile == [propexpected]
 

--- a/tests/translate/convert/test_po2prop.py
+++ b/tests/translate/convert/test_po2prop.py
@@ -12,7 +12,7 @@ class TestPO2Prop:
         """Helper that converts po source to .properties source without requiring files."""
         inputfile = BytesIO(posource.encode())
         inputpo = po.pofile(inputfile)
-        convertor = po2prop.po2prop()
+        convertor = po2prop.po2prop()  # ty:ignore[unresolved-attribute]
         return convertor.convertstore(inputpo)
 
     @staticmethod

--- a/tests/translate/convert/test_po2sub.py
+++ b/tests/translate/convert/test_po2sub.py
@@ -16,8 +16,8 @@ class TestPO2Sub:
         """Helper that converts po source to subtitle source without requiring files."""
         inputfile = BytesIO(posource.encode())
         inputpo = po.pofile(inputfile)
-        convertor = po2sub.po2sub()
-        outputsub = convertor.convert_store(inputpo)
+        convertor = po2sub.po2sub()  # ty:ignore[missing-argument]
+        outputsub = convertor.convert_store(inputpo)  # ty:ignore[too-many-positional-arguments]
         return outputsub.decode("utf-8")
 
     @staticmethod

--- a/tests/translate/convert/test_po2tmx.py
+++ b/tests/translate/convert/test_po2tmx.py
@@ -13,7 +13,7 @@ class TestPO2TMX:
         """Helper that converts po source to tmx source without requiring files."""
         inputfile = BytesIO(posource.encode("utf-8"))
         outputfile = BytesIO()
-        outputfile.tmxfile = tmx.tmxfile(inputfile=None, sourcelanguage=sourcelanguage)
+        outputfile.tmxfile = tmx.tmxfile(inputfile=None, sourcelanguage=sourcelanguage)  # ty:ignore[unresolved-attribute]
         po2tmx.convertpo(
             inputfile,
             outputfile,
@@ -22,7 +22,7 @@ class TestPO2TMX:
             targetlanguage=targetlanguage,
             comment=comment,
         )
-        return outputfile.tmxfile
+        return outputfile.tmxfile  # ty:ignore[unresolved-attribute]
 
     def test_basic(self) -> None:
         minipo = r"""# Afrikaans translation of program ABC

--- a/tests/translate/convert/test_prop2mozfunny.py
+++ b/tests/translate/convert/test_prop2mozfunny.py
@@ -7,7 +7,7 @@ class TestPO2Prop:
     @staticmethod
     def merge2inc(incsource, posource):
         """Helper that merges po translations to .inc source without requiring files."""
-        inputfile = BytesIO(posource.encode("utf-8") if posource else None)
+        inputfile = BytesIO(posource.encode("utf-8") if posource else None)  # ty:ignore[invalid-argument-type]
         templatefile = BytesIO(incsource.encode("utf-8"))
         outputfile = BytesIO()
         result = prop2mozfunny.po2inc(inputfile, outputfile, templatefile)

--- a/tests/translate/filters/test_checks.py
+++ b/tests/translate/filters/test_checks.py
@@ -203,27 +203,27 @@ def test_acceleratedvariables() -> None:
     """Test for accelerated variables."""
     # FIXME: disabled since acceleratedvariables has been removed, but these checks are still needed
     mozillachecker = checks.MozillaChecker()
-    assert fails(mozillachecker.acceleratedvariables, "%S &Options", "&%S Ikhetho")
-    assert passes(mozillachecker.acceleratedvariables, "%S &Options", "%S &Ikhetho")
+    assert fails(mozillachecker.acceleratedvariables, "%S &Options", "&%S Ikhetho")  # ty:ignore[unresolved-attribute]
+    assert passes(mozillachecker.acceleratedvariables, "%S &Options", "%S &Ikhetho")  # ty:ignore[unresolved-attribute]
     ooochecker = checks.OpenOfficeChecker()
     assert fails(
-        ooochecker.acceleratedvariables,
+        ooochecker.acceleratedvariables,  # ty:ignore[unresolved-attribute]
         "%PRODUCTNAME% ~Options",
         "~%PRODUCTNAME% Ikhetho",
     )
     assert passes(
-        ooochecker.acceleratedvariables,
+        ooochecker.acceleratedvariables,  # ty:ignore[unresolved-attribute]
         "%PRODUCTNAME% ~Options",
         "%PRODUCTNAME% ~Ikhetho",
     )
     lochecker = checks.LibreOfficeChecker()
     assert fails(
-        lochecker.acceleratedvariables,
+        lochecker.acceleratedvariables,  # ty:ignore[unresolved-attribute]
         "%PRODUCTNAME% ~Options",
         "~%PRODUCTNAME% Ikhetho",
     )
     assert passes(
-        lochecker.acceleratedvariables,
+        lochecker.acceleratedvariables,  # ty:ignore[unresolved-attribute]
         "%PRODUCTNAME% ~Options",
         "%PRODUCTNAME% ~Ikhetho",
     )
@@ -1427,7 +1427,7 @@ def test_simplecaps() -> None:
 
 
 @mark.skipif(
-    not spelling.available or not spelling._get_checker("af"),
+    not spelling.available or not spelling._get_checker("af"),  # ty:ignore[possibly-missing-attribute]
     reason="Spell checking for af is not available",
 )
 def test_spellcheck() -> None:

--- a/tests/translate/filters/test_pofilter.py
+++ b/tests/translate/filters/test_pofilter.py
@@ -23,7 +23,7 @@ class BaseTestFilter:
         """Helper that parses xliff file content without requiring files."""
         dummyfile = BytesIO(filetext.encode())
         dummyfile.name = self.filename
-        return factory.getobject(dummyfile)
+        return factory.getobject(dummyfile)  # ty:ignore[invalid-argument-type]
 
     def filter(self, translationstore, checkerconfig=None, cmdlineoptions=None):
         """
@@ -111,7 +111,7 @@ class BaseTestFilter:
 
         # Re-initialize the translation store object in order to get an unfuzzy
         # unit with no filter notes.
-        self.setup_method(self)
+        self.setup_method(self)  # ty:ignore[unresolved-attribute]
 
         filter_result = self.filter(self.translationstore, cmdlineoptions=["--fuzzy"])
         assert headerless_len(filter_result.units) == 0
@@ -131,7 +131,7 @@ class BaseTestFilter:
         assert headerless_len(filter_result.units) == 0
 
         # Re-initialize the translation store object.
-        self.setup_method(self)
+        self.setup_method(self)  # ty:ignore[unresolved-attribute]
 
         filter_result = self.filter(self.translationstore, cmdlineoptions=["--review"])
         assert headerless_len(filter_result.units) == 0

--- a/tests/translate/misc/test_multistring.py
+++ b/tests/translate/misc/test_multistring.py
@@ -19,9 +19,9 @@ class TestMultistring:
         with pytest.raises(ValueError):
             multistring([])
         with pytest.raises(TypeError):
-            multistring([1])
+            multistring([1])  # ty:ignore[invalid-argument-type]
         with pytest.raises(TypeError):
-            multistring(["one", None])
+            multistring(["one", None])  # ty:ignore[invalid-argument-type]
 
     def test_repr(self) -> None:
         s1 = multistring("test")

--- a/tests/translate/storage/placeables/test_base.py
+++ b/tests/translate/storage/placeables/test_base.py
@@ -41,17 +41,17 @@ class TestStringElem:
         assert str(self.elem.sub[2]) == "&brandLong;"
         assert str(self.elem.sub[3]) == "</a>"
 
-        assert len(self.elem.sub[0].sub) == 1
-        assert self.elem.sub[0].sub[0] == "Ģët "
-        assert len(self.elem.sub[1].sub) == 1
+        assert len(self.elem.sub[0].sub) == 1  # ty:ignore[possibly-missing-attribute]
+        assert self.elem.sub[0].sub[0] == "Ģët "  # ty:ignore[possibly-missing-attribute]
+        assert len(self.elem.sub[1].sub) == 1  # ty:ignore[possibly-missing-attribute]
         assert (
-            self.elem.sub[1].sub[0]
+            self.elem.sub[1].sub[0]  # ty:ignore[possibly-missing-attribute]
             == '<a href="http://www.example.com" alt="Ģët &brand;!">'
         )
-        assert len(self.elem.sub[2].sub) == 1
-        assert self.elem.sub[2].sub[0] == "&brandLong;"
-        assert len(self.elem.sub[3].sub) == 1
-        assert self.elem.sub[3].sub[0] == "</a>"
+        assert len(self.elem.sub[2].sub) == 1  # ty:ignore[possibly-missing-attribute]
+        assert self.elem.sub[2].sub[0] == "&brandLong;"  # ty:ignore[possibly-missing-attribute]
+        assert len(self.elem.sub[3].sub) == 1  # ty:ignore[possibly-missing-attribute]
+        assert self.elem.sub[3].sub[0] == "</a>"  # ty:ignore[possibly-missing-attribute]
 
     def test_add(self) -> None:
         assert f"{self.elem} " == f"{self.ORIGSTR} "
@@ -180,7 +180,7 @@ class TestStringElem:
 
     def test_isleaf(self) -> None:
         for child in self.elem.sub:
-            assert child.isleaf()
+            assert child.isleaf()  # ty:ignore[possibly-missing-attribute]
 
     def test_prune(self) -> None:
         elem = StringElem("foo")

--- a/tests/translate/storage/placeables/test_terminology.py
+++ b/tests/translate/storage/placeables/test_terminology.py
@@ -53,7 +53,7 @@ msgstr "lêernaam"
         assert isinstance(tree.sub[2], general.XMLTagPlaceable)
 
         tree.print_tree()
-        term = tree.sub[3].sub[1]
+        term = tree.sub[3].sub[1]  # ty:ignore[possibly-missing-attribute]
 
         assert isinstance(term, TerminologyPlaceable)
         assert str(term) == self.term_po.getunits()[2].source

--- a/tests/translate/storage/test_csvl10n.py
+++ b/tests/translate/storage/test_csvl10n.py
@@ -314,7 +314,7 @@ GENERAL@2|Notes,"cable, motor, switch"
             result.quoting = csv.QUOTE_NONNUMERIC
             return result
 
-        csv.Sniffer.sniff = patched_sniff
+        csv.Sniffer.sniff = patched_sniff  # ty:ignore[invalid-assignment]
 
         try:
             # This should not raise ValueError about converting string to float
@@ -345,7 +345,7 @@ GENERAL@2|Notes,"cable, motor, switch"
             # The sniffer should have detected single quotes as quotechar
             return result
 
-        csv.Sniffer.sniff = patched_sniff
+        csv.Sniffer.sniff = patched_sniff  # ty:ignore[invalid-assignment]
 
         try:
             # This should not raise ValueError and should correctly parse single-quoted CSV

--- a/tests/translate/storage/test_factory.py
+++ b/tests/translate/storage/test_factory.py
@@ -84,40 +84,40 @@ class BaseTestFactory:
 
     def test_getobject_store(self) -> None:
         """Tests that we get a valid object."""
-        fileobj = givefile(self.filename, self.file_content)
+        fileobj = givefile(self.filename, self.file_content)  # ty:ignore[unresolved-attribute]
         store = factory.getobject(fileobj)
-        assert isinstance(store, self.expected_instance)
+        assert isinstance(store, self.expected_instance)  # ty:ignore[unresolved-attribute]
         assert store == factory.getobject(store)
 
     def test_getobject(self) -> None:
         """Tests that we get a valid object."""
-        fileobj = givefile(self.filename, self.file_content)
+        fileobj = givefile(self.filename, self.file_content)  # ty:ignore[unresolved-attribute]
         store = factory.getobject(fileobj)
-        assert isinstance(store, self.expected_instance)
+        assert isinstance(store, self.expected_instance)  # ty:ignore[unresolved-attribute]
 
     def test_get_noname_object(self) -> None:
         """Tests that we get a valid object from a file object without a name."""
-        fileobj = BytesIO(self.file_content)
+        fileobj = BytesIO(self.file_content)  # ty:ignore[unresolved-attribute]
         assert not hasattr(fileobj, "name")
         store = factory.getobject(fileobj)
-        assert isinstance(store, self.expected_instance)
+        assert isinstance(store, self.expected_instance)  # ty:ignore[unresolved-attribute]
 
     def test_gzfile(self) -> None:
         """Test that we can open a gzip file correctly."""
-        filename = os.path.join(self.testdir, f"{self.filename}.gz")
+        filename = os.path.join(self.testdir, f"{self.filename}.gz")  # ty:ignore[unresolved-attribute]
         gzfile = GzipFile(filename, mode="wb")
-        gzfile.write(self.file_content)
+        gzfile.write(self.file_content)  # ty:ignore[unresolved-attribute]
         gzfile.close()
         store = factory.getobject(filename)
-        assert isinstance(store, self.expected_instance)
+        assert isinstance(store, self.expected_instance)  # ty:ignore[unresolved-attribute]
 
     def test_bz2file(self) -> None:
         """Test that we can open a gzip file correctly."""
-        filename = os.path.join(self.testdir, f"{self.filename}.bz2")
+        filename = os.path.join(self.testdir, f"{self.filename}.bz2")  # ty:ignore[unresolved-attribute]
         with BZ2File(filename, mode="wb") as bz2file:
-            bz2file.write(self.file_content)
+            bz2file.write(self.file_content)  # ty:ignore[unresolved-attribute]
         store = factory.getobject(filename)
-        assert isinstance(store, self.expected_instance)
+        assert isinstance(store, self.expected_instance)  # ty:ignore[unresolved-attribute]
 
     def test_directory(self) -> None:
         """Test that a directory is correctly detected."""

--- a/tests/translate/storage/test_markdown.py
+++ b/tests/translate/storage/test_markdown.py
@@ -413,8 +413,8 @@ class TestMarkdownTranslationUnitExtractionAndTranslation(TestCase):
         assert content == fragments[2:3]
         assert trailer == fragments[3:5]
 
-        fragments[0].important = True
-        fragments[4].important = True
+        fragments[0].important = True  # ty:ignore[invalid-assignment]
+        fragments[4].important = True  # ty:ignore[invalid-assignment]
         (
             leader,
             content,

--- a/tests/translate/storage/test_mo.py
+++ b/tests/translate/storage/test_mo.py
@@ -537,7 +537,7 @@ class TestMOFile(test_base.TestTranslationStore):
             finally:
                 sys.argv = argv
 
-            store = factory.getobject(BytesIO(posource))
+            store = factory.getobject(BytesIO(posource))  # ty:ignore[invalid-argument-type]
             if store.isempty() and not os.path.exists(MO_POCOMPILE):
                 # pocompile doesn't create MO files for empty PO files, so we
                 # can skip the checks here.

--- a/tests/translate/storage/test_po.py
+++ b/tests/translate/storage/test_po.py
@@ -274,14 +274,14 @@ class TestPOFile(test_base.TestTranslationStore):
         for version, output in versions:
             if actual_version >= version:
                 print(
-                    f"Detected gettext {'.'.join(map(str, version))} or newer ({actual_version})"
+                    f"Detected gettext {'.'.join(map(str, version))} or newer ({actual_version})"  # ty:ignore[invalid-argument-type]
                 )
                 return output
 
         # Fallback to the oldest version
         oldest_version, oldest_output = versions[-1]
         print(
-            f"Detected gettext older than {'.'.join(map(str, oldest_version))} ({actual_version})"
+            f"Detected gettext older than {'.'.join(map(str, oldest_version))} ({actual_version})"  # ty:ignore[invalid-argument-type]
         )
         return oldest_output
 

--- a/tests/translate/storage/test_qm.py
+++ b/tests/translate/storage/test_qm.py
@@ -20,24 +20,24 @@ class TestQtFile(test_base.TestTranslationStore):
     def test_save(self) -> None:
         # QM does not implement saving
         with pytest.raises(TypeError):
-            self.StoreClass.savefile(self.StoreClass())
+            self.StoreClass.savefile(self.StoreClass())  # ty:ignore[missing-argument]
 
     def test_files(self) -> None:
         # QM does not implement saving
         with pytest.raises(TypeError):
-            self.StoreClass.savefile(self.StoreClass())
+            self.StoreClass.savefile(self.StoreClass())  # ty:ignore[missing-argument]
 
     def test_nonascii(self) -> None:
         # QM does not implement serialising
         with pytest.raises(TypeError):
-            self.StoreClass.serialize(self.StoreClass())
+            self.StoreClass.serialize(self.StoreClass())  # ty:ignore[missing-argument]
 
     def test_add(self) -> None:
         # QM does not implement serialising
         with pytest.raises(TypeError):
-            self.StoreClass.serialize(self.StoreClass())
+            self.StoreClass.serialize(self.StoreClass())  # ty:ignore[missing-argument]
 
     def test_remove(self) -> None:
         # QM does not implement serialising
         with pytest.raises(TypeError):
-            self.StoreClass.serialize(self.StoreClass())
+            self.StoreClass.serialize(self.StoreClass())  # ty:ignore[missing-argument]

--- a/tests/translate/storage/test_subtitles.py
+++ b/tests/translate/storage/test_subtitles.py
@@ -30,7 +30,7 @@ class TestSubtitleUnit(TestSubRipFile):
 
     @pytest.mark.xfail(reason="Not Implemented")
     def test_note_sanity(self) -> None:
-        super().test_note_sanity()
+        super().test_note_sanity()  # ty:ignore[unresolved-attribute]
 
 
 class TestMicroDVDFile(TestSubRipFile):

--- a/tests/translate/storage/test_xliff2.py
+++ b/tests/translate/storage/test_xliff2.py
@@ -47,23 +47,23 @@ class TestXLIFF2Unit(test_base.TestTranslationUnit):
         assert unit.istranslatable()
         unit.marktranslatable(False)
         assert not unit.istranslatable()
-        assert unit.getunitelement().get("translate") == "no"
+        assert unit.getunitelement().get("translate") == "no"  # ty:ignore[possibly-missing-attribute]
 
         # Test marking as translatable
         unit.marktranslatable(True)
         assert unit.istranslatable()
-        assert unit.getunitelement().get("translate") == "yes"
+        assert unit.getunitelement().get("translate") == "yes"  # ty:ignore[possibly-missing-attribute]
 
         # Test that marking as translatable again when already translatable sets to "yes"
         unit.marktranslatable(True)
         assert unit.istranslatable()
-        assert unit.getunitelement().get("translate") == "yes"
+        assert unit.getunitelement().get("translate") == "yes"  # ty:ignore[possibly-missing-attribute]
 
         # Test that marking as untranslatable when already untranslatable doesn't change it
         unit.marktranslatable(False)
         unit.marktranslatable(False)
         assert not unit.istranslatable()
-        assert unit.getunitelement().get("translate") == "no"
+        assert unit.getunitelement().get("translate") == "no"  # ty:ignore[possibly-missing-attribute]
 
 
 class TestXLIFF2file(test_base.TestTranslationStore):

--- a/tests/translate/storage/test_yaml.py
+++ b/tests/translate/storage/test_yaml.py
@@ -349,7 +349,7 @@ foo: "Hello \n World."
         )
 
     @pytest.mark.skipif(
-        ruamel.yaml.version_info < (0, 16, 6),
+        ruamel.yaml.version_info < (0, 16, 6),  # ty:ignore[unsupported-operator]
         reason="Empty keys serialization broken in ruamel.yaml<0.16.6",
     )
     def test_empty_key(self) -> None:

--- a/tests/translate/tools/test_pocount.py
+++ b/tests/translate/tools/test_pocount.py
@@ -231,7 +231,7 @@ def test_error_cases(opts, expected) -> None:
         capture_output=True,
         text=True,
         check=False,
-    )
+    )  # ty:ignore[no-matching-overload]
 
     assert expected in result.stderr
 

--- a/tests/translate/tools/test_poterminology.py
+++ b/tests/translate/tools/test_poterminology.py
@@ -15,7 +15,7 @@ class TestPOTerminology:
         assert extractor.extract_terms() == {}
 
         with open(sample_po_file, "rb") as fh:
-            inputfile = factory.getobject(fh)
+            inputfile = factory.getobject(fh)  # ty:ignore[invalid-argument-type]
         extractor.processunits(inputfile.units, str(sample_po_file))
         terms = extractor.extract_terms()
         assert len(terms) > 50
@@ -29,7 +29,7 @@ class TestPOTerminology:
         extractor = poterminology.TerminologyExtractor()
 
         with open(sample_po_file, "rb") as fh:
-            inputfile = factory.getobject(fh)
+            inputfile = factory.getobject(fh)  # ty:ignore[invalid-argument-type]
 
         # Process units
         extractor.processunits(inputfile.units, str(sample_po_file))

--- a/translate/convert/csv2po.py
+++ b/translate/convert/csv2po.py
@@ -81,7 +81,7 @@ class csv2po:
 
     def makeindex(self) -> None:
         """Makes indexes required for searching..."""
-        for pounit in self.pofile.units:
+        for pounit in self.pofile.units:  # ty:ignore[possibly-missing-attribute]
             joinedcomment = " ".join(pounit.getlocations())
             source = pounit.source
             # the definitive way to match is by source comment (joinedcomment)

--- a/translate/convert/ical2po.py
+++ b/translate/convert/ical2po.py
@@ -73,10 +73,10 @@ class ical2po:
 
     def merge_stores(self) -> None:
         """Convert two source format files to a target format file."""
-        self.extraction_msg = f"extracted from {self.template_store.filename}, {self.source_store.filename}"
+        self.extraction_msg = f"extracted from {self.template_store.filename}, {self.source_store.filename}"  # ty:ignore[possibly-missing-attribute]
 
         self.source_store.makeindex()
-        for template_unit in self.template_store.units:
+        for template_unit in self.template_store.units:  # ty:ignore[possibly-missing-attribute]
             target_unit = self.convert_unit(template_unit)
 
             template_unit_name = "".join(template_unit.getlocations())

--- a/translate/convert/ini2po.py
+++ b/translate/convert/ini2po.py
@@ -79,10 +79,10 @@ class ini2po:
 
     def merge_stores(self) -> None:
         """Convert two source format files to a target format file."""
-        self.extraction_msg = f"extracted from {self.template_store.filename}, {self.source_store.filename}"
+        self.extraction_msg = f"extracted from {self.template_store.filename}, {self.source_store.filename}"  # ty:ignore[possibly-missing-attribute]
 
         self.source_store.makeindex()
-        for template_unit in self.template_store.units:
+        for template_unit in self.template_store.units:  # ty:ignore[possibly-missing-attribute]
             target_unit = self.convert_unit(template_unit)
 
             template_unit_name = "".join(template_unit.getlocations())

--- a/translate/convert/odf2xliff.py
+++ b/translate/convert/odf2xliff.py
@@ -38,7 +38,7 @@ def convertodf(inputfile, outputfile, templates) -> bool:
     store = factory.getobject(outputfile)
 
     try:
-        store.setfilename(store.getfilenode("NoName"), inputfile.name)
+        store.setfilename(store.getfilenode("NoName"), inputfile.name)  # ty:ignore[unresolved-attribute]
     except Exception:
         print("couldn't set origin filename")  # noqa: T201
         sys.exit()

--- a/translate/convert/oo2po.py
+++ b/translate/convert/oo2po.py
@@ -145,7 +145,7 @@ def convertoo(
     inputstore.parse(inputfile.read())
     if not sourcelanguage:
         testlangtype = targetlanguage or (inputstore and inputstore.languages[0]) or ""
-        sourcelanguage = "01" if testlangtype.isdigit() else "en-US"
+        sourcelanguage = "01" if testlangtype.isdigit() else "en-US"  # ty:ignore[possibly-missing-attribute]
     if sourcelanguage not in inputstore.languages:
         logger.warning(
             "sourcelanguage '%s' not found in inputfile '%s' (contains %s)",

--- a/translate/convert/oo2xliff.py
+++ b/translate/convert/oo2xliff.py
@@ -137,7 +137,7 @@ def convertoo(
     inputstore.parse(inputfile.read())
     if not sourcelanguage:
         testlangtype = targetlanguage or (inputstore and inputstore.languages[0]) or ""
-        sourcelanguage = "01" if testlangtype.isdigit() else "en-US"
+        sourcelanguage = "01" if testlangtype.isdigit() else "en-US"  # ty:ignore[possibly-missing-attribute]
     if sourcelanguage not in inputstore.languages:
         logger.warning(
             "sourcelanguage '%s' not found in inputfile '%s' (contains %s)",

--- a/translate/convert/php2po.py
+++ b/translate/convert/php2po.py
@@ -73,10 +73,10 @@ class php2po:
 
     def merge_stores(self) -> None:
         """Convert two source format files to a target format file."""
-        self.extraction_msg = f"extracted from {self.template_store.filename}, {self.source_store.filename}"
+        self.extraction_msg = f"extracted from {self.template_store.filename}, {self.source_store.filename}"  # ty:ignore[possibly-missing-attribute]
 
         self.source_store.makeindex()
-        for template_unit in self.template_store.units:
+        for template_unit in self.template_store.units:  # ty:ignore[possibly-missing-attribute]
             target_unit = self.convert_unit(template_unit)
 
             add_translation = (

--- a/translate/convert/po2dtd.py
+++ b/translate/convert/po2dtd.py
@@ -34,7 +34,7 @@ def dtdwarning(message, category, filename, lineno, line=None) -> str:
     return f"Warning: {message}\n"
 
 
-warnings.formatwarning = dtdwarning
+warnings.formatwarning = dtdwarning  # ty:ignore[invalid-assignment]
 
 
 def applytranslation(entity, dtdunit, inputunit, mixedentities) -> None:

--- a/translate/convert/po2idml.py
+++ b/translate/convert/po2idml.py
@@ -117,7 +117,7 @@ def translate_idml(template, input_file, translatable_files):
 
                 # Copy the children to the XLIFF unit's source or target node.
                 fake_node = etree.fromstring(fake_string)
-                node.extend(fake_node.getchildren())
+                node.extend(fake_node.getchildren())  # ty:ignore[deprecated]
 
                 return node
 
@@ -165,7 +165,10 @@ def write_idml(template_zip, output_file, dom_trees) -> None:
         output_zip.writestr(
             filename,
             etree.tostring(
-                dom_tree, encoding="UTF-8", xml_declaration=True, standalone="yes"
+                dom_tree,
+                encoding="UTF-8",
+                xml_declaration=True,
+                standalone="yes",  # ty:ignore[invalid-argument-type]
             ),
         )
 

--- a/translate/convert/po2moz.py
+++ b/translate/convert/po2moz.py
@@ -52,7 +52,7 @@ class MozConvertOptionParser(convert.ConvertOptionParser):
 
     def recursiveprocess(self, options):
         """Recurse through directories and convert files."""
-        self.replacer.replacestring = options.locale
+        self.replacer.replacestring = options.locale  # ty:ignore[unresolved-attribute]
         return super().recursiveprocess(options)
 
 
@@ -90,7 +90,7 @@ def main(argv=None) -> None:
     parser.add_threshold_option()
     parser.add_fuzzy_option()
     parser.add_remove_untranslated_option()
-    parser.replacer = replacer
+    parser.replacer = replacer  # ty:ignore[unresolved-attribute]
     parser.run(argv)
 
 

--- a/translate/convert/po2rc.py
+++ b/translate/convert/po2rc.py
@@ -49,7 +49,7 @@ class rerc:
     def __init__(self, templatefile, charset="utf-8", lang=None, sublang=None) -> None:
         self.templatecontent = templatefile.read()
         self.templatestore = rcfile()
-        self.templatestore.charset = charset
+        self.templatestore.charset = charset  # ty:ignore[unresolved-attribute]
         self.templatestore.parse(self.templatecontent)
         self.inputdict = {}
         self.charset = charset

--- a/translate/convert/po2symb.py
+++ b/translate/convert/po2symb.py
@@ -114,7 +114,7 @@ def convert_symbian(
 ) -> int:
     store = factory.getobject(input_file)
     location_index = build_location_index(store)
-    header_index = {"Author": store.parseheader()["Last-Translator"]}
+    header_index = {"Author": store.parseheader()["Last-Translator"]}  # ty:ignore[unresolved-attribute]
     output = write_symbian(template_file, header_index, location_index)
     for line in output:
         output_file.write(line)

--- a/translate/convert/po2tmx.py
+++ b/translate/convert/po2tmx.py
@@ -111,8 +111,8 @@ class tmxmultifile:
             pass
 
         outputfile = wStringIO.CatchStringOutput(onclose)
-        outputfile.filename = subfile
-        outputfile.tmxfile = self.tmxfile
+        outputfile.filename = subfile  # ty:ignore[unresolved-attribute]
+        outputfile.tmxfile = self.tmxfile  # ty:ignore[unresolved-attribute]
         return outputfile
 
 

--- a/translate/convert/po2txt.py
+++ b/translate/convert/po2txt.py
@@ -93,7 +93,7 @@ class po2txt:
         target format.
         """
         # Parse the template file using TxtFile to segment it the same way txt2po does
-        self.template_file.seek(0)
+        self.template_file.seek(0)  # ty:ignore[possibly-missing-attribute]
         template_store = txt.TxtFile(
             self.template_file,
             encoding=self.encoding,

--- a/translate/convert/po2wordfast.py
+++ b/translate/convert/po2wordfast.py
@@ -74,8 +74,8 @@ class wfmultifile:
             pass
 
         outputfile = wStringIO.CatchStringOutput(onclose)
-        outputfile.filename = subfile
-        outputfile.wffile = self.wffile
+        outputfile.filename = subfile  # ty:ignore[unresolved-attribute]
+        outputfile.wffile = self.wffile  # ty:ignore[unresolved-attribute]
         return outputfile
 
 

--- a/translate/convert/symb2po.py
+++ b/translate/convert/symb2po.py
@@ -88,7 +88,7 @@ def get_template_dict(template_file):
 
 
 def build_output(units, template_header, template_dict):
-    output_store = factory.classes["po"]()
+    output_store = factory.classes["po"]()  # ty:ignore[unresolved-attribute]
     ignore = {"r_string_languagegroup_name"}
     header_entries = {
         "Last-Translator": template_header.get("Author", ""),

--- a/translate/convert/toml2po.py
+++ b/translate/convert/toml2po.py
@@ -87,10 +87,10 @@ class toml2po:
 
         Template provides the structure, source file provides translations.
         """
-        self.extraction_msg = f"extracted from {self.template_store.filename}, {self.source_store.filename}"
+        self.extraction_msg = f"extracted from {self.template_store.filename}, {self.source_store.filename}"  # ty:ignore[possibly-missing-attribute]
 
         self.source_store.makeindex()
-        for template_unit in self.template_store.units:
+        for template_unit in self.template_store.units:  # ty:ignore[possibly-missing-attribute]
             target_unit = self.convert_unit(template_unit)
 
             for location in target_unit.getlocations():

--- a/translate/convert/web2py2po.py
+++ b/translate/convert/web2py2po.py
@@ -45,7 +45,7 @@ class web2py2po:
         return pounit
 
     def convertstore(self, mydict):
-        targetheader = self.mypofile.header()
+        targetheader = self.mypofile.header()  # ty:ignore[possibly-missing-attribute]
         targetheader.addnote("extracted from web2py", "developer")
 
         for source_str in mydict:
@@ -54,9 +54,9 @@ class web2py2po:
                 # a convention with new (untranslated) web2py files
                 target_str = ""
             pounit = self.convertunit(source_str, target_str)
-            self.mypofile.addunit(pounit)
+            self.mypofile.addunit(pounit)  # ty:ignore[possibly-missing-attribute]
 
-        self.mypofile.removeduplicates(self.duplicatestyle)
+        self.mypofile.removeduplicates(self.duplicatestyle)  # ty:ignore[possibly-missing-attribute]
 
         return self.mypofile
 

--- a/translate/convert/yaml2po.py
+++ b/translate/convert/yaml2po.py
@@ -73,10 +73,10 @@ class yaml2po:
 
     def merge_stores(self) -> None:
         """Convert two source format files to a target format file."""
-        self.extraction_msg = f"extracted from {self.template_store.filename}, {self.source_store.filename}"
+        self.extraction_msg = f"extracted from {self.template_store.filename}, {self.source_store.filename}"  # ty:ignore[possibly-missing-attribute]
 
         self.source_store.makeindex()
-        for template_unit in self.template_store.units:
+        for template_unit in self.template_store.units:  # ty:ignore[possibly-missing-attribute]
             target_unit = self.convert_unit(template_unit)
 
             for location in target_unit.getlocations():

--- a/translate/filters/helpers.py
+++ b/translate/filters/helpers.py
@@ -60,7 +60,7 @@ def filtertestmethod(testmethod, strfilter):
         return testmethod(strfilter(str1), strfilter(str2))
 
     filteredmethod.__doc__ = testmethod.__doc__
-    filteredmethod.name = getattr(testmethod, "name", testmethod.__name__)
+    filteredmethod.name = getattr(testmethod, "name", testmethod.__name__)  # ty:ignore[unresolved-attribute]
     return filteredmethod
 
 
@@ -78,5 +78,5 @@ def multifiltertestmethod(testmethod, strfilters):
         return testmethod(multifilter(str1, strfilters), multifilter(str2, strfilters))
 
     filteredmethod.__doc__ = testmethod.__doc__
-    filteredmethod.name = getattr(testmethod, "name", testmethod.__name__)
+    filteredmethod.name = getattr(testmethod, "name", testmethod.__name__)  # ty:ignore[unresolved-attribute]
     return filteredmethod

--- a/translate/filters/pofilter.py
+++ b/translate/filters/pofilter.py
@@ -49,7 +49,7 @@ class pocheckfilter:
             excludefilters=options.excludefilters,
             limitfilters=options.limitfilters,
             checkerclasses=checkerclasses,
-            languagecode=checkerconfig.targetlanguage,
+            languagecode=checkerconfig.targetlanguage,  # ty:ignore[possibly-missing-attribute]
         )
         self.options = options
 
@@ -224,7 +224,7 @@ class FilterOptionParser(optrecurse.RecursiveOptionParser):
 def runfilter(inputfile, outputfile, templatefile, checkfilter=None) -> int:
     """Reads in inputfile, filters using checkfilter, writes to outputfile."""
     fromfile = factory.getobject(inputfile)
-    tofile = checkfilter.filterfile(fromfile)
+    tofile = checkfilter.filterfile(fromfile)  # ty:ignore[possibly-missing-attribute]
 
     if tofile.isempty():
         return 0
@@ -414,7 +414,7 @@ def cmdlineparser():
     )
 
     parser.passthrough.append("checkfilter")
-    parser.description = f"{__doc__.strip()}\n"
+    parser.description = f"{__doc__.strip()}\n"  # ty:ignore[possibly-missing-attribute]
 
     return parser
 

--- a/translate/filters/prefilters.py
+++ b/translate/filters/prefilters.py
@@ -172,7 +172,7 @@ def filterwordswithpunctuation(str1):
     if "'" not in str1:
         return str1
     occurrences = []
-    for word, replacement in wordswithpunctuation.items():
+    for word, replacement in wordswithpunctuation.items():  # ty:ignore[possibly-missing-attribute]
         occurrences.extend(
             [(pos, word, replacement) for pos in quote.find_all(str1, word)]
         )

--- a/translate/lang/identify.py
+++ b/translate/lang/identify.py
@@ -103,7 +103,7 @@ class LanguageIdentifier:
 
         text = " ".join(
             unit.source
-            for unit in instore[:50]
+            for unit in instore[:50]  # ty:ignore[not-subscriptable]
             if unit.istranslatable() and unit.source
         )
         if not text:
@@ -126,7 +126,7 @@ class LanguageIdentifier:
 
         text = " ".join(
             unit.target
-            for unit in instore[:200]
+            for unit in instore[:200]  # ty:ignore[not-subscriptable]
             if unit.istranslatable() and unit.target
         )
         if not text:

--- a/translate/lang/team.py
+++ b/translate/lang/team.py
@@ -781,4 +781,4 @@ if __name__ == "__main__":
 
     for fname in argv[1:]:
         store = factory.getobject(fname)
-        print(fname, guess_language(store.parseheader().get("Language-Team", "")))  # noqa: T201
+        print(fname, guess_language(store.parseheader().get("Language-Team", "")))  # noqa: T201  # ty:ignore[unresolved-attribute]

--- a/translate/misc/dictutils.py
+++ b/translate/misc/dictutils.py
@@ -63,7 +63,7 @@ class cidict(dict):
         lkey = key.lower()
         return any(akey.lower() == lkey for akey in self.keys())
 
-    def pop(self, key: str):
+    def pop(self, key: str):  # ty:ignore[invalid-method-override]
         if not isinstance(key, str):
             raise TypeError(
                 f"cidict can only have str or unicode as key (got {type(key)!r})"

--- a/translate/misc/multistring.py
+++ b/translate/misc/multistring.py
@@ -72,7 +72,7 @@ class multistring(str):
         strings = [str(self), *self.extra_strings]
         return f"multistring({strings!r})"
 
-    def replace(self, old: str, new: str, count: int = -1) -> multistring:
+    def replace(self, old: str, new: str, count: int = -1) -> multistring:  # ty:ignore[invalid-method-override]
         newstr = multistring(super().replace(old, new, count))
         newstr.extra_strings.extend(
             s.replace(old, new, count) for s in self.extra_strings

--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -174,7 +174,8 @@ class RecursiveOptionParser(optparse.OptionParser):
                 f'.TH {prog} 1 "{formatToolkit(self.version)}" "" "{formatToolkit(self.version)}"\n',
                 ".SH NAME\n",
                 "{} \\- {}\n".format(
-                    self.get_prog_name(), self.description.split("\n\n")[0]
+                    self.get_prog_name(),
+                    self.description.split("\n\n")[0],  # ty:ignore[possibly-missing-attribute]
                 ),
                 ".SH SYNOPSIS\n",
                 ".PP\n",
@@ -184,7 +185,7 @@ class RecursiveOptionParser(optparse.OptionParser):
         usage += " ".join(self.getusageman(option) for option in self.option_list)
         usage += "\\fP"
         result.append(f"{formatprog(usage)}\n")
-        description_lines = self.description.split("\n\n")[1:]
+        description_lines = self.description.split("\n\n")[1:]  # ty:ignore[possibly-missing-attribute]
         if description_lines:
             result.extend(
                 (
@@ -203,7 +204,7 @@ class RecursiveOptionParser(optparse.OptionParser):
                 (
                     ".TP\n",
                     "{}\n".format(str(option).replace("-", "\\-")),
-                    "{}\n".format(option.help.replace("-", "\\-")),
+                    "{}\n".format(option.help.replace("-", "\\-")),  # ty:ignore[possibly-missing-attribute]
                 )
             )
         return "".join(result)

--- a/translate/misc/ourdom.py
+++ b/translate/misc/ourdom.py
@@ -54,7 +54,7 @@ def writexml_helper(self, writer, indent="", addindent="", newl="") -> None:
 
     for a_name in a_names:
         writer.write(f' {a_name}="')
-        minidom._write_data(writer, attrs[a_name].value)
+        minidom._write_data(writer, attrs[a_name].value)  # ty:ignore[unresolved-attribute]
         writer.write('"')
     if self.childNodes:
         # We need to write text nodes without newline and indentation, so
@@ -154,7 +154,7 @@ class Document(minidom.Document):
         return e
 
     def createElementNS(self, namespaceURI, qualifiedName):
-        prefix, _localName = minidom._nssplit(qualifiedName)
+        prefix, _localName = minidom._nssplit(qualifiedName)  # ty:ignore[unresolved-attribute]
         e = Element(qualifiedName, namespaceURI, prefix)
         e.ownerDocument = self
         return e
@@ -170,16 +170,16 @@ class ExpatBuilderNS(expatbuilder.ExpatBuilderNS):
         """Free all data structures used during DOM construction."""
         self.document = theDOMImplementation.createDocument(EMPTY_NAMESPACE, None, None)
         self.curNode = self.document
-        self._elem_info = self.document._elem_info
+        self._elem_info = self.document._elem_info  # ty:ignore[unresolved-attribute]
         self._cdata = False
-        self._initNamespaces()
+        self._initNamespaces()  # ty:ignore[unresolved-attribute]
 
     def start_element_handler(self, name, attributes) -> None:
         # All we want to do is construct our own Element instead of
         # minidom.Element, unfortunately the only way to do this is to
         # copy this whole function from expatbuilder.py
         if " " in name:
-            uri, localname, prefix, qname = expatbuilder._parse_ns_name(self, name)
+            uri, localname, prefix, qname = expatbuilder._parse_ns_name(self, name)  # ty:ignore[unresolved-attribute]
         else:
             uri = EMPTY_NAMESPACE
             qname = name
@@ -187,14 +187,14 @@ class ExpatBuilderNS(expatbuilder.ExpatBuilderNS):
             prefix = EMPTY_PREFIX
         node = Element(qname, uri, prefix, localname)
         node.ownerDocument = self.document
-        expatbuilder._append_child(self.curNode, node)
+        expatbuilder._append_child(self.curNode, node)  # ty:ignore[unresolved-attribute]
         self.curNode = node
 
-        if self._ns_ordered_prefixes:
-            for prefix, uri in self._ns_ordered_prefixes:
+        if self._ns_ordered_prefixes:  # ty:ignore[unresolved-attribute]
+            for prefix, uri in self._ns_ordered_prefixes:  # ty:ignore[unresolved-attribute]
                 if prefix:
                     a = minidom.Attr(
-                        expatbuilder._intern(self, f"xmlns:{prefix}"),
+                        expatbuilder._intern(self, f"xmlns:{prefix}"),  # ty:ignore[unresolved-attribute]
                         XMLNS_NAMESPACE,
                         prefix,
                         "xmlns",
@@ -203,18 +203,18 @@ class ExpatBuilderNS(expatbuilder.ExpatBuilderNS):
                     a = minidom.Attr("xmlns", XMLNS_NAMESPACE, "xmlns", EMPTY_PREFIX)
                 a.value = uri
                 a.ownerDocument = self.document
-                expatbuilder._set_attribute_node(node, a)
-            del self._ns_ordered_prefixes[:]
+                expatbuilder._set_attribute_node(node, a)  # ty:ignore[unresolved-attribute]
+            del self._ns_ordered_prefixes[:]  # ty:ignore[unresolved-attribute]
 
         if attributes:
-            node._ensure_attributes()
-            attrs = node._attrs
-            attrsNS = node._attrsNS
+            node._ensure_attributes()  # ty:ignore[unresolved-attribute]
+            attrs = node._attrs  # ty:ignore[unresolved-attribute]
+            attrsNS = node._attrsNS  # ty:ignore[unresolved-attribute]
             for i in range(0, len(attributes), 2):
                 aname = attributes[i]
                 value = attributes[i + 1]
                 if " " in aname:
-                    uri, localname, prefix, qname = expatbuilder._parse_ns_name(
+                    uri, localname, prefix, qname = expatbuilder._parse_ns_name(  # ty:ignore[unresolved-attribute]
                         self, aname
                     )
                     a = minidom.Attr(qname, uri, localname, prefix)
@@ -237,21 +237,21 @@ class ExpatBuilderNS(expatbuilder.ExpatBuilderNS):
         def end_element_handler(self, name) -> None:
             curNode = self.curNode
             if " " in name:
-                uri, localname, prefix, _qname = expatbuilder._parse_ns_name(self, name)
-                assert curNode.namespaceURI == uri, (
+                uri, localname, prefix, _qname = expatbuilder._parse_ns_name(self, name)  # ty:ignore[unresolved-attribute]
+                assert curNode.namespaceURI == uri, (  # ty:ignore[possibly-missing-attribute]
                     "element stack messed up! (namespace)"
                 )
-                assert curNode.localName == localname
-                assert curNode.prefix == prefix
+                assert curNode.localName == localname  # ty:ignore[possibly-missing-attribute]
+                assert curNode.prefix == prefix  # ty:ignore[possibly-missing-attribute]
             else:
-                assert curNode.nodeName == name, (
+                assert curNode.nodeName == name, (  # ty:ignore[possibly-missing-attribute]
                     "element stack messed up - bad nodeName"
                 )
-                assert curNode.namespaceURI == EMPTY_NAMESPACE, (
+                assert curNode.namespaceURI == EMPTY_NAMESPACE, (  # ty:ignore[possibly-missing-attribute]
                     "element stack messed up - bad namespaceURI"
                 )
-            self.curNode = curNode.parentNode
-            self._finish_end_element(curNode)
+            self.curNode = curNode.parentNode  # ty:ignore[invalid-assignment, possibly-missing-attribute]
+            self._finish_end_element(curNode)  # ty:ignore[unresolved-attribute]
 
 
 # parser methods that use our modified xml classes

--- a/translate/misc/quote.py
+++ b/translate/misc/quote.py
@@ -188,7 +188,7 @@ def extractwithoutquotes(
                     if callable_includeescapes:
                         replace_escape = includeescapes(
                             section[epos : epos + lenescape + 1]
-                        )
+                        )  # ty:ignore[call-non-callable]
                         # TODO: deprecate old method of returning boolean from
                         # includeescape, by removing this if block
                         if not isinstance(replace_escape, str):
@@ -242,7 +242,7 @@ def extractwithoutquotes(
 def _encode_entity_char(char: str, codepoint2name: dict[str, str]) -> str:
     charnum = ord(char)
     if charnum in codepoint2name:
-        return f"&{codepoint2name[charnum]};"
+        return f"&{codepoint2name[charnum]};"  # ty:ignore[invalid-argument-type]
     return char
 
 
@@ -343,7 +343,7 @@ def htmlentityencode(source):
 
     :param unicode source: Source string to encode
     """
-    return entityencode(source, html.entities.codepoint2name)
+    return entityencode(source, html.entities.codepoint2name)  # ty:ignore[invalid-argument-type]
 
 
 def htmlentitydecode(source: str) -> str:
@@ -352,7 +352,7 @@ def htmlentitydecode(source: str) -> str:
 
     :param unicode source: Source string to decode
     """
-    return entitydecode(source, html.entities.name2codepoint)
+    return entitydecode(source, html.entities.name2codepoint)  # ty:ignore[invalid-argument-type]
 
 
 def javapropertiesencode(source: str, encoding: str | None = None) -> str:

--- a/translate/misc/selector.py
+++ b/translate/misc/selector.py
@@ -32,7 +32,7 @@ from wsgiref.util import shift_path_info
 # resolver not essential for basic features
 # FIXME: this library is overkill, simplify
 with contextlib.suppress(ImportError):
-    from resolver import resolve
+    from resolver import resolve  # ty:ignore[unresolved-import]
 
 
 class MappingFileError(Exception):
@@ -408,7 +408,7 @@ class SimpleParser:
         if self.ostart in text:
             parts = self.outermost_optionals_split(text)
             parts = map(self.parse, parts)
-            parts[1::2] = [f"({p})?" for p in parts[1::2]]
+            parts[1::2] = [f"({p})?" for p in parts[1::2]]  # ty:ignore[invalid-assignment, not-subscriptable]
         else:
             parts = [part.split(self.end) for part in text.split(self.start)]
             parts = [y for x in parts for y in x]

--- a/translate/misc/xml_helpers.py
+++ b/translate/misc/xml_helpers.py
@@ -132,7 +132,7 @@ def normalize_xml_space(node, xml_space: str, remove_start: bool = False) -> Non
         node.tail = normalize_space(node.tail)
 
     for child in node:
-        normalize_xml_space(child, remove_start)
+        normalize_xml_space(child, remove_start)  # ty:ignore[invalid-argument-type]
 
 
 def reindent(

--- a/translate/search/match.py
+++ b/translate/search/match.py
@@ -126,8 +126,8 @@ class matcher:
             # some modules (like the native Levenshtein) can't use it.
             if isinstance(candidate.source, multistring):
                 if len(candidate.source.strings) > 1:
-                    simpleunit.orig_source = candidate.source
-                    simpleunit.orig_target = candidate.target
+                    simpleunit.orig_source = candidate.source  # ty:ignore[unresolved-attribute]
+                    simpleunit.orig_target = candidate.target  # ty:ignore[unresolved-attribute]
                 simpleunit.source = str(candidate.source)
                 simpleunit.target = str(candidate.target)
             else:
@@ -138,7 +138,7 @@ class matcher:
             # notes, pot2po adds all previous comments as translator comments
             # in the new po file
             simpleunit.addnote(candidate.getnotes(origin="translator"))
-            simpleunit.fuzzy = candidate.isfuzzy()
+            simpleunit.fuzzy = candidate.isfuzzy()  # ty:ignore[unresolved-attribute]
             self.candidates.units.append(simpleunit)
         if sort:
             self.candidates.units.sort(key=sourcelen, reverse=self.sort_reverse)
@@ -286,7 +286,7 @@ class terminologymatcher(matcher):
         self.addpercentage = False
         self.match_info = {}
 
-    def inittm(self, store) -> None:
+    def inittm(self, store) -> None:  # ty:ignore[invalid-method-override]
         """Normal initialisation, but convert all source strings to lower case."""
         super().inittm(store)
         extras = []
@@ -336,7 +336,7 @@ class terminologymatcher(matcher):
             return []
         text = text.lower()
         comparer = self.comparer
-        comparer.match_info = {}
+        comparer.match_info = {}  # ty:ignore[invalid-assignment]
         match_info = {}
         matches = []
         known = set()
@@ -361,7 +361,7 @@ class terminologymatcher(matcher):
             if (source, cand.target) in known:
                 continue
             if comparer.similarity(text, source, self.MIN_SIMILARITY):
-                match_info[source] = {"pos": comparer.match_info[source]["pos"]}
+                match_info[source] = {"pos": comparer.match_info[source]["pos"]}  # ty:ignore[possibly-missing-attribute]
                 matches.append(cand)
                 known.add((source, cand.target))
 

--- a/translate/services/tmserver.py
+++ b/translate/services/tmserver.py
@@ -137,7 +137,7 @@ class TMServer:
         start_response("200 OK", [("Content-type", "text/plain")])
         data = BytesIO(environ["wsgi.input"].read(int(environ["CONTENT_LENGTH"])))
         data.name = sid
-        store = factory.getobject(data)
+        store = factory.getobject(data)  # ty:ignore[invalid-argument-type]
         count = self.tmdb.add_store(store, slang, tlang)
         response = f"added {count} units from {sid}"
         return [response]

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -227,7 +227,7 @@ class EncodingXMLParser(DecodingXMLParser):
     EMIT_DEPTH = 0
     FOREIGN_DTD = False
 
-    def process_string(self, text: str) -> tuple[str, bool, bool]:
+    def process_string(self, text: str) -> tuple[str, bool, bool]:  # ty:ignore[invalid-method-override]
         return (
             AndroidResourceUnit.escape(text, quote_wrapping_whitespaces=False),
             False,
@@ -286,7 +286,7 @@ class AndroidResourceUnit(base.TranslationUnit):
     def getid(self):
         return self.xmlelement.get("name")
 
-    def setid(self, newid):
+    def setid(self, newid):  # ty:ignore[invalid-method-override]
         return self.xmlelement.set("name", newid)
 
     def getcontext(self):
@@ -445,7 +445,7 @@ class AndroidResourceUnit(base.TranslationUnit):
                 self.xmlelement = newelement
                 self.setid(old_id)
 
-            plural_tags = self._store.get_plural_tags()
+            plural_tags = self._store.get_plural_tags()  # ty:ignore[possibly-missing-attribute]
 
             # Sync plural_strings elements to plural_tags count.
             plural_strings = self.sync_plural_count(target, plural_tags)
@@ -459,7 +459,7 @@ class AndroidResourceUnit(base.TranslationUnit):
             # Include additional plural for decimal numbers if not present. This is
             # enforced by Android lint but translate-toolkit currently does not support
             # editing this.
-            locale = self._store.get_base_locale_code()
+            locale = self._store.get_base_locale_code()  # ty:ignore[possibly-missing-attribute]
             if locale in data.DECIMAL_EXTRA_TAGS:
                 for extra in data.DECIMAL_EXTRA_TAGS[locale]:
                     if extra not in plural_tags:
@@ -524,7 +524,7 @@ class AndroidResourceUnit(base.TranslationUnit):
         if (self.xmlelement is not None) and (self.xmlelement.getparent is not None):
             prevSibling = self.xmlelement.getprevious()
             while (prevSibling is not None) and (prevSibling.tag is etree.Comment):
-                prevSibling.getparent().remove(prevSibling)
+                prevSibling.getparent().remove(prevSibling)  # ty:ignore[possibly-missing-attribute]
                 prevSibling = self.xmlelement.getprevious()
 
         super().removenotes()
@@ -562,7 +562,7 @@ class AndroidResourceFile(lisa.LISAfile):
         self.namespace = self.document.getroot().nsmap.get(None, None)
         self.body = self.document.getroot()
 
-    def parse(self, xml) -> None:
+    def parse(self, xml) -> None:  # ty:ignore[invalid-method-override]
         """Populates this object from the given xml string."""
         if not hasattr(self, "filename"):
             self.filename = getattr(xml, "name", "")
@@ -611,7 +611,7 @@ class AndroidResourceFile(lisa.LISAfile):
         do_cleanup = False
         if new:
             # Include any possible new namespaces
-            newns = self.body.nsmap
+            newns = self.body.nsmap  # ty:ignore[possibly-missing-attribute]
             for ns in unit.xmlelement.nsmap:
                 if ns not in newns:
                     do_cleanup = True
@@ -630,13 +630,13 @@ class AndroidResourceFile(lisa.LISAfile):
                 cloned_doc.getroot().clear()
                 self.XMLdoctype = etree.tostring(
                     cloned_doc, xml_declaration=False, encoding="unicode"
-                ).rsplit("\n", 1)[0]
+                ).rsplit("\n", 1)[0]  # ty:ignore[invalid-argument-type]
 
         super().addunit(unit, new)
         # Move aliased namespaces to the <resources> tag
         # The top_nsmap was introduced in LXML 3.5.0
         if do_cleanup:
-            etree.cleanup_namespaces(self.body, top_nsmap=newns)
+            etree.cleanup_namespaces(self.body, top_nsmap=newns)  # ty:ignore[invalid-argument-type]
 
     def removeunit(self, unit) -> None:
         unit.removenotes()

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -145,7 +145,7 @@ class TranslationUnit:
         """
         return self._line_number
 
-    def __eq__(self, other: TranslationUnit) -> bool:
+    def __eq__(self, other: TranslationUnit) -> bool:  # ty:ignore[invalid-method-override]
         """
         Compares two TranslationUnits.
 
@@ -464,10 +464,10 @@ class TranslationUnit:
         return False
 
     def getsourcelanguage(self):
-        return self._store.getsourcelanguage()
+        return self._store.getsourcelanguage()  # ty:ignore[possibly-missing-attribute]
 
     def gettargetlanguage(self):
-        return self._store.gettargetlanguage()
+        return self._store.gettargetlanguage()  # ty:ignore[possibly-missing-attribute]
 
     def merge(
         self, otherunit, overwrite=False, comments=True, authoritative=False
@@ -595,7 +595,7 @@ class MetadataTranslationUnit(TranslationUnit):
 
     metadata = property(getmetadata, setmetadata)
 
-    def __eq__(self, other: TranslationUnit) -> bool:
+    def __eq__(self, other: TranslationUnit) -> bool:  # ty:ignore[invalid-method-override]
         """
         Compare two units including their metadata.
 
@@ -648,7 +648,7 @@ U = TypeVar("U", bound=TranslationUnit)
 class TranslationStore(Generic[U]):
     """Base class for stores for multiple translation units of type UnitClass."""
 
-    UnitClass: ClassVar[type[U]] = TranslationUnit
+    UnitClass: ClassVar[type[U]] = TranslationUnit  # ty:ignore[invalid-assignment]
     """The class of units that will be instantiated and used by this class"""
     Name = "Base translation store"
     """The human usable name of this store type"""
@@ -670,7 +670,7 @@ class TranslationStore(Generic[U]):
         """Construct a blank TranslationStore."""
         self.units = []
         if unitclass:
-            self.UnitClass = unitclass
+            self.UnitClass = unitclass  # ty:ignore[invalid-attribute-access]
         self._encoding = encoding
         self.locationindex = {}
         self.sourceindex = {}
@@ -932,7 +932,7 @@ class TranslationStore(Generic[U]):
             elif detected_encoding["encoding"] == "ascii":
                 detected_encoding["encoding"] = self.encoding
             else:
-                detected_encoding["encoding"] = detected_encoding["encoding"].lower()
+                detected_encoding["encoding"] = detected_encoding["encoding"].lower()  # ty:ignore[possibly-missing-attribute]
 
         encodings = []
         # Purposefully accessed the internal _encoding, as encoding is never 'auto'
@@ -1191,7 +1191,7 @@ class DictUnit(TranslationUnit):
             raise ValueError(f"Unsupported element: {child_element}")
 
     def storevalues(self, output) -> None:
-        self.storevalue(output, self.value)
+        self.storevalue(output, self.value)  # ty:ignore[unresolved-attribute]
 
     def getvalue(self):
         """Returns dictionary for serialization."""

--- a/translate/storage/benchmark.py
+++ b/translate/storage/benchmark.py
@@ -147,8 +147,8 @@ if __name__ == "__main__":
 
     storetype = args.storetype
 
-    if storetype in factory.classes_str:
-        _module, _class = factory.classes_str[storetype]
+    if storetype in factory.classes_str:  # ty:ignore[unresolved-attribute]
+        _module, _class = factory.classes_str[storetype]  # ty:ignore[unresolved-attribute]
         module = import_module(f"translate.storage.{_module}")
         storeclass = getattr(module, _class)
     else:

--- a/translate/storage/bundleprojstore.py
+++ b/translate/storage/bundleprojstore.py
@@ -115,7 +115,7 @@ class BundleProjectStore(ProjectStore):
                 os.unlink(tempfname)
         self._tempfiles = {}
 
-    def get_file(self, fname):
+    def get_file(self, fname):  # ty:ignore[invalid-method-override]
         """
         Retrieve a project file (source, translation or target file) from
         the project archive.
@@ -173,7 +173,7 @@ class BundleProjectStore(ProjectStore):
                     append_section[section](fname)
                     self._files[fname] = None
 
-    def save(self, filename=None) -> None:
+    def save(self, filename=None) -> None:  # ty:ignore[invalid-method-override]
         """Save all project files to the bundle zip file."""
         self._update_from_tempfiles()
 
@@ -210,7 +210,7 @@ class BundleProjectStore(ProjectStore):
         self._zip_delete([pfname])
         self._zip_add(pfname, infile)
 
-    def _load_settings(self) -> None:
+    def _load_settings(self) -> None:  # ty:ignore[invalid-method-override]
         """Grab the project.xtp file from the zip file and load it."""
         if "project.xtp" not in self.zip.namelist():
             raise InvalidBundleError("Not a translate project bundle")
@@ -231,10 +231,10 @@ class BundleProjectStore(ProjectStore):
         """
         if not zfile.fp.closed:
             zfile.close()
-        if not self.zip.fp.closed:
+        if not self.zip.fp.closed:  # ty:ignore[possibly-missing-attribute]
             self.zip.close()
-        move(zfile.filename, self.zip.filename)
-        self.zip = ZipFile(self.zip.filename, mode="a")
+        move(zfile.filename, self.zip.filename)  # ty:ignore[invalid-argument-type]
+        self.zip = ZipFile(self.zip.filename, mode="a")  # ty:ignore[no-matching-overload]
 
     def _update_from_tempfiles(self) -> None:
         """Update project files from temporary files."""

--- a/translate/storage/catkeys.py
+++ b/translate/storage/catkeys.py
@@ -209,7 +209,7 @@ class CatkeysUnit(base.MetadataTranslationUnit):
             id = f"{context}\04{id}"
         return id
 
-    def markfuzzy(self, present=True) -> None:
+    def markfuzzy(self, present=True) -> None:  # ty:ignore[invalid-method-override]
         if present:
             self.target = ""
 
@@ -257,10 +257,10 @@ class CatkeysFile(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def settargetlanguage(self, newlang) -> None:
+    def settargetlanguage(self, newlang) -> None:  # ty:ignore[invalid-method-override]
         self.header.settargetlanguage(newlang)
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Parse the given file or file source string."""
         if hasattr(input, "name"):
             self.filename = input.name

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -339,7 +339,7 @@ def get_libgettextpo_version() -> tuple[int, int, int]:
     :return: libgettextpo version in the following format::
         (major version, minor version, subminor version)
     """
-    libversion = c_int.in_dll(gpo, "libgettextpo_version")
+    libversion = c_int.in_dll(gpo, "libgettextpo_version")  # ty:ignore[invalid-argument-type]
     major = libversion.value >> 16
     minor = (libversion.value >> 8) & 0xFF
     subminor = libversion.value - (major << 16) - (minor << 8)
@@ -367,7 +367,7 @@ class pounit(pocommon.pounit):
         self._rich_target = None
         encoding = encoding or "utf-8"
         if not gpo_message:
-            self._gpo_message = gpo.po_message_create()
+            self._gpo_message = gpo.po_message_create()  # ty:ignore[possibly-missing-attribute]
         if isinstance(source, str):
             self.source = source
             self.target = ""
@@ -386,9 +386,9 @@ class pounit(pocommon.pounit):
                 nplural = 0
                 text = True
                 while text:
-                    text = gpo.po_message_msgstr_plural(gpo_message, nplural)
+                    text = gpo.po_message_msgstr_plural(gpo_message, nplural)  # ty:ignore[possibly-missing-attribute]
                     if text:
-                        gpo.po_message_set_msgstr_plural(
+                        gpo.po_message_set_msgstr_plural(  # ty:ignore[possibly-missing-attribute]
                             gpo_message,
                             text.decode(encoding).encode(self.CPO_ENC),
                             nplural,
@@ -399,12 +399,12 @@ class pounit(pocommon.pounit):
 
     def infer_state(self) -> None:
         # FIXME: do obsolete
-        if gpo.po_message_is_obsolete(self._gpo_message):
-            if gpo.po_message_is_fuzzy(self._gpo_message):
+        if gpo.po_message_is_obsolete(self._gpo_message):  # ty:ignore[possibly-missing-attribute]
+            if gpo.po_message_is_fuzzy(self._gpo_message):  # ty:ignore[possibly-missing-attribute]
                 self.set_state_n(self.STATE[self.S_FUZZY_OBSOLETE][0])
             else:
                 self.set_state_n(self.STATE[self.S_OBSOLETE][0])
-        elif gpo.po_message_is_fuzzy(self._gpo_message):
+        elif gpo.po_message_is_fuzzy(self._gpo_message):  # ty:ignore[possibly-missing-attribute]
             self.set_state_n(self.STATE[self.S_FUZZY][0])
         elif self.target:
             self.set_state_n(self.STATE[self.S_TRANSLATED][0])
@@ -414,7 +414,7 @@ class pounit(pocommon.pounit):
     def setmsgid_plural(self, msgid_plural) -> None:
         if isinstance(msgid_plural, list):
             msgid_plural = "".join(msgid_plural)
-        gpo.po_message_set_msgid_plural(self._gpo_message, gpo_encode(msgid_plural))
+        gpo.po_message_set_msgid_plural(self._gpo_message, gpo_encode(msgid_plural))  # ty:ignore[possibly-missing-attribute]
 
     msgid_plural = property(None, setmsgid_plural)
 
@@ -431,13 +431,13 @@ class pounit(pocommon.pounit):
             return text
 
         singular = remove_msgid_comments(
-            gpo_decode(gpo.po_message_msgid(self._gpo_message)) or ""
+            gpo_decode(gpo.po_message_msgid(self._gpo_message)) or ""  # ty:ignore[possibly-missing-attribute]
         )
         if singular:
             if self.hasplural():
                 multi = multistring(singular)
                 pluralform = (
-                    gpo_decode(gpo.po_message_msgid_plural(self._gpo_message)) or ""
+                    gpo_decode(gpo.po_message_msgid_plural(self._gpo_message)) or ""  # ty:ignore[possibly-missing-attribute]
                 )
                 multi.extra_strings.append(pluralform)
                 return multi
@@ -449,28 +449,28 @@ class pounit(pocommon.pounit):
         if isinstance(source, multistring):
             source = source.strings
         if isinstance(source, list):
-            gpo.po_message_set_msgid(self._gpo_message, gpo_encode(source[0]))
+            gpo.po_message_set_msgid(self._gpo_message, gpo_encode(source[0]))  # ty:ignore[possibly-missing-attribute]
             if len(source) > 1:
-                gpo.po_message_set_msgid_plural(
+                gpo.po_message_set_msgid_plural(  # ty:ignore[possibly-missing-attribute]
                     self._gpo_message, gpo_encode(source[1])
                 )
         else:
-            gpo.po_message_set_msgid(self._gpo_message, gpo_encode(source))
-            gpo.po_message_set_msgid_plural(self._gpo_message, None)
+            gpo.po_message_set_msgid(self._gpo_message, gpo_encode(source))  # ty:ignore[possibly-missing-attribute]
+            gpo.po_message_set_msgid_plural(self._gpo_message, None)  # ty:ignore[possibly-missing-attribute]
 
     @property
     def target(self):
         if self.hasplural():
             plurals = []
             nplural = 0
-            plural = gpo.po_message_msgstr_plural(self._gpo_message, nplural)
+            plural = gpo.po_message_msgstr_plural(self._gpo_message, nplural)  # ty:ignore[possibly-missing-attribute]
             while plural:
                 plurals.append(plural.decode(self.CPO_ENC))
                 nplural += 1
-                plural = gpo.po_message_msgstr_plural(self._gpo_message, nplural)
+                plural = gpo.po_message_msgstr_plural(self._gpo_message, nplural)  # ty:ignore[possibly-missing-attribute]
             multi = multistring(plurals) if plurals else multistring("")
         else:
-            multi = gpo_decode(gpo.po_message_msgstr(self._gpo_message)) or ""
+            multi = gpo_decode(gpo.po_message_msgstr(self._gpo_message)) or ""  # ty:ignore[possibly-missing-attribute]
         return multi
 
     @target.setter
@@ -496,35 +496,35 @@ class pounit(pocommon.pounit):
         #   Maybe this behaviour should be unified.
         if isinstance(target, (dict, list)):
             i = 0
-            message = gpo.po_message_msgstr_plural(self._gpo_message, i)
+            message = gpo.po_message_msgstr_plural(self._gpo_message, i)  # ty:ignore[possibly-missing-attribute]
             while message is not None:
-                gpo.po_message_set_msgstr_plural(self._gpo_message, i, None)
+                gpo.po_message_set_msgstr_plural(self._gpo_message, i, None)  # ty:ignore[possibly-missing-attribute]
                 i += 1
-                message = gpo.po_message_msgstr_plural(self._gpo_message, i)
+                message = gpo.po_message_msgstr_plural(self._gpo_message, i)  # ty:ignore[possibly-missing-attribute]
         # add the items of a list
         if isinstance(target, list):
             for i, targetstring in enumerate(target):
-                gpo.po_message_set_msgstr_plural(
+                gpo.po_message_set_msgstr_plural(  # ty:ignore[possibly-missing-attribute]
                     self._gpo_message, i, gpo_encode(targetstring)
                 )
         # add the values of a dict
         elif isinstance(target, dict):
             for i, targetstring in enumerate(target.values()):
-                gpo.po_message_set_msgstr_plural(
+                gpo.po_message_set_msgstr_plural(  # ty:ignore[possibly-missing-attribute]
                     self._gpo_message, i, gpo_encode(targetstring)
                 )
         # add a single string
         elif target is None:
-            gpo.po_message_set_msgstr(self._gpo_message, gpo_encode(""))
+            gpo.po_message_set_msgstr(self._gpo_message, gpo_encode(""))  # ty:ignore[possibly-missing-attribute]
         else:
-            gpo.po_message_set_msgstr(self._gpo_message, gpo_encode(target))
+            gpo.po_message_set_msgstr(self._gpo_message, gpo_encode(target))  # ty:ignore[possibly-missing-attribute]
 
     def getid(self):
         """
         The unique identifier for this unit according to the conventions in
         .mo files.
         """
-        id = gpo_decode(gpo.po_message_msgid(self._gpo_message)) or ""
+        id = gpo_decode(gpo.po_message_msgid(self._gpo_message)) or ""  # ty:ignore[possibly-missing-attribute]
         # Gettext does not consider the plural to determine duplicates, only
         # the msgid. For generation of .mo files, we might want to use this
         # code to generate the entry for the hash table, but for now, it is
@@ -532,20 +532,20 @@ class pounit(pocommon.pounit):
         #        plural = gpo.po_message_msgid_plural(self._gpo_message)
         #        if not plural is None:
         #            id = '%s\0%s' % (id, plural)
-        context = gpo.po_message_msgctxt(self._gpo_message)
+        context = gpo.po_message_msgctxt(self._gpo_message)  # ty:ignore[possibly-missing-attribute]
         if context:
             id = f"{gpo_decode(context)}\04{id}"
         return id
 
     def getnotes(self, origin=None):
         if origin is None:
-            comments = gpo.po_message_comments(
+            comments = gpo.po_message_comments(  # ty:ignore[possibly-missing-attribute]
                 self._gpo_message
-            ) + gpo.po_message_extracted_comments(self._gpo_message)
+            ) + gpo.po_message_extracted_comments(self._gpo_message)  # ty:ignore[possibly-missing-attribute]
         elif origin == "translator":
-            comments = gpo.po_message_comments(self._gpo_message)
+            comments = gpo.po_message_comments(self._gpo_message)  # ty:ignore[possibly-missing-attribute]
         elif origin in {"programmer", "developer", "source code"}:
-            comments = gpo.po_message_extracted_comments(self._gpo_message)
+            comments = gpo.po_message_extracted_comments(self._gpo_message)  # ty:ignore[possibly-missing-attribute]
         else:
             raise ValueError("Comment type not valid")
 
@@ -587,12 +587,12 @@ class pounit(pocommon.pounit):
                     newlines.append(line)
             newnotes = gpo_encode("\n".join(newlines))
             if origin in {"programmer", "developer", "source code"}:
-                gpo.po_message_set_extracted_comments(self._gpo_message, newnotes)
+                gpo.po_message_set_extracted_comments(self._gpo_message, newnotes)  # ty:ignore[possibly-missing-attribute]
             else:
-                gpo.po_message_set_comments(self._gpo_message, newnotes)
+                gpo.po_message_set_comments(self._gpo_message, newnotes)  # ty:ignore[possibly-missing-attribute]
 
     def removenotes(self, origin=None) -> None:
-        gpo.po_message_set_comments(self._gpo_message, b"")
+        gpo.po_message_set_comments(self._gpo_message, b"")  # ty:ignore[possibly-missing-attribute]
 
     def copy(self):
         newpo = self.__class__()
@@ -601,7 +601,7 @@ class pounit(pocommon.pounit):
 
     def merge(
         self, otherpo, overwrite=False, comments=True, authoritative=False
-    ) -> None:
+    ) -> None:  # ty:ignore[invalid-method-override]
         """
         Merges the otherpo (with the same msgid) into this one.
 
@@ -653,10 +653,10 @@ class pounit(pocommon.pounit):
         return len(self.source) == len(self.target) == len(self.getcontext()) == 0
 
     def hastypecomment(self, typecomment):
-        return gpo.po_message_is_format(self._gpo_message, gpo_encode(typecomment))
+        return gpo.po_message_is_format(self._gpo_message, gpo_encode(typecomment))  # ty:ignore[possibly-missing-attribute]
 
     def settypecomment(self, typecomment, present=True) -> None:
-        gpo.po_message_set_format(self._gpo_message, gpo_encode(typecomment), present)
+        gpo.po_message_set_format(self._gpo_message, gpo_encode(typecomment), present)  # ty:ignore[possibly-missing-attribute]
 
     def hasmarkedcomment(self, commentmarker) -> bool:
         commentmarker = f"({commentmarker})"
@@ -666,23 +666,23 @@ class pounit(pocommon.pounit):
         return False
 
     def isfuzzy(self):
-        return gpo.po_message_is_fuzzy(self._gpo_message)
+        return gpo.po_message_is_fuzzy(self._gpo_message)  # ty:ignore[possibly-missing-attribute]
 
     def _domarkfuzzy(self, present=True) -> None:
-        gpo.po_message_set_fuzzy(self._gpo_message, present)
+        gpo.po_message_set_fuzzy(self._gpo_message, present)  # ty:ignore[possibly-missing-attribute]
 
     def makeobsolete(self) -> None:
         # FIXME: libgettexpo currently does not reset other data, we probably want to do that
         # but a better solution would be for libgettextpo to output correct data on serialisation
-        gpo.po_message_set_obsolete(self._gpo_message, True)
+        gpo.po_message_set_obsolete(self._gpo_message, True)  # ty:ignore[possibly-missing-attribute]
         self.infer_state()
 
     def resurrect(self) -> None:
-        gpo.po_message_set_obsolete(self._gpo_message, False)
+        gpo.po_message_set_obsolete(self._gpo_message, False)  # ty:ignore[possibly-missing-attribute]
         self.infer_state()
 
     def hasplural(self):
-        return gpo.po_message_msgid_plural(self._gpo_message) is not None
+        return gpo.po_message_msgid_plural(self._gpo_message) is not None  # ty:ignore[possibly-missing-attribute]
 
     def _extract_msgidcomments(self, text: str | None = None) -> str:
         """
@@ -691,7 +691,7 @@ class pounit(pocommon.pounit):
         :return: Returns the extracted msgidcomments found in this unit's msgid.
         """
         if not text:
-            text = gpo_decode(gpo.po_message_msgid(self._gpo_message)) or ""
+            text = gpo_decode(gpo.po_message_msgid(self._gpo_message)) or ""  # ty:ignore[possibly-missing-attribute]
         if text:
             return pocommon.extract_msgid_comment(text)
         return ""
@@ -710,14 +710,14 @@ class pounit(pocommon.pounit):
     def getlocations(self):
         locations = []
         i = 0
-        location = gpo.po_message_filepos(self._gpo_message, i)
+        location = gpo.po_message_filepos(self._gpo_message, i)  # ty:ignore[possibly-missing-attribute]
         while location:
-            locname = gpo_decode(gpo.po_filepos_file(location))
-            locline = gpo.po_filepos_start_line(location)
+            locname = gpo_decode(gpo.po_filepos_file(location))  # ty:ignore[possibly-missing-attribute]
+            locline = gpo.po_filepos_start_line(location)  # ty:ignore[possibly-missing-attribute]
             locstring = locname if locline == -1 else f"{locname}:{locline!s}"
             locations.append(pocommon.unquote_plus(locstring))
             i += 1
-            location = gpo.po_message_filepos(self._gpo_message, i)
+            location = gpo.po_message_filepos(self._gpo_message, i)  # ty:ignore[possibly-missing-attribute]
         return locations
 
     def addlocation(self, location) -> None:
@@ -730,16 +730,16 @@ class pounit(pocommon.pounit):
         else:
             file = location
             line = -1
-        gpo.po_message_add_filepos(self._gpo_message, gpo_encode(file), line)
+        gpo.po_message_add_filepos(self._gpo_message, gpo_encode(file), line)  # ty:ignore[possibly-missing-attribute]
 
     def getcontext(self):
-        msgctxt = gpo.po_message_msgctxt(self._gpo_message)
+        msgctxt = gpo.po_message_msgctxt(self._gpo_message)  # ty:ignore[possibly-missing-attribute]
         if msgctxt:
             return gpo_decode(msgctxt)
         return self._extract_msgidcomments()
 
     def setcontext(self, context) -> None:
-        gpo.po_message_set_msgctxt(self._gpo_message, gpo_encode(context))
+        gpo.po_message_set_msgctxt(self._gpo_message, gpo_encode(context))  # ty:ignore[possibly-missing-attribute]
 
     @classmethod
     def buildfromunit(cls, unit, encoding=None):
@@ -790,15 +790,15 @@ class pofile(pocommon.pofile):
         if inputfile is None:
             self.units = []
             self._encoding = kwargs.get("encoding")
-            self._gpo_memory_file = gpo.po_file_create()
-            self._gpo_message_iterator = gpo.po_message_iterator(
+            self._gpo_memory_file = gpo.po_file_create()  # ty:ignore[possibly-missing-attribute]
+            self._gpo_message_iterator = gpo.po_message_iterator(  # ty:ignore[possibly-missing-attribute]
                 self._gpo_memory_file, None
             )
         super().__init__(inputfile=inputfile, noheader=noheader, **kwargs)
 
     def addunit(self, unit, new=True) -> None:
         if new:
-            gpo.po_message_insert(self._gpo_message_iterator, unit._gpo_message)
+            gpo.po_message_insert(self._gpo_message_iterator, unit._gpo_message)  # ty:ignore[possibly-missing-attribute]
         super().addunit(unit)
 
     def removeunit(self, unit):
@@ -809,11 +809,11 @@ class pofile(pocommon.pofile):
         header._store = self
         self.units.insert(0, header)
         self._free_iterator()
-        self._gpo_message_iterator = gpo.po_message_iterator(
+        self._gpo_message_iterator = gpo.po_message_iterator(  # ty:ignore[possibly-missing-attribute]
             self._gpo_memory_file, None
         )
-        gpo.po_message_insert(self._gpo_message_iterator, header._gpo_message)
-        while gpo.po_next_message(self._gpo_message_iterator):
+        gpo.po_message_insert(self._gpo_message_iterator, header._gpo_message)  # ty:ignore[possibly-missing-attribute]
+        while gpo.po_next_message(self._gpo_message_iterator):  # ty:ignore[possibly-missing-attribute]
             pass
 
     def removeduplicates(self, duplicatestyle="merge") -> None:
@@ -848,8 +848,8 @@ class pofile(pocommon.pofile):
                         origpo.setcontext(" ".join(origpo.getlocations()))
                         markedpos.append(thepo)
                     thepo.setcontext(" ".join(thepo.getlocations()))
-                    thepo_msgctxt = gpo.po_message_msgctxt(thepo._gpo_message)
-                    idpo_msgctxt = gpo.po_message_msgctxt(id_dict[id]._gpo_message)
+                    thepo_msgctxt = gpo.po_message_msgctxt(thepo._gpo_message)  # ty:ignore[possibly-missing-attribute]
+                    idpo_msgctxt = gpo.po_message_msgctxt(id_dict[id]._gpo_message)  # ty:ignore[possibly-missing-attribute]
                     if thepo_msgctxt != idpo_msgctxt:
                         uniqueunits.append(thepo)
                     else:
@@ -866,10 +866,10 @@ class pofile(pocommon.pofile):
                         thepo.setcontext(" ".join(thepo.getlocations()))
                 id_dict[id] = thepo
                 uniqueunits.append(thepo)
-        new_gpo_memory_file = gpo.po_file_create()
-        new_gpo_message_iterator = gpo.po_message_iterator(new_gpo_memory_file, None)
+        new_gpo_memory_file = gpo.po_file_create()  # ty:ignore[possibly-missing-attribute]
+        new_gpo_message_iterator = gpo.po_message_iterator(new_gpo_memory_file, None)  # ty:ignore[possibly-missing-attribute]
         for unit in uniqueunits:
-            gpo.po_message_insert(new_gpo_message_iterator, unit._gpo_message)
+            gpo.po_message_insert(new_gpo_message_iterator, unit._gpo_message)  # ty:ignore[possibly-missing-attribute]
         self._free_iterator()
         self._gpo_message_iterator = new_gpo_message_iterator
         self._free_memory_file()
@@ -883,15 +883,15 @@ class pofile(pocommon.pofile):
             # FIXME Do version test in case they fix this bug
             for unit in self.units:
                 if unit.isobsolete():
-                    gpo.po_message_set_extracted_comments(unit._gpo_message, b"")
-                    location = gpo.po_message_filepos(unit._gpo_message, 0)
+                    gpo.po_message_set_extracted_comments(unit._gpo_message, b"")  # ty:ignore[possibly-missing-attribute]
+                    location = gpo.po_message_filepos(unit._gpo_message, 0)  # ty:ignore[possibly-missing-attribute]
                     while location:
-                        gpo.po_message_remove_filepos(unit._gpo_message, 0)
-                        location = gpo.po_message_filepos(unit._gpo_message, 0)
+                        gpo.po_message_remove_filepos(unit._gpo_message, 0)  # ty:ignore[possibly-missing-attribute]
+                        location = gpo.po_message_filepos(unit._gpo_message, 0)  # ty:ignore[possibly-missing-attribute]
 
         def writefile(filename):
             xerror_storage.exception = None
-            result = gpo.po_file_write_v2(
+            result = gpo.po_file_write_v2(  # ty:ignore[possibly-missing-attribute]
                 self._gpo_memory_file, gpo_encode(filename), xerror_handler
             )
             if xerror_storage.exception is not None:
@@ -933,7 +933,7 @@ class pofile(pocommon.pofile):
 
         return all(not (not unit.isblank() and not unit.isobsolete()) for unit in units)
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         if hasattr(input, "name"):
             self.filename = input.name
         elif not getattr(self, "filename", ""):
@@ -955,7 +955,7 @@ class pofile(pocommon.pofile):
         try:
             xerror_storage.exception = None
             self._free_memory_file()
-            self._gpo_memory_file = gpo.po_file_read_v3(
+            self._gpo_memory_file = gpo.po_file_read_v3(  # ty:ignore[possibly-missing-attribute]
                 gpo_encode(input), xerror_handler
             )
             if xerror_storage.exception is not None:
@@ -968,24 +968,24 @@ class pofile(pocommon.pofile):
 
         self.units = []
         # Handle xerrors here
-        self._header = gpo.po_file_domain_header(self._gpo_memory_file, None)
+        self._header = gpo.po_file_domain_header(self._gpo_memory_file, None)  # ty:ignore[possibly-missing-attribute]
         if self._header:
             charset = gpo_decode(
-                gpo.po_header_field(self._header, gpo_encode("Content-Type"))
+                gpo.po_header_field(self._header, gpo_encode("Content-Type"))  # ty:ignore[possibly-missing-attribute]
             )
             if charset:
                 # Allow optional whitespace after '=' to match 'charset= koi8-r'
-                charset = re.search(r"charset=\s*([^\s]+)", charset).group(1)
+                charset = re.search(r"charset=\s*([^\s]+)", charset).group(1)  # ty:ignore[possibly-missing-attribute]
             self.encoding = charset
         self._free_iterator()
-        self._gpo_message_iterator = gpo.po_message_iterator(
+        self._gpo_message_iterator = gpo.po_message_iterator(  # ty:ignore[possibly-missing-attribute]
             self._gpo_memory_file, None
         )
-        newmessage = gpo.po_next_message(self._gpo_message_iterator)
+        newmessage = gpo.po_next_message(self._gpo_message_iterator)  # ty:ignore[possibly-missing-attribute]
         while newmessage:
             newunit = pounit(gpo_message=newmessage, encoding=self.encoding)
             self.addunit(newunit, new=False)
-            newmessage = gpo.po_next_message(self._gpo_message_iterator)
+            newmessage = gpo.po_next_message(self._gpo_message_iterator)  # ty:ignore[possibly-missing-attribute]
         self._free_iterator()
 
     def __del__(self) -> None:
@@ -1002,5 +1002,5 @@ class pofile(pocommon.pofile):
 
     def _free_iterator(self) -> None:
         if self._gpo_message_iterator is not None:
-            gpo.po_message_iterator_free(self._gpo_message_iterator)
+            gpo.po_message_iterator_free(self._gpo_message_iterator)  # ty:ignore[possibly-missing-attribute]
             self._gpo_message_iterator = None

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -76,7 +76,7 @@ class csvunit(base.TranslationUnit):
     def getcontext(self):
         return self.context
 
-    def setcontext(self, value) -> None:
+    def setcontext(self, value) -> None:  # ty:ignore[invalid-method-override]
         self.context = value
 
     def getnotes(self, origin=None):
@@ -212,7 +212,7 @@ EXTRA_KEY = "__CSVL10N__EXTRA__"
 def try_dialects(
     inputfile: StringIO,
     fieldnames: list[str] | None,
-    dialect: str | csv.Dialect,
+    dialect: str | type[csv.Dialect],
     has_header: bool = False,
 ) -> csv.DictReader:
     """
@@ -278,7 +278,7 @@ def valid_fieldnames(fieldnames: list[str]) -> bool:
 
 
 def detect_header(
-    inputfile: StringIO, dialect: str | csv.Dialect, fieldnames: list[str]
+    inputfile: StringIO, dialect: str | type[csv.Dialect], fieldnames: list[str]
 ) -> tuple[list[str], bool]:
     """
     Test if file has a header or not.
@@ -346,7 +346,7 @@ class csvfile(base.TranslationStore):
 
     def parse(
         self, csvsrc, sample_length: int | None = 1024, *, dialect: str | None = None
-    ) -> None:
+    ) -> None:  # ty:ignore[invalid-method-override]
         if self._encoding == "auto":
             self._automatic_encoding = True
             text, encoding = self.detect_encoding(
@@ -390,7 +390,9 @@ class csvfile(base.TranslationStore):
         has_header = False
         try:
             fieldnames, has_header = detect_header(
-                inputfile, self.dialect, self.fieldnames
+                inputfile,
+                self.dialect,
+                self.fieldnames,
             )
             self.fieldnames = fieldnames
         except csv.Error:

--- a/translate/storage/dtd.py
+++ b/translate/storage/dtd.py
@@ -131,7 +131,7 @@ _DTD_CODEPOINT2NAME = {
 
 def quotefordtd(source):
     """Quotes and escapes a line for regular DTD files."""
-    source = quote.entityencode(source, _DTD_CODEPOINT2NAME)
+    source = quote.entityencode(source, _DTD_CODEPOINT2NAME)  # ty:ignore[invalid-argument-type]
     if '"' in source:
         source = source.replace("'", "&apos;")  # This seems not to run.
         if '="' not in source:  # Avoid escaping " chars in href attributes.
@@ -171,7 +171,7 @@ def unquotefromdtd(source):
     )
     if quotechar == "'":
         extracted = extracted.replace("&apos;", "'")
-    return quote.entitydecode(extracted, _DTD_NAME2CODEPOINT)
+    return quote.entitydecode(extracted, _DTD_NAME2CODEPOINT)  # ty:ignore[invalid-argument-type]
 
 
 def removeinvalidamps(name: str, value: str) -> str:
@@ -268,7 +268,7 @@ class dtdunit(base.TranslationUnit):
     def getid(self):
         return self.entity
 
-    def setid(self, new_id) -> None:
+    def setid(self, new_id) -> None:  # ty:ignore[invalid-method-override]
         self.entity = new_id
 
     def getlocations(self):
@@ -307,11 +307,11 @@ class dtdunit(base.TranslationUnit):
         # for n in self._locnotes: yield n
         if len(self.entity) > 0:
             if getattr(self, "entitytype", None) == "external":
-                entityline = f"<!ENTITY % {self.entity} {self.entityparameter} {self.definition}{self.closing}"
+                entityline = f"<!ENTITY % {self.entity} {self.entityparameter} {self.definition}{self.closing}"  # ty:ignore[unresolved-attribute]
             else:
                 entityline = f"<!ENTITY{self.space_pre_entity}{self.entity}{self.space_pre_definition}{self.definition}{self.closing}"
             if getattr(self, "hashprefix", None):
-                entityline = f"{self.hashprefix} {entityline}"
+                entityline = f"{self.hashprefix} {entityline}"  # ty:ignore[unresolved-attribute]
             lines.append(f"{entityline}\n")
         return "".join(lines)
 
@@ -349,10 +349,10 @@ class dtdfile(base.TranslationStore):
         """Store a comment in the appropriate list on the unit."""
         commentpair = (commenttype, comment)
         comment_targets = {
-            "locfile": unit._locfilenotes,
-            "locgroupstart": unit._locgroupstarts,
-            "locgroupend": unit._locgroupends,
-            "locnote": unit._locnotes,
+            "locfile": unit._locfilenotes,  # ty:ignore[unresolved-attribute]
+            "locgroupstart": unit._locgroupstarts,  # ty:ignore[unresolved-attribute]
+            "locgroupend": unit._locgroupends,  # ty:ignore[unresolved-attribute]
+            "locnote": unit._locnotes,  # ty:ignore[unresolved-attribute]
             "comment": unit.comments,
         }
         comment_targets.get(commenttype, unit.comments).append(commentpair)
@@ -412,7 +412,7 @@ class dtdfile(base.TranslationStore):
             )
         raise ValueError(f"Unexpected quote character... {quote_char!r}")
 
-    def parse(self, dtdsrc) -> None:
+    def parse(self, dtdsrc) -> None:  # ty:ignore[invalid-method-override]
         """Read the source code of a dtd file in and include them as dtdunits in self.units."""
         if not dtdsrc:
             return
@@ -438,10 +438,10 @@ class dtdfile(base.TranslationStore):
 
             # Initialize unit state
             newdtd.comments = []
-            newdtd._locfilenotes = newdtd.comments
-            newdtd._locgroupstarts = newdtd.comments
-            newdtd._locgroupends = newdtd.comments
-            newdtd._locnotes = newdtd.comments
+            newdtd._locfilenotes = newdtd.comments  # ty:ignore[unresolved-attribute]
+            newdtd._locgroupstarts = newdtd.comments  # ty:ignore[unresolved-attribute]
+            newdtd._locgroupends = newdtd.comments  # ty:ignore[unresolved-attribute]
+            newdtd._locnotes = newdtd.comments  # ty:ignore[unresolved-attribute]
             newdtd.entity = None
             newdtd.definition = ""
             newdtd.unparsedlines = []
@@ -506,7 +506,7 @@ class dtdfile(base.TranslationStore):
                         has_content = True
                         beforeentity = line[:entitypos].strip()
                         if beforeentity.startswith("#"):
-                            newdtd.hashprefix = beforeentity
+                            newdtd.hashprefix = beforeentity  # ty:ignore[unresolved-attribute]
                         entitypart = "start"
                     else:
                         # Add to unparsed lines
@@ -533,10 +533,10 @@ class dtdfile(base.TranslationStore):
                         newdtd.entity = entity_name
                         assert quote.rstripeol(entity_name) == entity_name
                         if newdtd.entity:
-                            newdtd.entitytype = entitytype
+                            newdtd.entitytype = entitytype  # ty:ignore[unresolved-attribute]
                             if entitytype == "external":
                                 entitypart = "parameter"
-                                newdtd.entityparameter = ""
+                                newdtd.entityparameter = ""  # ty:ignore[unresolved-attribute]
                             else:
                                 entitypart = "definition"
                             # Remember the start position and the quote character
@@ -555,7 +555,7 @@ class dtdfile(base.TranslationStore):
                         paramstart = e
                         while e < len(line) and line[e].isalnum():
                             e += 1
-                        newdtd.entityparameter += line[paramstart:e]
+                        newdtd.entityparameter += line[paramstart:e]  # ty:ignore[unresolved-attribute]
                         while e < len(line) and line[e].isspace():
                             e += 1
                         line = line[e:]

--- a/translate/storage/flatxml.py
+++ b/translate/storage/flatxml.py
@@ -198,7 +198,7 @@ class FlatXMLFile(base.TranslationStore):
         self.root = etree.Element(self.namespaced(self.root_name))
         self.document = self.root.getroottree()
 
-    def parse(self, xml) -> None:
+    def parse(self, xml) -> None:  # ty:ignore[invalid-method-override]
         """Parses the passed xml file into the backing document."""
         if not hasattr(self, "filename"):
             self.filename = getattr(xml, "name", "")

--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -409,7 +409,7 @@ class FluentSelectorBranch:
         # A SelectExpression will be wrapped by at least on Placeable, but in
         # principle could be be wrapped by a longer series of Placeables.
         while isinstance(fluent_node, ast.Placeable):
-            fluent_node = fluent_node.expression
+            fluent_node = fluent_node.expression  # ty:ignore[invalid-assignment]
             if isinstance(fluent_node, ast.SelectExpression):
                 return fluent_node
         return None
@@ -536,7 +536,7 @@ class FluentSelectorBranch:
         :raise ValueError: If we reach a node that has no branch in the given
         list.
         """
-        pattern = ast.Pattern(list(self.to_flat_pattern_elements(branches)))
+        pattern = ast.Pattern(list(self.to_flat_pattern_elements(branches)))  # ty:ignore[invalid-argument-type]
         return _fluent_pattern_to_source(pattern)
 
     def branch_paths(self) -> Iterator[list[FluentSelectorBranch]]:
@@ -779,7 +779,7 @@ class FluentUnit(base.TranslationUnit):
 
         return f"gen-{hashlib.sha256(source.encode()).hexdigest()}"
 
-    def getid(self) -> str | None:
+    def getid(self) -> str | None:  # ty:ignore[invalid-method-override]
         return self._id
 
     # From fluent EBNF.
@@ -830,11 +830,11 @@ class FluentUnit(base.TranslationUnit):
         :return: A new FluentUnit.
         """
         if isinstance(fluent_entry, ast.ResourceComment):
-            return cls(comment=fluent_entry.content, fluent_type="ResourceComment")
+            return cls(comment=fluent_entry.content, fluent_type="ResourceComment")  # ty:ignore[invalid-argument-type]
         if isinstance(fluent_entry, ast.GroupComment):
-            return cls(comment=fluent_entry.content, fluent_type="GroupComment")
+            return cls(comment=fluent_entry.content, fluent_type="GroupComment")  # ty:ignore[invalid-argument-type]
         if isinstance(fluent_entry, ast.Comment):
-            return cls(comment=fluent_entry.content, fluent_type="DetachedComment")
+            return cls(comment=fluent_entry.content, fluent_type="DetachedComment")  # ty:ignore[invalid-argument-type]
         if isinstance(fluent_entry, ast.Term):
             return cls._create_from_fluent_pattern(
                 fluent_entry, "Term", f"-{fluent_entry.id.name}", comment
@@ -971,7 +971,7 @@ class FluentUnit(base.TranslationUnit):
                 for annotation in entry.annotations:
                     # Convert the fluent error position into a line number and
                     # offset of the unit's source.
-                    offset = annotation.span.start
+                    offset = annotation.span.start  # ty:ignore[possibly-missing-attribute]
                     line = 0
                     for added, orig in source_lines:
                         if not orig:
@@ -1082,7 +1082,7 @@ class FluentFile(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile.read())
 
-    def parse(self, fluentsrc: bytes) -> None:
+    def parse(self, fluentsrc: bytes) -> None:  # ty:ignore[invalid-method-override]
         found_ids = []
         resource = parse(fluentsrc.decode("utf-8"))
         for entry in resource.body:
@@ -1097,7 +1097,7 @@ class FluentFile(base.TranslationStore):
             if isinstance(entry, ast.ResourceComment)
         ]
 
-        resource_comments = "\n".join(resource_comment_list)
+        resource_comments = "\n".join(resource_comment_list)  # ty:ignore[no-matching-overload]
         comment_prefix = resource_comments
         for entry in resource.body:
             if isinstance(entry, ast.BaseComment):
@@ -1108,13 +1108,13 @@ class FluentFile(base.TranslationStore):
             elif isinstance(entry, (ast.Term, ast.Message)):
                 unit = FluentUnit.new_from_entry(
                     entry,
-                    self._combine_comments(comment_prefix, entry.comment),
+                    self._combine_comments(comment_prefix, entry.comment),  # ty:ignore[invalid-argument-type]
                 )
                 unit_id = unit.getid()
                 if unit_id in found_ids:
                     raise ValueError(
                         f'Entry "{unit_id}" has the same id as a previous entry'
-                        f" [offset {entry.span.start}]"
+                        f" [offset {entry.span.start}]"  # ty:ignore[possibly-missing-attribute]
                     )
                 found_ids.append(unit_id)
 
@@ -1123,7 +1123,7 @@ class FluentFile(base.TranslationStore):
                     raise ValueError(
                         f'Entry "{unit_id}" assigns to the same '
                         f'"{dup_attr.id.name}" attribute more than once '
-                        f"[offset {dup_attr.span.start}]"
+                        f"[offset {dup_attr.span.start}]"  # ty:ignore[possibly-missing-attribute]
                     )
                 self.addunit(unit)
             else:
@@ -1136,11 +1136,11 @@ class FluentFile(base.TranslationStore):
         """Convert the given fluent Junk object into a ValueError."""
         error_message = [
             "Parsing error for fluent source: "
-            + junk.content.strip()[0:64].replace("\n", "\\n")
+            + junk.content.strip()[0:64].replace("\n", "\\n")  # ty:ignore[possibly-missing-attribute]
             + "[...]"
         ]
         error_message.extend(
-            f"{annotation.code}: {annotation.message} [offset {annotation.span.start}]"
+            f"{annotation.code}: {annotation.message} [offset {annotation.span.start}]"  # ty:ignore[possibly-missing-attribute]
             for annotation in junk.annotations
         )
         return ValueError("\n".join(error_message))

--- a/translate/storage/fpo.py
+++ b/translate/storage/fpo.py
@@ -191,7 +191,7 @@ class pounit(pocommon.pounit):
 
     def merge(
         self, otherpo, overwrite=False, comments=True, authoritative=False
-    ) -> None:
+    ) -> None:  # ty:ignore[invalid-method-override]
         """
         Merges the otherpo (with the same msgid) into this one.
 
@@ -291,7 +291,7 @@ class pounit(pocommon.pounit):
         """Alters whether a given typecomment is present."""
         if self.hastypecomment(typecomment) != present:
             if present:
-                self.typecomments.append(f"#, {typecomment}\n")
+                self.typecomments.append(f"#, {typecomment}\n")  # ty:ignore[possibly-missing-attribute]
             else:
                 # this should handle word boundaries properly ...
                 typecomments = [
@@ -450,7 +450,7 @@ class pofile(pocommon.pofile):
             # only add a temporary header
             self._cpo_store.makeheader(charset=self.encoding, encoding="8bit")
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Parses the given file or file source string."""
         try:
             if hasattr(input, "name"):

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -29,7 +29,7 @@ from translate.storage.base import ParseError
 
 # Override the piclose tag from simple > to ?> otherwise we consume HTML
 # within the processing instructions
-html.parser.piclose = re.compile(r"\?>")
+html.parser.piclose = re.compile(r"\?>")  # ty:ignore[unresolved-attribute]
 
 
 class htmlunit(base.TranslationUnit):
@@ -215,7 +215,7 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
         self.guess_encoding(htmlsrc)
         return htmlsrc.decode(self.encoding)
 
-    def parse(self, htmlsrc) -> None:
+    def parse(self, htmlsrc) -> None:  # ty:ignore[invalid-method-override]
         htmlsrc = self.do_encoding(htmlsrc)
         self.feed(htmlsrc)
 

--- a/translate/storage/ical.py
+++ b/translate/storage/ical.py
@@ -95,19 +95,19 @@ class icalfile(base.TranslationStore):
         for unit in self.units:
             for location in unit.getlocations():
                 match = ICAL_UNIT_LOCATION_RE.match(location)
-                for component in self._icalfile.components():
+                for component in self._icalfile.components():  # ty:ignore[possibly-missing-attribute]
                     if component.name != "VEVENT":
                         continue
-                    if component.uid.value != match.groupdict()["uid"]:
+                    if component.uid.value != match.groupdict()["uid"]:  # ty:ignore[possibly-missing-attribute]
                         continue
                     for property in component.getChildren():
-                        if property.name == match.groupdict()["property"]:
+                        if property.name == match.groupdict()["property"]:  # ty:ignore[possibly-missing-attribute]
                             property.value = unit.target
 
         if outicalfile:
             outicalfile.serialize(out)
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Parse the given file or file source string."""
         if hasattr(input, "name"):
             self.filename = input.name

--- a/translate/storage/ini.py
+++ b/translate/storage/ini.py
@@ -144,7 +144,7 @@ class inifile(base.TranslationStore):
         if outinifile:
             out.write(str(outinifile).encode("utf-8"))
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Parse the given file or file source string."""
         if hasattr(input, "name"):
             self.filename = input.name

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -129,7 +129,7 @@ class BaseJsonUnit(base.DictUnit):
     def setid(self, value, unitid=None) -> None:
         super().setid(value, unitid)
         self.get_unitid()
-        self._item = self._unitid.parts[-1][1]
+        self._item = self._unitid.parts[-1][1]  # ty:ignore[possibly-missing-attribute]
 
     def getid(self):
         return self._id
@@ -173,7 +173,7 @@ class DumpArgsType(TypedDict):
     sort_keys: NotRequired[bool]
 
 
-class JsonFile(base.DictStore[FlatJsonUnit]):
+class JsonFile(base.DictStore[BaseJsonUnit]):
     """A JSON file."""
 
     UnitClass: ClassVar[type[BaseJsonUnit]] = FlatJsonUnit
@@ -195,7 +195,7 @@ class JsonFile(base.DictStore[FlatJsonUnit]):
     def serialize(self, out) -> None:
         units = self.get_root_node()
         self.serialize_units(units)
-        out.write(json.dumps(units, **self.dump_args).encode(self.encoding))
+        out.write(json.dumps(units, **self.dump_args).encode(self.encoding))  # ty:ignore[invalid-argument-type]
         out.write(b"\n")
 
     def _extract_units(
@@ -389,9 +389,10 @@ class I18NextUnit(JsonNestedUnit):
         if not isinstance(self.target, multistring):
             super().storevalues(output)
         else:
-            if len(self.target.strings) > len(self._store.get_plural_tags()):
+            if len(self.target.strings) > len(self._store.get_plural_tags()):  # ty:ignore[possibly-missing-attribute]
                 self.target.extra_strings = self.target.extra_strings[
-                    : len(self._store.get_plural_tags()) - 1
+                    : len(self._store.get_plural_tags())  # ty:ignore[possibly-missing-attribute]
+                    - 1
                 ]
             self._fixup_item()
             for i, value in enumerate(self.target.strings):
@@ -479,7 +480,7 @@ class I18NextV4Unit(I18NextUnit):
 
     def _get_plural_labels(self, count):
         base_name = self._get_base_name()
-        return [f"{base_name}_{self._store.get_plural_tags()[i]}" for i in range(count)]
+        return [f"{base_name}_{self._store.get_plural_tags()[i]}" for i in range(count)]  # ty:ignore[possibly-missing-attribute]
 
 
 class I18NextV4File(JsonNestedFile):
@@ -602,7 +603,7 @@ class GoTextJsonUnit(BaseJsonUnit):
     def getvalue(self):
         target = self.target
         if isinstance(target, multistring):
-            strings = self.sync_plural_count(target, self._store.get_plural_tags())
+            strings = self.sync_plural_count(target, self._store.get_plural_tags())  # ty:ignore[possibly-missing-attribute]
             target = {
                 "select": {
                     "feature": "plural",
@@ -612,7 +613,7 @@ class GoTextJsonUnit(BaseJsonUnit):
                 target["select"]["arg"] = self.placeholders[0]["id"]
             target["select"]["cases"] = {
                 plural: {"msg": strings[offset]}
-                for offset, plural in enumerate(self._store.get_plural_tags())
+                for offset, plural in enumerate(self._store.get_plural_tags())  # ty:ignore[possibly-missing-attribute]
             }
         value = {"id": self._unitid.parts if self._unitid else self.getid()}
         if self.message:
@@ -704,7 +705,7 @@ class GoTextJsonFile(JsonFile):
             "language": self.gettargetlanguage(),
             "messages": units,
         }
-        out.write(json.dumps(file, **self.dump_args).encode(self.encoding))
+        out.write(json.dumps(file, **self.dump_args).encode(self.encoding))  # ty:ignore[invalid-argument-type]
         out.write(b"\n")
 
 
@@ -714,10 +715,10 @@ class GoI18NJsonUnit(FlatJsonUnit):
     def getvalue(self):
         target = self.target
         if isinstance(target, multistring):
-            strings = self.sync_plural_count(target, self._store.get_plural_tags())
+            strings = self.sync_plural_count(target, self._store.get_plural_tags())  # ty:ignore[possibly-missing-attribute]
             target = {
                 plural: strings[offset]
-                for offset, plural in enumerate(self._store.get_plural_tags())
+                for offset, plural in enumerate(self._store.get_plural_tags())  # ty:ignore[possibly-missing-attribute]
             }
         value = {"id": self.getid()}
         if self.notes:
@@ -778,7 +779,7 @@ class GoI18NJsonFile(JsonFile):
 
     def serialize(self, out) -> None:
         units = [unit.getvalue() for unit in self.units]
-        out.write(json.dumps(units, **self.dump_args).encode(self.encoding))
+        out.write(json.dumps(units, **self.dump_args).encode(self.encoding))  # ty:ignore[invalid-argument-type]
         out.write(b"\n")
 
 
@@ -796,8 +797,8 @@ class GoI18NV2JsonUnit(FlatJsonUnit):
         if self.notes:
             target["description"] = self.notes
 
-        strings = self.sync_plural_count(self.target, self._store.get_plural_tags())
-        for offset, plural in enumerate(self._store.get_plural_tags()):
+        strings = self.sync_plural_count(self.target, self._store.get_plural_tags())  # ty:ignore[possibly-missing-attribute]
+        for offset, plural in enumerate(self._store.get_plural_tags()):  # ty:ignore[possibly-missing-attribute]
             target[plural] = strings[offset]
 
         return target
@@ -1077,7 +1078,7 @@ class NextcloudJsonFile(JsonFile):
         output = dict(self._metadata)
         output["translations"] = translations
 
-        out.write(json.dumps(output, **self.dump_args).encode(self.encoding))
+        out.write(json.dumps(output, **self.dump_args).encode(self.encoding))  # ty:ignore[invalid-argument-type]
         out.write(b"\n")
 
 

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -227,7 +227,7 @@ class LISAunit(base.TranslationUnit):
                 if getXMLlang(set) == lang:
                     return set
         else:  # have to use index
-            if index >= len(languageNodes):
+            if index >= len(languageNodes):  # ty:ignore[unsupported-operator]
                 return None
             return languageNodes[index]
         return None
@@ -342,7 +342,7 @@ class LISAfile(base.TranslationStore[U]):
         unit.namespace = self.namespace
         super().addunit(unit)
         if new:
-            self.body.append(unit.xmlelement)
+            self.body.append(unit.xmlelement)  # ty:ignore[possibly-missing-attribute]
 
     def removeunit(self, unit) -> None:
         super().removeunit(unit)
@@ -379,9 +379,9 @@ class LISAfile(base.TranslationStore[U]):
             doctype=self.XMLdoctype,
         )
 
-        out.write(self.serialize_hook(treestring))
+        out.write(self.serialize_hook(treestring))  # ty:ignore[invalid-argument-type]
 
-    def parse(self, xml) -> None:
+    def parse(self, xml) -> None:  # ty:ignore[invalid-method-override]
         """Populates this object from the given xml string."""
         if not hasattr(self, "filename"):
             self.filename = getattr(xml, "name", "")

--- a/translate/storage/markdown.py
+++ b/translate/storage/markdown.py
@@ -162,7 +162,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
         *extras,
         max_line_length: int | None = None,
     ) -> None:
-        super().__init__(*extras, max_line_length=max_line_length)
+        super().__init__(*extras, max_line_length=max_line_length)  # ty:ignore[invalid-argument-type]
         self.translate_callback = translate_callback
         self.bypass = False
         self.path = []
@@ -172,7 +172,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
         try:
             # set the root node here, because the rendering also involves some parsing,
             # and the parsing requires a valid root node.
-            mistletoe.token._root_node = token
+            mistletoe.token._root_node = token  # ty:ignore[invalid-assignment]
             return super().render(token)
         finally:
             mistletoe.token._root_node = None
@@ -183,7 +183,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     _leading_ws = re.compile(r"^(\s+)\S")
     _trailing_ws = re.compile(r"\S(\s+)$")
 
-    def render_raw_text(self, token: span_token.RawText) -> Iterable[Fragment]:
+    def render_raw_text(self, token: span_token.RawText) -> Iterable[Fragment]:  # ty:ignore[invalid-method-override]
         # make separate fragments for leading and trailing space, if applicable
         match = self._leading_ws.search(token.content)
         if match:
@@ -196,15 +196,15 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
         else:
             yield Fragment(token.content, wordwrap=True)
 
-    def render_auto_link(self, token: span_token.AutoLink) -> Iterable[Fragment]:
+    def render_auto_link(self, token: span_token.AutoLink) -> Iterable[Fragment]:  # ty:ignore[invalid-method-override]
         # replace with placeholder, unless in bypass mode
         if self.bypass:
             yield from super().render_auto_link(token)
             return
 
-        yield Fragment(None, placeholder_content=super().render_auto_link(token))
+        yield Fragment(None, placeholder_content=super().render_auto_link(token))  # ty:ignore[invalid-argument-type]
 
-    def render_line_break(self, token: span_token.LineBreak) -> Iterable[Fragment]:
+    def render_line_break(self, token: span_token.LineBreak) -> Iterable[Fragment]:  # ty:ignore[invalid-method-override]
         if self.bypass:
             yield from super().render_line_break(token)
             return
@@ -217,7 +217,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
             yield from super().render_html_span(token)
             return
 
-        yield Fragment(None, placeholder_content=super().render_html_span(token))
+        yield Fragment(None, placeholder_content=super().render_html_span(token))  # ty:ignore[invalid-argument-type]
 
     def render_link_or_image(
         self, token: span_token.SpanToken, target: str
@@ -226,47 +226,49 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
             yield from super().render_link_or_image(token, target)
             return
 
-        yield from self.embed_span(Fragment("["), token.children, Fragment("]"))
+        yield from self.embed_span(Fragment("["), token.children, Fragment("]"))  # ty:ignore[invalid-argument-type]
 
-        if token.dest_type in {"uri", "angle_uri"}:
+        if token.dest_type in {"uri", "angle_uri"}:  # ty:ignore[unresolved-attribute]
             # Markdown link format: "[" description "](" dest_part [" " title] ")"
-            dest_part = f"<{target}>" if token.dest_type == "angle_uri" else target
-            placeholder = Fragment(None, important=True)
-            placeholder.placeholder_content = [
+            dest_part = f"<{target}>" if token.dest_type == "angle_uri" else target  # ty:ignore[unresolved-attribute]
+            placeholder = Fragment(None, important=True)  # ty:ignore[invalid-argument-type]
+            placeholder.placeholder_content = [  # ty:ignore[unresolved-attribute]
                 Fragment("("),
                 Fragment(dest_part),
             ]
-            if token.title:
+            if token.title:  # ty:ignore[unresolved-attribute]
                 translated_title = self.translate_callback(
-                    token.title, [*self.path, "link-title"]
+                    token.title,  # ty:ignore[unresolved-attribute]
+                    [*self.path, "link-title"],
                 )
-                placeholder.placeholder_content.extend(
+                placeholder.placeholder_content.extend(  # ty:ignore[unresolved-attribute]
                     [
                         Fragment(" ", wordwrap=True),
-                        Fragment(token.title_delimiter),
+                        Fragment(token.title_delimiter),  # ty:ignore[unresolved-attribute]
                         Fragment(translated_title, wordwrap=True),
                         Fragment(
                             ")"
-                            if token.title_delimiter == "("
-                            else token.title_delimiter
+                            if token.title_delimiter == "("  # ty:ignore[unresolved-attribute]
+                            else token.title_delimiter  # ty:ignore[unresolved-attribute]
                         ),
                     ]
                 )
-            placeholder.placeholder_content.append(Fragment(")"))
+            placeholder.placeholder_content.append(Fragment(")"))  # ty:ignore[unresolved-attribute]
             yield placeholder
-        elif token.dest_type == "full":
+        elif token.dest_type == "full":  # ty:ignore[unresolved-attribute]
             # Markdown link format: "[" description "][" label "]"
             translated_label = self.translate_callback(
-                token.label, [*self.path, "link-label"]
+                token.label,  # ty:ignore[unresolved-attribute]
+                [*self.path, "link-label"],
             )
-            placeholder = Fragment(None, important=True)
-            placeholder.placeholder_content = [
+            placeholder = Fragment(None, important=True)  # ty:ignore[invalid-argument-type]
+            placeholder.placeholder_content = [  # ty:ignore[unresolved-attribute]
                 Fragment("["),
                 Fragment(translated_label, wordwrap=True),
                 Fragment("]"),
             ]
             yield placeholder
-        elif token.dest_type == "collapsed":
+        elif token.dest_type == "collapsed":  # ty:ignore[unresolved-attribute]
             # Markdown link format: "[" description "][]"
             yield Fragment("[]")
         else:
@@ -289,8 +291,8 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
                 else None
             )
 
-        placeholder = Fragment(None)
-        placeholder.placeholder_content = [
+        placeholder = Fragment(None)  # ty:ignore[invalid-argument-type]
+        placeholder.placeholder_content = [  # ty:ignore[unresolved-attribute]
             Fragment("["),
             Fragment(label, wordwrap=True),
             Fragment("]: ", wordwrap=True),
@@ -299,7 +301,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
             ),
         ]
         if title:
-            placeholder.placeholder_content.extend(
+            placeholder.placeholder_content.extend(  # ty:ignore[unresolved-attribute]
                 [
                     Fragment(" ", wordwrap=True),
                     Fragment(token.title_delimiter),
@@ -316,8 +318,8 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
 
     def render_heading(
         self, token: block_token.Heading, max_line_length: int
-    ) -> Iterable[str]:
-        self.path.append(f":{token.line_number}")
+    ) -> Iterable[str]:  # ty:ignore[invalid-method-override]
+        self.path.append(f":{token.line_number}")  # ty:ignore[unresolved-attribute]
         content = list(super().render_heading(token, max_line_length=max_line_length))
         self.path.pop()
         return content
@@ -325,7 +327,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     def render_setext_heading(
         self, token: block_token.SetextHeading, max_line_length: int
     ) -> Iterable[str]:
-        self.path.append(f":{token.line_number}")
+        self.path.append(f":{token.line_number}")  # ty:ignore[unresolved-attribute]
         content = list(
             super().render_setext_heading(token, max_line_length=max_line_length)
         )
@@ -334,16 +336,16 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
 
     def render_quote(
         self, token: block_token.Quote, max_line_length: int
-    ) -> Iterable[str]:
-        self.path.append(f":{token.line_number}")
+    ) -> Iterable[str]:  # ty:ignore[invalid-method-override]
+        self.path.append(f":{token.line_number}")  # ty:ignore[unresolved-attribute]
         content = list(super().render_quote(token, max_line_length=max_line_length))
         self.path.pop()
         return content
 
     def render_paragraph(
         self, token: block_token.Paragraph, max_line_length: int
-    ) -> Iterable[str]:
-        self.path.append(f":{token.line_number}")
+    ) -> Iterable[str]:  # ty:ignore[invalid-method-override]
+        self.path.append(f":{token.line_number}")  # ty:ignore[unresolved-attribute]
         content = list(super().render_paragraph(token, max_line_length=max_line_length))
         self.path.pop()
         return content
@@ -363,7 +365,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
 
     def render_list_item(
         self, token: block_token.ListItem, max_line_length: int
-    ) -> Iterable[str]:
+    ) -> Iterable[str]:  # ty:ignore[invalid-method-override]
         self.path.append(f":{token.line_number}")
         content = list(super().render_list_item(token, max_line_length=max_line_length))
         self.path.pop()
@@ -371,8 +373,8 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
 
     def render_table(
         self, token: block_token.Table, max_line_length: int
-    ) -> Iterable[str]:
-        self.path.append(f":{token.line_number}")
+    ) -> Iterable[str]:  # ty:ignore[invalid-method-override]
+        self.path.append(f":{token.line_number}")  # ty:ignore[unresolved-attribute]
         content = list(super().render_table(token, max_line_length=max_line_length))
         self.path.pop()
         return content
@@ -380,7 +382,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     def render_link_reference_definition_block(
         self, token: LinkReferenceDefinitionBlock, max_line_length: int
     ) -> Iterable[str]:
-        self.path.append(f":{token.line_number}")
+        self.path.append(f":{token.line_number}")  # ty:ignore[unresolved-attribute]
         content = list(
             super().render_link_reference_definition_block(
                 token, max_line_length=max_line_length
@@ -423,7 +425,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
 
             # render the translatable content (with placeholders) to markdown
             content_md = "\n".join(
-                self.fragments_to_lines(content, max_line_length=float("inf"))
+                self.fragments_to_lines(content, max_line_length=float("inf"))  # ty:ignore[invalid-argument-type]
             )
 
             # translate and parse into new fragments. handle hard line breaks.
@@ -464,8 +466,8 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
                         break
                 if end:
                     chunk = fragments[start:end]
-                    placeholder = Fragment(None, placeholder_content=chunk)
-                    placeholder.important = any(
+                    placeholder = Fragment(None, placeholder_content=chunk)  # ty:ignore[invalid-argument-type]
+                    placeholder.important = any(  # ty:ignore[unresolved-attribute]
                         getattr(fragment, "important", False) for fragment in chunk
                     )
                     fragments[start:end] = (placeholder,)
@@ -526,9 +528,9 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     ) -> str:
         """Replaces placeholder markers in the given markdown with placeholder content."""
         for index, placeholder in enumerate(placeholders):
-            content = self.expand_placeholders(placeholder.placeholder_content)
+            content = self.expand_placeholders(placeholder.placeholder_content)  # ty:ignore[unresolved-attribute]
             content_md = "\n".join(
-                self.fragments_to_lines(content, max_line_length=float("inf"))
+                self.fragments_to_lines(content, max_line_length=float("inf"))  # ty:ignore[invalid-argument-type]
             )
             markdown = markdown.replace(f"{{{index + 1}}}", content_md)
 

--- a/translate/storage/mo.py
+++ b/translate/storage/mo.py
@@ -56,7 +56,7 @@ def mounpack(filename="messages.mo"):
     """Helper to unpack Gettext MO files into a Python string."""
     with open(filename, "rb") as fh:
         s = fh.read()
-        return "\\x%02x" * len(s) % tuple(map(ord, s))
+        return "\\x%02x" * len(s) % tuple(map(ord, s))  # ty:ignore[invalid-argument-type]
 
 
 def my_swap4(result):
@@ -242,7 +242,7 @@ class mofile(poheader.poheader, base.TranslationStore):
             out.write(strs)
 
     @staticmethod
-    def parse_header(content: list[bytes]) -> tuple[str, int, int, int, int, int]:
+    def parse_header(content: bytes) -> tuple[str, int, int, int, int, int, int, int]:
         (little,) = struct.unpack("<L", content[:4])
         (big,) = struct.unpack(">L", content[:4])
         if little == MO_MAGIC_NUMBER:
@@ -270,13 +270,13 @@ class mofile(poheader.poheader, base.TranslationStore):
             offsethash,
         )
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Parses the given file or file source string."""
         if hasattr(input, "name"):
             self.filename = input.name
         elif not getattr(self, "filename", ""):
             self.filename = ""
-        content: list[bytes]
+        content: bytes
         if hasattr(input, "read"):
             mosrc = input.read()
             input.close()

--- a/translate/storage/mozilla_lang.py
+++ b/translate/storage/mozilla_lang.py
@@ -88,7 +88,7 @@ class LangStore(txt.TxtFile):
         self.location_root = getattr(inputfile, "location_root", "")
         super().__init__(inputfile, **kwargs)
 
-    def parse(self, lines) -> None:
+    def parse(self, lines) -> None:  # ty:ignore[invalid-method-override]
         source_unit = None
         comment = ""
         if not isinstance(lines, list):
@@ -138,7 +138,7 @@ class LangStore(txt.TxtFile):
 
             if line.startswith(";"):
                 source_unit = self.addsourceunit(line[1:])
-                source_unit.eol = self.eol
+                source_unit.eol = self.eol  # ty:ignore[unresolved-attribute]
                 source_unit._line_number = lineoffset + 1
                 source_unit.addlocation(
                     f"{self.filename[len(self.location_root) :]}:{lineoffset + 1}"

--- a/translate/storage/omegat.py
+++ b/translate/storage/omegat.py
@@ -137,7 +137,7 @@ class OmegaTFile(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Parsese the given file or file source string."""
         if hasattr(input, "name"):
             self.filename = input.name

--- a/translate/storage/oo.py
+++ b/translate/storage/oo.py
@@ -459,7 +459,7 @@ class oomultifile:
         """Returns a pseudo-file object for the given subfile."""
         subfilesrc = self.getsubfilesrc(subfile)
         inputfile = BytesIO(subfilesrc.encode())
-        inputfile.filename = subfile
+        inputfile.filename = subfile  # ty:ignore[unresolved-attribute]
         return inputfile
 
     def openoutputfile(self, subfile):
@@ -472,7 +472,7 @@ class oomultifile:
             self.multifile.flush()
 
         outputfile = wStringIO.CatchStringOutput(onclose)
-        outputfile.filename = subfile
+        outputfile.filename = subfile  # ty:ignore[unresolved-attribute]
         return outputfile
 
     def getoofile(self, subfile):

--- a/translate/storage/php.py
+++ b/translate/storage/php.py
@@ -416,7 +416,7 @@ class phpfile(base.TranslationStore):
             newunit.addnote(comment, "developer")
         self.addunit(newunit)
 
-    def parse(self, phpsrc) -> None:
+    def parse(self, phpsrc) -> None:  # ty:ignore[invalid-method-override]
         """Read the source of a PHP file in and include them as units."""
 
         def handle_array(prefix, nodes, lexer) -> None:

--- a/translate/storage/pocommon.py
+++ b/translate/storage/pocommon.py
@@ -125,7 +125,7 @@ class pounit(base.TranslationUnit):
         # implementation specific fuzzy detection, must not use get_state_n()
         raise NotImplementedError
 
-    def markfuzzy(self, present=True) -> None:
+    def markfuzzy(self, present=True) -> None:  # ty:ignore[invalid-method-override]
         if present:
             self.set_state_n(self.STATE[self.S_FUZZY][0])
         else:

--- a/translate/storage/poheader.py
+++ b/translate/storage/poheader.py
@@ -201,9 +201,9 @@ class poheader:
         allowed to be a header. Note that this could still return an empty
         header element, if present.
         """
-        if len(self.units) == 0:
+        if len(self.units) == 0:  # ty:ignore[unresolved-attribute]
             return None
-        candidate = self.units[0]
+        candidate = self.units[0]  # ty:ignore[unresolved-attribute]
         if candidate.isheader():
             return candidate
         return None
@@ -256,7 +256,7 @@ class poheader:
         # subtly broken for POXLIFF, since we don't duplicate the code
         # from lisa::addunit().
         header._store = self
-        self.units.insert(0, header)
+        self.units.insert(0, header)  # ty:ignore[unresolved-attribute]
 
     def getheaderplural(self):
         """Returns the nplural and plural values from the header."""
@@ -447,7 +447,7 @@ class poheader:
 
         Check .makeheaderdict() for information on parameters.
         """
-        headerpo = self.UnitClass("", encoding=self._encoding)
+        headerpo = self.UnitClass("", encoding=self._encoding)  # ty:ignore[unresolved-attribute]
         # This is hack to make sure proper newlines are used
         # in markfuzzy -> settypecomment calls.
         headerpo._store = self

--- a/translate/storage/poxliff.py
+++ b/translate/storage/poxliff.py
@@ -97,7 +97,7 @@ class PoXliffUnit(xliff.xliffunit):
     def source(self, source) -> None:
         self.setsource(source, sourcelang="en")
 
-    def setsource(self, source, sourcelang="en") -> None:
+    def setsource(self, source, sourcelang="en") -> None:  # ty:ignore[invalid-method-override]
         # TODO: consider changing from plural to singular, etc.
         self._rich_source = None
         if not hasplurals(source):
@@ -116,7 +116,7 @@ class PoXliffUnit(xliff.xliffunit):
             self.target = target
 
     # We don't support any rich strings yet
-    multistring_to_rich = base.TranslationUnit.multistring_to_rich
+    multistring_to_rich = base.TranslationUnit.multistring_to_rich  # ty:ignore[invalid-method-override]
     rich_to_multistring = base.TranslationUnit.rich_to_multistring
 
     rich_source = base.TranslationUnit.rich_source
@@ -199,7 +199,7 @@ class PoXliffUnit(xliff.xliffunit):
         for unit in self.units[1:]:
             unit.marktranslated()
 
-    def setid(self, id) -> None:
+    def setid(self, id) -> None:  # ty:ignore[invalid-method-override]
         super().setid(id)
         if len(self.units) > 1:
             for i, unit in enumerate(self.units):
@@ -289,7 +289,7 @@ class PoXliffFile(xliff.xlifffile, poheader.poheader):
             kwargs["sourcelanguage"] = "en-US"
         xliff.xlifffile.__init__(self, *args, **kwargs)
 
-    def createfilenode(self, filename, sourcelanguage="en-US", datatype="po"):
+    def createfilenode(self, filename, sourcelanguage="en-US", datatype="po"):  # ty:ignore[invalid-method-override]
         # Let's ignore the sourcelanguage parameter opting for the internal
         # one. PO files will probably be one language
         return super().createfilenode(
@@ -310,7 +310,7 @@ class PoXliffFile(xliff.xlifffile, poheader.poheader):
         setXMLspace(unit.xmlelement, "preserve")
         return unit
 
-    def parse(self, xml) -> None:
+    def parse(self, xml) -> None:  # ty:ignore[invalid-method-override]
         """Populates this object from the given xml string."""
         # TODO: Make more robust
 

--- a/translate/storage/project.py
+++ b/translate/storage/project.py
@@ -17,6 +17,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import os
+from typing import cast
 
 from translate.convert import factory as convert_factory
 from translate.storage.projstore import ProjectStore
@@ -187,9 +188,12 @@ class Project:
 
         os.rename(converted_file.name, output_fname)
 
-        output_type = self.store.TYPE_INFO["next_type"][input_type]
+        output_type = cast("str", self.store.TYPE_INFO["next_type"][input_type])
         outputfile, output_fname = self.store.append_file(
-            output_fname, None, ftype=output_type, delete_orig=True
+            output_fname,
+            None,
+            ftype=output_type,
+            delete_orig=True,
         )
         self.store.convert_map[input_fname] = (output_fname, templ_fname)
 

--- a/translate/storage/projstore.py
+++ b/translate/storage/projstore.py
@@ -161,7 +161,7 @@ class ProjectStore:
             self._files[fname] = realfname
         else:
             self._files[fname] = afile
-        self.TYPE_INFO["lists"][ftype].append(fname)
+        self.TYPE_INFO["lists"][ftype].append(fname)  # ty:ignore[possibly-missing-attribute]
 
         return afile, fname
 
@@ -188,7 +188,7 @@ class ProjectStore:
                     ftype = ft
                     break
 
-        self.TYPE_INFO["lists"][ftype].remove(fname)
+        self.TYPE_INFO["lists"][ftype].remove(fname)  # ty:ignore[possibly-missing-attribute]
         if self._files[fname] and hasattr(self._files[fname], "close"):
             self._files[fname].close()
         del self._files[fname]
@@ -234,11 +234,11 @@ class ProjectStore:
             rfname = fname
             if not os.path.isfile(rfname):
                 rfname = getattr(rfile, "name", None)
-            if not rfile or not os.path.isfile(rfname):
+            if not rfile or not os.path.isfile(rfname):  # ty:ignore[invalid-argument-type]
                 rfname = getattr(rfile, "filename", None)
-            if not rfile or not os.path.isfile(rfname):
+            if not rfile or not os.path.isfile(rfname):  # ty:ignore[invalid-argument-type]
                 raise OSError(f"Could not locate file: {rfile} ({fname})")
-            rfile = open(rfname, mode)
+            rfile = open(rfname, mode)  # ty:ignore[no-matching-overload]
             self._files[fname] = rfile
 
         return rfile
@@ -246,7 +246,7 @@ class ProjectStore:
     def get_filename_type(self, fname):
         """Get the type of file ('src', 'trans', 'tgt') with the given name."""
         for ftype in self.TYPE_INFO["lists"]:
-            if fname in self.TYPE_INFO["lists"][ftype]:
+            if fname in self.TYPE_INFO["lists"][ftype]:  # ty:ignore[unsupported-operator]
                 return ftype
         raise FileNotInProjectError(fname)
 
@@ -358,7 +358,7 @@ class ProjectStore:
                 continue
 
             settings[section] = []
-            for fnode in groupnode.getchildren():
+            for fnode in groupnode.getchildren():  # ty:ignore[deprecated]
                 settings[section].append(fnode.text)
 
         conversions_el = xml.find("conversions")

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -426,7 +426,7 @@ class DialectXWiki(DialectJava):
 
     @staticmethod
     def encode(string, encoding=None):
-        return xwiki_properties_encode(string or "", encoding)
+        return xwiki_properties_encode(string or "", encoding)  # ty:ignore[invalid-argument-type]
 
     @staticmethod
     def decode(string):
@@ -479,8 +479,8 @@ class DialectGwt(DialectJavaUtf8):
     @classmethod
     def get_key_cldr_name(cls, key):
         match = cls.plural_regex.fullmatch(key)
-        basekey = match.group(1)
-        variant = match.group(2)
+        basekey = match.group(1)  # ty:ignore[possibly-missing-attribute]
+        variant = match.group(2)  # ty:ignore[possibly-missing-attribute]
         if variant is None:
             variant = ""
 
@@ -695,7 +695,7 @@ class proppluralunit(base.TranslationUnit):
         return [key for key in data.cldr_plural_categories if key in existing]
 
     def _get_source_mapping(self):
-        cldr_mapping = proppluralunit._get_language_mapping(self._store.sourcelanguage)
+        cldr_mapping = proppluralunit._get_language_mapping(self._store.sourcelanguage)  # ty:ignore[possibly-missing-attribute]
         if cldr_mapping:
             return cldr_mapping
         return self._get_existing_mapping()
@@ -733,7 +733,7 @@ class proppluralunit(base.TranslationUnit):
     def _get_ordered_units(self):
         # Used for str (GWT order)
         mapping = self.personality.get_expand_output_target_mapping(
-            self._store.get_plural_tags()
+            self._store.get_plural_tags()  # ty:ignore[possibly-missing-attribute]
         )
         names = [
             name for name in self.personality.get_cldr_names_order() if name in mapping
@@ -756,7 +756,7 @@ class proppluralunit(base.TranslationUnit):
         else:
             strings = [text]
         if mapping is None:
-            mapping = self._store.get_plural_tags()
+            mapping = self._store.get_plural_tags()  # ty:ignore[possibly-missing-attribute]
 
         strings = self._get_strings(strings, mapping)
         units = self._get_units(mapping)
@@ -771,7 +771,7 @@ class proppluralunit(base.TranslationUnit):
             b.target = a
 
     def gettarget(self):
-        ll = [x.target for x in self._get_units(self._store.get_plural_tags())]
+        ll = [x.target for x in self._get_units(self._store.get_plural_tags())]  # ty:ignore[possibly-missing-attribute]
         if len(ll) > 1:
             return multistring(ll)
         return ll[0]
@@ -1130,7 +1130,7 @@ class propfile(base.TranslationStore):
             self.parse(propsrc)
             self.makeindex()
 
-    def parse(self, propsrc) -> None:
+    def parse(self, propsrc) -> None:  # ty:ignore[invalid-method-override]
         """Read the source of a properties file in and include them as units."""
         text, encoding = self.detect_encoding(
             propsrc,
@@ -1149,7 +1149,7 @@ class propfile(base.TranslationStore):
         was_header = False
         unit_start_line = 1
 
-        for linenum, line in enumerate(propsrc.split("\n"), start=1):
+        for linenum, line in enumerate(propsrc.split("\n"), start=1):  # ty:ignore[possibly-missing-attribute]
             # handle multiline value if we're in one
             line = rstripeol(line)
             if inmultilinevalue:
@@ -1424,15 +1424,15 @@ class XWikiPageProperties(xwikifile):
         return etree.XMLParser(strip_cdata=False, resolve_entities=False)
 
     def extract_language(self) -> None:
-        language_node = self.root.find("language")
+        language_node = self.root.find("language")  # ty:ignore[possibly-missing-attribute]
         if language_node is not None and language_node.text:
             self.setsourcelanguage(language_node.text)
         else:
-            language_node = self.root.find("defaultLanguage")
+            language_node = self.root.find("defaultLanguage")  # ty:ignore[possibly-missing-attribute]
             if language_node is not None and language_node.text:
                 self.setsourcelanguage(language_node.text)
 
-    def parse(self, propsrc) -> None:
+    def parse(self, propsrc) -> None:  # ty:ignore[invalid-method-override]
         if propsrc != b"\n":
             self.root = etree.XML(propsrc, self.get_parser())
             content = "".join(self.root.find("content").itertext())
@@ -1490,7 +1490,7 @@ class XWikiFullPage(XWikiPageProperties):
 
     Name = "XWiki Full Page"
 
-    def parse(self, propsrc) -> None:
+    def parse(self, propsrc) -> None:  # ty:ignore[invalid-method-override]
         if propsrc != b"\n":
             self.root = etree.XML(propsrc, self.get_parser())
             content = "".join(self.root.find("content").itertext()).replace("\n", "\\n")

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -557,7 +557,7 @@ class pounit(pocommon.pounit):
         # rewritten here for performance:
         return (
             is_null(self.msgid)
-            and not is_null(self.msgstr)
+            and not is_null(self.msgstr)  # ty:ignore[invalid-argument-type]
             and len(self.msgidcomments) == 0
             and is_null(self.msgctxt)
         )
@@ -591,7 +591,7 @@ class pounit(pocommon.pounit):
         if not self.typecomments:
             return False
         self._ensure_typecomments_cache()
-        return typecomment in self._typecomments_cache
+        return typecomment in self._typecomments_cache  # ty:ignore[unsupported-operator]
 
     def hasmarkedcomment(self, commentmarker) -> bool:
         """
@@ -613,9 +613,9 @@ class pounit(pocommon.pounit):
             # The typecomments cache might be still missing if typecomments are not present
             self._ensure_typecomments_cache()
             if present:
-                self._typecomments_cache.append(typecomment)
+                self._typecomments_cache.append(typecomment)  # ty:ignore[possibly-missing-attribute]
             else:
-                self._typecomments_cache.remove(typecomment)
+                self._typecomments_cache.remove(typecomment)  # ty:ignore[possibly-missing-attribute]
             if self._typecomments_cache:
                 self._typecomments_cache.sort()
                 comments_str = ", ".join(self._typecomments_cache)
@@ -626,10 +626,10 @@ class pounit(pocommon.pounit):
     def isfuzzy(self):
         return self.hastypecomment("fuzzy")
 
-    def markfuzzy(self, present=True) -> None:
+    def markfuzzy(self, present=True) -> None:  # ty:ignore[invalid-method-override]
         if present:
             self.set_state_n(self.STATE[self.S_FUZZY][0])
-        elif (self.hasplural() and not self._msgstrlen()) or is_null(self.msgstr):
+        elif (self.hasplural() and not self._msgstrlen()) or is_null(self.msgstr):  # ty:ignore[invalid-argument-type]
             self.set_state_n(self.STATE[self.S_UNTRANSLATED][0])
         else:
             self.set_state_n(self.STATE[self.S_TRANSLATED][0])
@@ -861,7 +861,7 @@ class pofile(pocommon.pofile[pounit]):
     def create_unit(self):
         return self.UnitClass(wrapper=self.wrapper)
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Parses the given file or file source string."""
         if hasattr(input, "name"):
             self.filename = input.name

--- a/translate/storage/qm.py
+++ b/translate/storage/qm.py
@@ -73,7 +73,7 @@ def qmunpack(file_="messages.qm"):
     """Helper to unpack Qt .qm files into a Python string."""
     with open(file_, "rb") as fh:
         s = fh.read()
-        return "\\x%02x" * len(s) % tuple(map(ord, s))
+        return "\\x%02x" * len(s) % tuple(map(ord, s))  # ty:ignore[invalid-argument-type]
 
 
 class qmunit(base.TranslationUnit):
@@ -99,7 +99,7 @@ class qmfile(base.TranslationStore):
         """Output a string representation of the .qm data file."""
         raise NotImplementedError("Writing of .qm files is not supported yet")
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Parses the given file or file source string."""
         if hasattr(input, "name"):
             self.filename = input.name

--- a/translate/storage/qph.py
+++ b/translate/storage/qph.py
@@ -46,7 +46,7 @@ class QphUnit(lisa.LISAunit):
     textNode = ""
     namespace = ""
 
-    def createlanguageNode(self, lang, text, purpose):
+    def createlanguageNode(self, lang, text, purpose):  # ty:ignore[invalid-method-override]
         """Returns an xml Element setup with given parameters."""
         assert purpose
         langset = etree.Element(self.namespaced(purpose))

--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -154,7 +154,7 @@ class rcunit(base.TranslationUnit):
 
     def isblank(self) -> bool:
         """Returns whether this is a blank element, containing only comments."""
-        return not (self.name or self.value)
+        return not (self.name or self.value)  # ty:ignore[unresolved-attribute]
 
 
 def rc_statement() -> ParserElement:
@@ -360,7 +360,7 @@ class rcfile(base.TranslationStore):
                         sub_popup,
                     )
 
-    def parse(self, rcsrc, encoding="auto") -> None:
+    def parse(self, rcsrc, encoding="auto") -> None:  # ty:ignore[invalid-method-override]
         """Read the source of a .rc file in and include them as units."""
         self.encoding = encoding
         if encoding != "auto":
@@ -374,14 +374,14 @@ class rcfile(base.TranslationStore):
             )
 
         # Extract first newline
-        for line in decoded.splitlines(True):
+        for line in decoded.splitlines(True):  # ty:ignore[possibly-missing-attribute]
             if len(line) >= 2 and line[-2] in {"\r", "\n"}:
                 self.newline = line[-2:]
             else:
                 self.newline = line[-1]
             break
 
-        decoded = decoded.replace("\r", "")
+        decoded = decoded.replace("\r", "")  # ty:ignore[possibly-missing-attribute]
 
         # Parse the strings into a structure.
         results = rc_statement().search_string(decoded)
@@ -486,4 +486,4 @@ class rcfile(base.TranslationStore):
 
     def serialize(self, out) -> None:
         """Write the units back to file."""
-        out.write(("".join(self.blocks)).encode(self.encoding))
+        out.write(("".join(self.blocks)).encode(self.encoding))  # ty:ignore[unresolved-attribute]

--- a/translate/storage/resx.py
+++ b/translate/storage/resx.py
@@ -38,7 +38,7 @@ class RESXUnit(lisa.LISAunit):
     namespace = ""
     rich_parsers = general.parsers
 
-    def createlanguageNode(self, lang, text, purpose):
+    def createlanguageNode(self, lang, text, purpose):  # ty:ignore[invalid-method-override]
         """Returns an xml Element setup with given parameters."""
         langset = etree.Element(self.namespaced(self.languageNode))
 
@@ -224,7 +224,7 @@ class RESXFile(lisa.LISAfile):
                 # this is the first element; adjust root.
                 # should not happen in a ResX file prepared by Visual Studio
                 # since it includes an inline XSD plus resheader at all times.
-                self.body.text = "\n  "
+                self.body.text = "\n  "  # ty:ignore[invalid-assignment]
             # adjust the indent of the following <value> element
             unit.xmlelement.text = "\n    "
         return unit

--- a/translate/storage/statistics.py
+++ b/translate/storage/statistics.py
@@ -49,9 +49,9 @@ class Statistics:
     def init_checker(self, checkerstyle=None) -> None:
         checkerclasses = [
             checkerstyle or checks.StandardChecker,
-            pofilter.StandardPOChecker,
+            pofilter.StandardPOChecker,  # ty:ignore[unresolved-attribute]
         ]
-        self.checker = pofilter.POTeeChecker(checkerclasses=checkerclasses)
+        self.checker = pofilter.POTeeChecker(checkerclasses=checkerclasses)  # ty:ignore[unresolved-attribute]
 
     def fuzzy_units(self):
         """Return a list of fuzzy units."""
@@ -155,7 +155,7 @@ class Statistics:
         self.classification["total"] = []
         #        for checkname in self.checker.getfilters().keys():
         #            self.classification[f"check-{checkname}"] = []
-        for item, unit in enumerate(self.unit_iter()):
+        for item, unit in enumerate(self.unit_iter()):  # ty:ignore[unresolved-attribute]
             classes = self.classifyunit(unit)
             #            if self.basefile.getsuggestions(item):
             #                classes.append("has-suggestion")
@@ -170,7 +170,7 @@ class Statistics:
         """Counts the source and target words in each of the units."""
         self.sourcewordcounts = []
         self.targetwordcounts = []
-        for unit in self.unit_iter():
+        for unit in self.unit_iter():  # ty:ignore[unresolved-attribute]
             self.sourcewordcounts.append(
                 [self.wordcount(text) for text in getattr(unit.source, "strings", [""])]
             )

--- a/translate/storage/stringsdict.py
+++ b/translate/storage/stringsdict.py
@@ -31,7 +31,7 @@ class StringsDictUnit(base.DictUnit):
         super().__init__(source=source)
 
         loc = source or ""
-        if len(loc) > 0 and loc[0] == ":":
+        if len(loc) > 0 and loc[0] == ":":  # ty:ignore[index-out-of-bounds]
             loc = loc[1:]
 
         # Check if this unit is a format string or a variable
@@ -52,19 +52,19 @@ class StringsDictUnit(base.DictUnit):
     def outerkey(self):
         self.get_unitid()
 
-        if len(self._unitid.parts) < 1:
+        if len(self._unitid.parts) < 1:  # ty:ignore[possibly-missing-attribute]
             return None
 
-        return self._unitid.parts[0][1]
+        return self._unitid.parts[0][1]  # ty:ignore[possibly-missing-attribute]
 
     @property
     def innerkey(self):
         self.get_unitid()
 
-        if len(self._unitid.parts) < 2:
+        if len(self._unitid.parts) < 2:  # ty:ignore[possibly-missing-attribute]
             return None
 
-        return self._unitid.parts[1][1]
+        return self._unitid.parts[1][1]  # ty:ignore[possibly-missing-attribute]
 
     def getid(self):
         return self.source
@@ -128,7 +128,7 @@ class StringsDictFile(base.DictStore):
             tags.insert(0, "zero")
         return tags
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Read a .stringsdict file into a dictionary, and convert it to translation units."""
         if isinstance(input, (bytes, str)):
             plist = plistlib.loads(input)

--- a/translate/storage/subtitles.py
+++ b/translate/storage/subtitles.py
@@ -125,7 +125,7 @@ class SubtitleFile(base.TranslationStore):
             subtitle.end = unit._end
             # Restore SSA/ASS metadata only for SSA and ASS formats
             if (
-                self._format in {formats.SSA, formats.ASS}
+                self._format in {formats.SSA, formats.ASS}  # ty:ignore[unresolved-attribute]
                 and hasattr(subtitle, "ssa")
                 and subtitle.ssa
             ):
@@ -147,8 +147,8 @@ class SubtitleFile(base.TranslationStore):
         # Using transient output might be dropped if/when we have more control
         # over the open mode of out files.
         output = StringIO()
-        self._subtitlefile.write_to_file(subtitles, documents.MAIN, output)
-        out.write(output.getvalue().encode(self._subtitlefile.encoding))
+        self._subtitlefile.write_to_file(subtitles, documents.MAIN, output)  # ty:ignore[possibly-missing-attribute, unresolved-attribute]
+        out.write(output.getvalue().encode(self._subtitlefile.encoding))  # ty:ignore[possibly-missing-attribute]
 
     def _set_default_ssa_metadata(self, unit: SubtitleUnit) -> None:
         """Set default SSA metadata for a unit (helper for SSA/ASS subclasses)."""
@@ -174,7 +174,7 @@ class SubtitleFile(base.TranslationStore):
                 newunit._duration = subtitle.duration_seconds
                 # Preserve SSA/ASS metadata only for SSA and ASS formats
                 if (
-                    self._format in {formats.SSA, formats.ASS}
+                    self._format in {formats.SSA, formats.ASS}  # ty:ignore[unresolved-attribute]
                     and hasattr(subtitle, "ssa")
                     and subtitle.ssa
                 ):
@@ -212,14 +212,14 @@ class SubtitleFile(base.TranslationStore):
         newstore._parsefile(storefile)
         return newstore
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         if isinstance(input, bytes):
             # Gaupol does not allow parsing from strings
             kwargs = {"delete": False}
             if self.filename:
                 kwargs["suffix"] = self.filename
 
-            temp_file = NamedTemporaryFile(**kwargs)
+            temp_file = NamedTemporaryFile(**kwargs)  # ty:ignore[no-matching-overload]
             temp_file.close()
 
             try:
@@ -248,9 +248,9 @@ class SubRipFile(SubtitleFile):
         super().__init__(*args, **kwargs)
         if self._subtitlefile is None:
             self._subtitlefile = SubRip(self.filename or "", self.encoding)
-            self._format = formats.SUBRIP
+            self._format = formats.SUBRIP  # ty:ignore[unresolved-attribute]
         if self._subtitlefile.newline is None:
-            self._subtitlefile.newline = newlines.UNIX
+            self._subtitlefile.newline = newlines.UNIX  # ty:ignore[unresolved-attribute]
 
 
 class MicroDVDFile(SubtitleFile):
@@ -264,9 +264,9 @@ class MicroDVDFile(SubtitleFile):
         super().__init__(*args, **kwargs)
         if self._subtitlefile is None:
             self._subtitlefile = MicroDVD(self.filename or "", self.encoding)
-            self._format = formats.MICRODVD
+            self._format = formats.MICRODVD  # ty:ignore[unresolved-attribute]
         if self._subtitlefile.newline is None:
-            self._subtitlefile.newline = newlines.UNIX
+            self._subtitlefile.newline = newlines.UNIX  # ty:ignore[unresolved-attribute]
 
 
 class AdvSubStationAlphaFile(SubtitleFile):
@@ -279,9 +279,9 @@ class AdvSubStationAlphaFile(SubtitleFile):
         super().__init__(*args, **kwargs)
         if self._subtitlefile is None:
             self._subtitlefile = AdvSubStationAlpha(self.filename or "", self.encoding)
-            self._format = formats.ASS
+            self._format = formats.ASS  # ty:ignore[unresolved-attribute]
         if self._subtitlefile.newline is None:
-            self._subtitlefile.newline = newlines.UNIX
+            self._subtitlefile.newline = newlines.UNIX  # ty:ignore[unresolved-attribute]
 
     def addsourceunit(self, source: str) -> base.TranslationUnit:
         """Add a unit with default SSA metadata."""
@@ -301,9 +301,9 @@ class SubStationAlphaFile(SubtitleFile):
         super().__init__(*args, **kwargs)
         if self._subtitlefile is None:
             self._subtitlefile = SubStationAlpha(self.filename or "", self.encoding)
-            self._format = formats.SSA
+            self._format = formats.SSA  # ty:ignore[unresolved-attribute]
         if self._subtitlefile.newline is None:
-            self._subtitlefile.newline = newlines.UNIX
+            self._subtitlefile.newline = newlines.UNIX  # ty:ignore[unresolved-attribute]
 
     def addsourceunit(self, source: str) -> base.TranslationUnit:
         """Add a unit with default SSA metadata."""

--- a/translate/storage/tbx.py
+++ b/translate/storage/tbx.py
@@ -38,7 +38,7 @@ class tbxunit(lisa.LISAunit):
     languageNode = "langSet"
     textNode = "term"
 
-    def createlanguageNode(self, lang, text, purpose):
+    def createlanguageNode(self, lang, text, purpose):  # ty:ignore[invalid-method-override]
         """Returns a langset xml Element setup with given parameters."""
         langset = etree.Element(self.languageNode)
         setXMLlang(langset, lang)
@@ -65,7 +65,7 @@ class tbxunit(lisa.LISAunit):
 
     def removenotes(self, origin=None) -> None:
         """Remove all the translator notes."""
-        notes = self.xmlelement.iterdescendants(self._get_origin_element(origin))
+        notes = self.xmlelement.iterdescendants(self._get_origin_element(origin))  # ty:ignore[invalid-argument-type]
         for note in notes:
             self.xmlelement.remove(note)
 
@@ -78,14 +78,14 @@ class tbxunit(lisa.LISAunit):
             text = text.strip()
         if not text:
             return
-        note = etree.SubElement(self.xmlelement, self._get_origin_element(origin))
+        note = etree.SubElement(self.xmlelement, self._get_origin_element(origin))  # ty:ignore[invalid-argument-type]
         safely_set_text(note, text)
         if origin and origin not in {"pos", "definition"}:
             note.set("from", origin)
 
     def _getnotenodes(self, origin=None):
         """Get all nodes matching ``origin`` in the XML document."""
-        return self.xmlelement.iterdescendants(self._get_origin_element(origin))
+        return self.xmlelement.iterdescendants(self._get_origin_element(origin))  # ty:ignore[invalid-argument-type]
 
     def _getnodetext(self, node):
         """

--- a/translate/storage/tiki.py
+++ b/translate/storage/tiki.py
@@ -153,7 +153,7 @@ class TikiStore(base.TranslationStore[TikiUnit]):
         """Returns a tiki-file footer string."""
         return '"###end###"=>"###end###");\n?>'
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """
         Parse the given input into source units.
 

--- a/translate/storage/tmx.py
+++ b/translate/storage/tmx.py
@@ -32,7 +32,7 @@ class tmxunit(lisa.LISAunit):
     languageNode = "tuv"
     textNode = "seg"
 
-    def createlanguageNode(self, lang, text, purpose):
+    def createlanguageNode(self, lang, text, purpose):  # ty:ignore[invalid-method-override]
         """Returns a langset xml Element setup with given parameters."""
         langset = etree.Element(self.languageNode)
         setXMLlang(langset, lang)
@@ -195,6 +195,6 @@ class tmxfile(lisa.LISAfile):
         setXMLlang(next(tuvs), srclang)
         setXMLlang(next(tuvs), translang)
 
-    def translate(self, sourcetext, sourcelang=None, targetlang=None):
+    def translate(self, sourcetext, sourcelang=None, targetlang=None):  # ty:ignore[invalid-method-override]
         """Method to test old unit tests."""
         return getattr(self.findunit(sourcetext), "target", None)

--- a/translate/storage/trados.py
+++ b/translate/storage/trados.py
@@ -164,14 +164,14 @@ class TradosUnit(base.TranslationUnit):
 
     @property
     def source(self):
-        return unescape(self._soup.findAll("seg")[0].contents[0])
+        return unescape(self._soup.findAll("seg")[0].contents[0])  # ty:ignore[possibly-missing-attribute]
 
     @source.setter
     def source(self, source) -> None:
         pass
 
     def gettarget(self):
-        return unescape(self._soup.findAll("seg")[1].contents[0])
+        return unescape(self._soup.findAll("seg")[1].contents[0])  # ty:ignore[possibly-missing-attribute]
 
     target = property(gettarget, None)
 
@@ -201,7 +201,7 @@ class TradosTxtTmFile(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         if hasattr(input, "name"):
             self.filename = input.name
         elif not getattr(self, "filename", ""):

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -113,7 +113,7 @@ class tsunit(lisa.LISAunit):
     _context = None
     _locations = None
 
-    def createlanguageNode(self, lang, text, purpose):
+    def createlanguageNode(self, lang, text, purpose):  # ty:ignore[invalid-method-override]
         """Returns an xml Element setup with given parameters."""
         assert purpose
         if purpose == "target":
@@ -292,7 +292,7 @@ class tsunit(lisa.LISAunit):
             return None
         return context.text
 
-    def setcontext(self, value) -> None:
+    def setcontext(self, value) -> None:  # ty:ignore[invalid-method-override]
         if value == self.getcontextname():
             return
         parent = self.xmlelement.getparent()
@@ -365,7 +365,7 @@ class tsunit(lisa.LISAunit):
 
     def get_previous_unit(self):
         found = None
-        for pos, unit in enumerate(self._store.units):
+        for pos, unit in enumerate(self._store.units):  # ty:ignore[possibly-missing-attribute]
             # Use is here to compare objects as __eq__ implementation in
             # LISAUnit might give unexpected results
             if unit is self:
@@ -373,7 +373,7 @@ class tsunit(lisa.LISAunit):
                 break
         if not found or found == 0:
             return None
-        return self._store.units[found - 1]
+        return self._store.units[found - 1]  # ty:ignore[possibly-missing-attribute]
 
     def getlocations(self):
         if self._locations is None:
@@ -381,7 +381,7 @@ class tsunit(lisa.LISAunit):
 
         return [
             f"{location}{':' if location else ''}{line}"
-            for location, line in self._locations
+            for location, line in self._locations  # ty:ignore[not-iterable]
         ]
 
     def merge(
@@ -507,7 +507,7 @@ class tsfile(lisa.LISAfile[tsunit]):
     def _getcontextnames(self):
         """Returns all contextnames in this TS file."""
         contextnodes = self.document.findall(self.namespaced("context"))
-        return [self.getcontextname(contextnode) for contextnode in contextnodes]
+        return [self.getcontextname(contextnode) for contextnode in contextnodes]  # ty:ignore[unresolved-attribute]
 
     def _getcontextnode(self, contextname):
         """Returns the context node with the given name."""
@@ -553,7 +553,7 @@ class tsfile(lisa.LISAfile[tsunit]):
         return self.body is not None
 
     def nplural(self):
-        code = self.header.get("language").lower().replace("-", "_").split("_")[0]
+        code = self.header.get("language").lower().replace("-", "_").split("_")[0]  # ty:ignore[possibly-missing-attribute]
         if code in data.qt_plural_tags:
             return len(data.qt_plural_tags[code])
         lang = data.get_language(self.header.get("language"))

--- a/translate/storage/txt.py
+++ b/translate/storage/txt.py
@@ -112,7 +112,7 @@ class TxtFile(base.TranslationStore[TxtUnit]):
             txtsrc = inputfile.readlines()
             self.parse(txtsrc)
 
-    def parse(self, lines) -> None:
+    def parse(self, lines) -> None:  # ty:ignore[invalid-method-override]
         """Read in text lines and create txtunits from the blocks of text."""
         if self.no_segmentation:
             unit = self.addsourceunit(

--- a/translate/storage/utx.py
+++ b/translate/storage/utx.py
@@ -229,7 +229,7 @@ class UtxFile(base.TranslationStore):
     def settargetlanguage(self, targetlanguage) -> None:
         self._header["target_language"] = targetlanguage
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Parsese the given file or file source string."""
         if hasattr(input, "name"):
             self.filename = input.name

--- a/translate/storage/wordfast.py
+++ b/translate/storage/wordfast.py
@@ -303,12 +303,12 @@ class WordfastHeader:
     header = property(getheader, setheader)
 
     def settargetlang(self, newlang) -> None:
-        self._header_dict["target-lang"] = f"%{newlang}"
+        self._header_dict["target-lang"] = f"%{newlang}"  # ty:ignore[invalid-assignment]
 
     targetlang = property(None, settargetlang)
 
     def settucount(self, count) -> None:
-        self._header_dict["tucount"] = f"%TU={count:08d}"
+        self._header_dict["tucount"] = f"%TU={count:08d}"  # ty:ignore[invalid-assignment]
 
     tucount = property(None, settucount)
 
@@ -384,7 +384,7 @@ class WordfastTMFile(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Parsese the given file or file source string."""
         if hasattr(input, "name"):
             self.filename = input.name

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -95,7 +95,7 @@ class Xliff1Unit(XliffUnit):
             return
         setXMLspace(self.xmlelement, "preserve")
 
-    def createlanguageNode(self, lang, text, purpose):
+    def createlanguageNode(self, lang, text, purpose):  # ty:ignore[invalid-method-override]
         """Returns an xml Element setup with given parameters."""
         # TODO: for now we do source, but we have to test if it is target,
         # perhaps with parameter. Alternatively, we can use lang, if
@@ -164,7 +164,7 @@ class Xliff1Unit(XliffUnit):
                 )
                 # TODO: support multiple targets better
                 # TODO: support notes in alt-trans
-                newunit.xmlelement = node
+                newunit.xmlelement = node  # ty:ignore[unresolved-attribute]
 
                 translist.append(newunit)
         return translist
@@ -354,7 +354,7 @@ class Xliff1Unit(XliffUnit):
         if state_id < self.S_UNREVIEWED:
             self.set_state_n(self.S_UNREVIEWED)
 
-    def setid(self, id) -> None:
+    def setid(self, id) -> None:  # ty:ignore[invalid-method-override]
         # sanitize id in case ID_SEPARATOR is present
         self.xmlelement.set("id", id.replace(ID_SEPARATOR, ID_SEPARATOR_SAFE))
 
@@ -561,7 +561,7 @@ class Xliff1File(XliffFile[Xliff1Unit]):
         """Set the name of the given file."""
         return filenode.set("original", filename)
 
-    def setsourcelanguage(self, language) -> None:
+    def setsourcelanguage(self, language) -> None:  # ty:ignore[invalid-method-override]
         if not language:
             return
         for filenode in self.document.getroot().iterchildren(self.namespaced("file")):
@@ -573,7 +573,7 @@ class Xliff1File(XliffFile[Xliff1Unit]):
 
     sourcelanguage = property(getsourcelanguage, setsourcelanguage)
 
-    def settargetlanguage(self, language) -> None:
+    def settargetlanguage(self, language) -> None:  # ty:ignore[invalid-method-override]
         if not language:
             return
         for filenode in self.document.getroot().iterchildren(self.namespaced("file")):
@@ -686,7 +686,7 @@ class Xliff1File(XliffFile[Xliff1Unit]):
                 target_group.append(unit.xmlelement)
             else:
                 # Add directly to body
-                self.body.append(unit.xmlelement)
+                self.body.append(unit.xmlelement)  # ty:ignore[possibly-missing-attribute]
 
     def addsourceunit(self, source, filename="NoName", createifmissing=False):
         """
@@ -727,7 +727,7 @@ class Xliff1File(XliffFile[Xliff1Unit]):
         """Adds a group tag into the specified file."""
         if not self.switchfile(filename, createifmissing):
             return None
-        group = etree.SubElement(self.body, self.namespaced("group"))
+        group = etree.SubElement(self.body, self.namespaced("group"))  # ty:ignore[no-matching-overload]
         if restype:
             group.set("restype", restype)
         return group
@@ -740,13 +740,13 @@ class Xliff1File(XliffFile[Xliff1Unit]):
         :returns: The matching or newly created group element
         """
         # Try to find a matching group in the current body
-        for group in self.body.iterchildren(self.namespaced("group")):
+        for group in self.body.iterchildren(self.namespaced("group")):  # ty:ignore[possibly-missing-attribute]
             # Check if all attributes match
             if group.attrib == source_group.attrib:
                 return group
 
         # No matching group found, create a new one
-        group = etree.SubElement(self.body, self.namespaced("group"))
+        group = etree.SubElement(self.body, self.namespaced("group"))  # ty:ignore[no-matching-overload]
         for attr, value in source_group.attrib.items():
             group.set(attr, value)
         return group

--- a/translate/storage/xliff2.py
+++ b/translate/storage/xliff2.py
@@ -79,7 +79,7 @@ class Xliff2Unit(XliffUnit):
             return
         self._ensure_xml_space_preserve()
 
-    def addnote(self, text: str, origin: str | None = None) -> None:
+    def addnote(self, text: str, origin: str | None = None) -> None:  # ty:ignore[invalid-method-override]
         """Add a note specifically in the XLIFF 2.0 way."""
         if not text:
             return
@@ -135,7 +135,7 @@ class Xliff2Unit(XliffUnit):
         unit_element.append(self.xmlelement)
         return unit_element
 
-    def getid(self) -> str | None:
+    def getid(self) -> str | None:  # ty:ignore[invalid-method-override]
         """Get the unit id."""
         segment_id = self.xmlelement.get("id")
         unit_element = self.getunitelement()
@@ -286,13 +286,13 @@ class Xliff2File(XliffFile[Xliff2Unit]):
         super().addunit(unit, new=False)
         if new:
             # TODO: merge units with same ID and different segment
-            self.body.append(unit.getunitelement())
+            self.body.append(unit.getunitelement())  # ty:ignore[possibly-missing-attribute]
 
     def getsourcelanguage(self) -> str:
         """Get the source language for this file."""
         return self.document.getroot().get("srcLang", "en")
 
-    def setsourcelanguage(self, lang: str) -> None:
+    def setsourcelanguage(self, lang: str) -> None:  # ty:ignore[invalid-method-override]
         """Set the source language for this file."""
         self.document.getroot().set("srcLang", lang)
 
@@ -300,7 +300,7 @@ class Xliff2File(XliffFile[Xliff2Unit]):
         """Get the target language for this file."""
         return self.document.getroot().get("trgLang")
 
-    def settargetlanguage(self, lang: str) -> None:
+    def settargetlanguage(self, lang: str) -> None:  # ty:ignore[invalid-method-override]
         """Set the target language for this file."""
         if lang:
             self.document.getroot().set("trgLang", lang)

--- a/translate/storage/xliff_common.py
+++ b/translate/storage/xliff_common.py
@@ -41,7 +41,7 @@ class XliffUnit(lisa.LISAunit):
         if getXMLspace(self.xmlelement) != "preserve":
             setXMLspace(self.xmlelement, "preserve")
 
-    def createlanguageNode(self, lang: str, text: str, purpose: str) -> etree._Element:
+    def createlanguageNode(self, lang: str, text: str, purpose: str) -> etree._Element:  # ty:ignore[invalid-method-override]
         """
         Create and return an xml Element setup with given parameters.
 
@@ -53,7 +53,7 @@ class XliffUnit(lisa.LISAunit):
         return langset
 
     @classmethod
-    def multistring_to_rich(cls, mstr: Any) -> list[Any]:
+    def multistring_to_rich(cls, mstr: Any) -> list[Any]:  # ty:ignore[invalid-method-override]
         """
         Convert a multistring to rich format.
 
@@ -168,7 +168,7 @@ class XliffUnit(lisa.LISAunit):
         # TODO: consider other attributes like "approved"
         super().merge(otherunit, overwrite, comments)
         if self.target:
-            self.marktranslated()
+            self.marktranslated()  # ty:ignore[unresolved-attribute]
             if otherunit.isfuzzy():
                 self.markfuzzy()
             elif otherunit.source == self.source:
@@ -222,4 +222,4 @@ class XliffFile(lisa.LISAfile[U]):
                 return filenode
         if not createifmissing:
             return None
-        return self.createfilenode(filename)
+        return self.createfilenode(filename)  # ty:ignore[unresolved-attribute]

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -278,7 +278,7 @@ class YAMLFile(base.DictStore[YAMLUnit]):
         """Preprocess hook for child formats."""
         return data
 
-    def parse(self, input) -> None:
+    def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Parse the given file or file source string."""
         if hasattr(input, "name"):
             self.filename = input.name
@@ -319,7 +319,7 @@ class RubyYAMLUnit(YAMLUnit):
         if not isinstance(self.target, multistring):
             return self.target
 
-        tags = self._store.get_plural_tags()
+        tags = self._store.get_plural_tags()  # ty:ignore[possibly-missing-attribute]
 
         # Sync plural_strings elements to plural_tags count.
         strings = self.sync_plural_count(self.target, tags)

--- a/translate/tools/poconflicts.py
+++ b/translate/tools/poconflicts.py
@@ -46,8 +46,8 @@ class ConflictOptionParser(optrecurse.RecursiveOptionParser):
             metavar="INPUT",
             help="read from INPUT (directory or file(s)) in po format",
         )
-        inputoption.optionalswitch = True
-        inputoption.required = True
+        inputoption.optionalswitch = True  # ty:ignore[unresolved-attribute]
+        inputoption.required = True  # ty:ignore[unresolved-attribute]
         self.define_option(inputoption)
         outputoption = optrecurse.optparse.Option(
             "-o",
@@ -57,8 +57,8 @@ class ConflictOptionParser(optrecurse.RecursiveOptionParser):
             metavar="OUTPUT",
             help="write to OUTPUT (directory) in po format",
         )
-        outputoption.optionalswitch = True
-        outputoption.required = True
+        outputoption.optionalswitch = True  # ty:ignore[unresolved-attribute]
+        outputoption.required = True  # ty:ignore[unresolved-attribute]
         self.define_option(outputoption)
 
     def parse_args(self, args=None, values=None):
@@ -107,7 +107,7 @@ class ConflictOptionParser(optrecurse.RecursiveOptionParser):
                     self.error(
                         optrecurse.optparse.OptionValueError(
                             "Output directory does not exist, attempt to create failed"
-                        )
+                        )  # ty:ignore[invalid-argument-type]
                     )
             if isinstance(options.input, list):
                 inputfiles = self.recurseinputfilelist(options)
@@ -144,7 +144,7 @@ class ConflictOptionParser(optrecurse.RecursiveOptionParser):
             string = string.replace(accelerator, "")
         return string.strip()
 
-    def processfile(self, fileprocessor, options, fullinputpath) -> bool:
+    def processfile(self, fileprocessor, options, fullinputpath) -> bool:  # ty:ignore[invalid-method-override]
         """Process an individual file."""
         inputfile = self.openinputfile(options, fullinputpath)
         inputfile = factory.getobject(inputfile)

--- a/translate/tools/pocount.py
+++ b/translate/tools/pocount.py
@@ -442,7 +442,7 @@ class StatCollector:
 
     def render(self, renderer_class: type[Renderer]) -> None:
         if renderer_class in {ShortWordsRenderer, ShortStringsRenderer}:
-            renderer = renderer_class(self, indent=self.longest_filename)
+            renderer = renderer_class(self, indent=self.longest_filename)  # ty:ignore[unknown-argument]
         else:
             renderer = renderer_class(self)
 

--- a/translate/tools/porestructure.py
+++ b/translate/tools/porestructure.py
@@ -61,7 +61,7 @@ class SplitOptionParser(optrecurse.RecursiveOptionParser):
                 self.error(
                     optrecurse.optparse.OptionValueError(
                         "Output directory does not exist, attempt to create failed"
-                    )
+                    )  # ty:ignore[invalid-argument-type]
                 )
         if self.isrecursive(options.input, "input") and getattr(
             options, "allowrecursiveinput", True
@@ -90,7 +90,7 @@ class SplitOptionParser(optrecurse.RecursiveOptionParser):
                 success = False
             progress_bar.report_progress(inputpath, success)
 
-    def processfile(self, options, fullinputpath) -> bool:
+    def processfile(self, options, fullinputpath) -> bool:  # ty:ignore[invalid-method-override]
         """Process an individual file."""
         inputfile = self.openinputfile(options, fullinputpath)
         inputpofile = po.pofile(inputfile)

--- a/translate/tools/poterminology.py
+++ b/translate/tools/poterminology.py
@@ -369,7 +369,7 @@ class TerminologyExtractor:
         termlist = sorted(terms.keys(), key=len)
         logger.info("%d terms after thresholding", len(termlist))
         for term in termlist:
-            words = term.split()
+            words = term.split()  # ty:ignore[unresolved-attribute]
             nonstop = [word for word in words if not self.stopword(word)]
             if len(nonstop) < nonstopmin and len(nonstop) != len(words):
                 del terms[term]
@@ -380,7 +380,7 @@ class TerminologyExtractor:
                 words.pop()
                 if terms[term][0] == terms.get(" ".join(words), [0])[0]:
                     del terms[" ".join(words)]
-            words = term.split()
+            words = term.split()  # ty:ignore[unresolved-attribute]
             while len(words) > 2:
                 words.pop(0)
                 if terms[term][0] == terms.get(" ".join(words), [0])[0]:
@@ -512,7 +512,7 @@ class TerminologyOptionParser(optrecurse.RecursiveOptionParser):
             progress_bar.report_progress(inputpath, success)
         self.outputterminology(options)
 
-    def processfile(self, fileprocessor, options, fullinputpath) -> None:
+    def processfile(self, fileprocessor, options, fullinputpath) -> None:  # ty:ignore[invalid-method-override]
         """Process an individual file."""
         inputfile = self.openinputfile(options, fullinputpath)
         inputfile = factory.getobject(inputfile)

--- a/translate/tools/pydiff.py
+++ b/translate/tools/pydiff.py
@@ -170,7 +170,7 @@ class DirDiffer:
         fromfiles = os.listdir(self.fromdir)
         tofiles = os.listdir(self.todir)
         difffiles = dict.fromkeys(fromfiles + tofiles).keys()
-        difffiles.sort()
+        difffiles.sort()  # ty:ignore[unresolved-attribute]
         for difffile in difffiles:
             if self.isexcluded(difffile):
                 continue


### PR DESCRIPTION
This allows us to gradually improve type annotations and enforce them with the new code. Added automatically by `ty check --add-ignore`.