### PR TITLE
Add Ruby personality to yaml2po and po2yaml

### DIFF
--- a/tests/translate/convert/test_po2yaml.py
+++ b/tests/translate/convert/test_po2yaml.py
@@ -198,6 +198,107 @@ msgstr "Ola mundo!"
         assert output == expected_output
 
 
+class TestRubyPO2YAML(TestPO2YAML):
+    """Tests for po2yaml with Ruby personality."""
+
+    def _convert(
+        self,
+        input_string,
+        template_string=None,
+        include_fuzzy=False,
+        output_threshold=None,
+        success_expected=True,
+    ):
+        """Helper that converts using Ruby personality."""
+        input_file = BytesIO(input_string.encode())
+        output_file = BytesIO()
+        template_file = None
+        if template_string:
+            template_file = BytesIO(template_string.encode())
+        expected_result = 1 if success_expected else 0
+        converter = self.ConverterClass(
+            input_file,
+            output_file,
+            template_file,
+            include_fuzzy,
+            output_threshold,
+            personality="ruby",
+        )
+        assert converter.run() == expected_result
+        return converter.target_store, output_file
+
+    def test_convert_empty_PO(self) -> None:
+        """Check converting empty PO returns no output."""
+        assert self._convert_to_string("", "en: {}") == "en: {}\n"
+
+    def test_simple_output(self) -> None:
+        """Check that a simple single entry PO converts valid Ruby YAML output."""
+        input_string = """
+#: key
+msgid "Hello, World!"
+msgstr ""
+"""
+        template_string = """en:
+  key: "Hello, World!"
+"""
+        output = self._convert_to_string(input_string, template_string)
+        assert "key: Hello, World!" in output
+
+    def test_convert_completion_above_threshold(self) -> None:
+        """Check conversion with completion above threshold."""
+        input_string = """
+#: key
+msgid "Hello, World!"
+msgstr "Ola mundo!"
+"""
+        template_string = """en:
+  key: "Hello, World!"
+"""
+        output = self._convert_to_string(
+            input_string, template_string, output_threshold=70
+        )
+        assert "key: Ola mundo!" in output
+
+    def test_ruby_roundtrip(self) -> None:
+        """Check PO converts back to Ruby YAML with language root key."""
+        input_string = """
+#: greeting
+msgid "Hello!"
+msgstr "Hola!"
+
+#: farewell
+msgid "Goodbye!"
+msgstr "Adéu!"
+"""
+        template_string = """en:
+  greeting: Hello!
+  farewell: Goodbye!
+"""
+        output = self._convert_to_string(input_string, template_string)
+        assert "greeting: Hola!" in output
+        assert "farewell: Adéu!" in output
+
+    def test_ruby_nested_roundtrip(self) -> None:
+        """Check PO converts back to nested Ruby YAML."""
+        input_string = """
+#: messages->welcome
+msgid "Welcome!"
+msgstr "Benvingut!"
+
+#: messages->error
+msgid "Something went wrong"
+msgstr "Alguna cosa ha anat malament"
+"""
+        template_string = """en:
+  messages:
+    welcome: Welcome!
+    error: Something went wrong
+"""
+        output = self._convert_to_string(input_string, template_string)
+        assert "welcome: Benvingut!" in output
+        assert "error: Alguna cosa ha anat malament" in output
+
+
 class TestPO2YAMLCommand(test_convert.TestConvertCommand, TestPO2YAML):
     """Tests running actual po2yaml commands on files."""
 
@@ -208,4 +309,5 @@ class TestPO2YAMLCommand(test_convert.TestConvertCommand, TestPO2YAML):
         "--threshold=PERCENT",
         "--fuzzy",
         "--nofuzzy",
+        "--personality=TYPE",
     ]

--- a/tests/translate/convert/test_yaml2po.py
+++ b/tests/translate/convert/test_yaml2po.py
@@ -187,6 +187,110 @@ farewell: Goodbye!
         assert "This is the version" in notes, f"Expected comment not found in: {notes}"
 
 
+class TestRubyYAML2PO(TestYAML2PO):
+    """Tests for yaml2po with Ruby personality."""
+
+    def _convert(
+        self,
+        input_string,
+        template_string=None,
+        blank_msgstr=False,
+        duplicate_style="msgctxt",
+        success_expected=True,
+    ):
+        """Helper that converts using Ruby personality."""
+        input_file = BytesIO(input_string.encode())
+        output_file = BytesIO()
+        template_file = None
+        if template_string:
+            template_file = BytesIO(template_string.encode())
+        expected_result = 1 if success_expected else 0
+        converter = self.ConverterClass(
+            input_file,
+            output_file,
+            template_file,
+            blank_msgstr,
+            duplicate_style,
+            personality="ruby",
+        )
+        assert converter.run() == expected_result
+        return converter.target_store, output_file
+
+    def test_comment_extraction_nested(self) -> None:
+        """Check that comments on nested Ruby YAML keys are extracted."""
+        input_string = """en:
+  settings:
+    # This is the app name
+    app_name: My App
+    # This is the version
+    version: 1.0.0
+"""
+        target_store = self._convert_to_store(input_string)
+        assert self._count_elements(target_store) == 2
+
+        assert target_store.units[1].getlocations() == ["settings->app_name"]
+        assert target_store.units[1].source == "My App"
+        notes = target_store.units[1].getnotes(origin="developer")
+        assert "This is the app name" in notes
+
+        assert target_store.units[2].getlocations() == ["settings->version"]
+        assert target_store.units[2].source == "1.0.0"
+        notes = target_store.units[2].getnotes(origin="developer")
+        assert "This is the version" in notes
+
+    def test_ruby_single(self) -> None:
+        """Check that a Ruby YAML file strips the language root key."""
+        input_string = """en:
+  greeting: Hello!
+  farewell: Goodbye!
+"""
+        target_store = self._convert_to_store(input_string)
+        assert self._count_elements(target_store) == 2
+        assert target_store.units[1].getlocations() == ["greeting"]
+        assert target_store.units[1].source == "Hello!"
+        assert target_store.units[2].getlocations() == ["farewell"]
+        assert target_store.units[2].source == "Goodbye!"
+
+    def test_ruby_merge(self) -> None:
+        """Check merging two Ruby YAML files with different language root keys."""
+        template_string = """en:
+  greeting: Hello!
+  farewell: Goodbye!
+"""
+        input_string = """ca:
+  greeting: Hola!
+"""
+        target_store = self._convert_to_store(input_string, template_string)
+        assert self._count_elements(target_store) == 2
+        assert target_store.units[1].getlocations() == ["greeting"]
+        assert target_store.units[1].source == "Hello!"
+        assert target_store.units[1].target == "Hola!"
+        assert target_store.units[2].getlocations() == ["farewell"]
+        assert target_store.units[2].source == "Goodbye!"
+        assert target_store.units[2].target == ""
+
+    def test_ruby_nested_merge(self) -> None:
+        """Check merging nested Ruby YAML files with different root keys."""
+        template_string = """en:
+  messages:
+    welcome: Welcome!
+    error: Something went wrong
+"""
+        input_string = """ca:
+  messages:
+    welcome: Benvingut!
+    error: Alguna cosa ha anat malament
+"""
+        target_store = self._convert_to_store(input_string, template_string)
+        assert self._count_elements(target_store) == 2
+        assert target_store.units[1].getlocations() == ["messages->welcome"]
+        assert target_store.units[1].source == "Welcome!"
+        assert target_store.units[1].target == "Benvingut!"
+        assert target_store.units[2].getlocations() == ["messages->error"]
+        assert target_store.units[2].source == "Something went wrong"
+        assert target_store.units[2].target == "Alguna cosa ha anat malament"
+
+
 class TestYAML2POCommand(test_convert.TestConvertCommand, TestYAML2PO):
     """Tests running actual yaml2po commands on files."""
 
@@ -196,4 +300,5 @@ class TestYAML2POCommand(test_convert.TestConvertCommand, TestYAML2PO):
         "-P, --pot",
         "-t TEMPLATE, --template=TEMPLATE",
         "--duplicates=DUPLICATESTYLE",
+        "--personality=TYPE",
     ]

--- a/translate/convert/po2yaml.py
+++ b/translate/convert/po2yaml.py
@@ -42,10 +42,15 @@ class po2yaml:
         template_file=None,
         include_fuzzy=False,
         output_threshold=None,
+        personality="default",
     ) -> None:
         """Initialize the converter."""
         if template_file is None:
             raise ValueError(self.MissingTemplateMessage)
+
+        if personality == "ruby":
+            self.TargetStoreClass = yaml.RubyYAMLFile
+            self.TargetUnitClass = yaml.RubyYAMLUnit
 
         self.source_store = self.SourceStoreClass(input_file)
         self.target_store = self.TargetStoreClass()
@@ -96,12 +101,16 @@ class po2yaml:
 
 
 def run_converter(
-    inputfile, outputfile, templatefile=None, includefuzzy=False, outputthreshold=None
+    inputfile,
+    outputfile,
+    templatefile=None,
+    includefuzzy=False,
+    outputthreshold=None,
+    personality="default",
 ):
     """Wrapper around converter."""
-    # TODO add Ruby personality.
     return po2yaml(
-        inputfile, outputfile, templatefile, includefuzzy, outputthreshold
+        inputfile, outputfile, templatefile, includefuzzy, outputthreshold, personality
     ).run()
 
 
@@ -119,6 +128,17 @@ def main(argv=None) -> None:
     )
     parser.add_threshold_option()
     parser.add_fuzzy_option()
+    parser.add_option(
+        "",
+        "--personality",
+        dest="personality",
+        default="default",
+        type="choice",
+        choices=["default", "ruby"],
+        help="override the output YAML format: default, ruby (for Ruby on Rails YAML files with a language root node, e.g. 'en:' or 'ca:')",
+        metavar="TYPE",
+    )
+    parser.passthrough.append("personality")
     parser.run(argv)
 
 

--- a/translate/convert/yaml2po.py
+++ b/translate/convert/yaml2po.py
@@ -41,10 +41,14 @@ class yaml2po:
         template_file=None,
         blank_msgstr=False,
         duplicate_style="msgctxt",
+        personality="default",
     ) -> None:
         """Initialize the converter."""
         self.blank_msgstr = blank_msgstr
         self.duplicate_style = duplicate_style
+
+        if personality == "ruby":
+            self.SourceStoreClass = yaml.RubyYAMLFile
 
         self.extraction_msg = None
         self.output_file = output_file
@@ -105,16 +109,21 @@ class yaml2po:
 
 
 def run_converter(
-    input_file, output_file, template_file=None, pot=False, duplicatestyle="msgctxt"
+    input_file,
+    output_file,
+    template_file=None,
+    pot=False,
+    duplicatestyle="msgctxt",
+    personality="default",
 ):
     """Wrapper around converter."""
-    # TODO add Ruby personality.
     return yaml2po(
         input_file,
         output_file,
         template_file,
         blank_msgstr=pot,
         duplicate_style=duplicatestyle,
+        personality=personality,
     ).run()
 
 
@@ -131,7 +140,18 @@ def main(argv=None) -> None:
         formats, usetemplates=True, usepots=True, description=__doc__
     )
     parser.add_duplicates_option()
+    parser.add_option(
+        "",
+        "--personality",
+        dest="personality",
+        default="default",
+        type="choice",
+        choices=["default", "ruby"],
+        help="override the input YAML format: default, ruby (for Ruby on Rails YAML files with a language root node, e.g. 'en:' or 'ca:')",
+        metavar="TYPE",
+    )
     parser.passthrough.append("pot")
+    parser.passthrough.append("personality")
     parser.run(argv)
 
 


### PR DESCRIPTION
Adds `--personality=ruby` option to `yaml2po` and `po2yaml` for Ruby on Rails YAML files that use a language root node (e.g. `en:`, `ca:`).

This is used in projects such as Mastodon and Discourse.

Examples:
https://raw.githubusercontent.com/mastodon/mastodon/refs/heads/main/config/locales/activerecord.en.yml
https://raw.githubusercontent.com/discourse/discourse/refs/heads/main/config/locales/client.en.yml