### PR TITLE
feat(poparser): avoid restarting parser for UTF-8 files

### DIFF
--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -182,11 +182,10 @@ if __name__ == "__main__":
         benchmarker.clear_test_dir()
         if args.podir is None:
             benchmarker.create_sample_files(*sample_file_sizes)
-        benchmarker.parse_files(file_dir=args.podir)
-        methods = []  # [("create_sample_files", "*sample_file_sizes")]
+        methods = []
 
         if args.check_parsing:
-            methods.append(("parse_files", ""))
+            methods.append(("parse_files", repr(args.podir)))
 
         if args.check_placeables:
             methods.append(("parse_placeables", ""))


### PR DESCRIPTION
These are most common these days, so optimize parser to deal with UTF-8 encoded files gracefully without restart.