### PR TITLE
chore(deps): remove no longer needed stubs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,6 @@ autodoc_mock_imports = [
     "iniparse",
     "vobject",
     "mistletoe",
-    "cwcwidth",
     "lxml",
     "phply",
     "ruamel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,7 @@ test = [
 types = [
   "setuptools>=61.2",
   "ty==0.0.13",
-  "types-lxml==2026.1.1",
-  "wcwidth-stubs==0.3.0.1"
+  "types-lxml==2026.1.1"
 ]
 
 [project]


### PR DESCRIPTION
The dependency was removed some time ago, but the stubs dependency remained in place.