### PR TITLE
chore: reduce APT deps for testing

### DIFF
--- a/.github/workflows/test-qemu.yml
+++ b/.github/workflows/test-qemu.yml
@@ -51,7 +51,7 @@ jobs:
 
         install: |
           apt-get update -q -y
-          apt-get install -q -y libgettextpo-dev libxml2-dev libxmlsec1-dev gettext hunspell-af python3-dev gcc g++ make
+          apt-get install -q -y libgettextpo-dev gettext libxml2-dev libxslt1-dev zlib1g-dev gcc g++ tzdata
           curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 
         run: |
@@ -59,5 +59,5 @@ jobs:
           uv sync --group test --all-extras --no-dev
           source .venv/bin/activate
           pytest --cov=. -r EfsxX
-          make test-functional
+          ./tests/cli/run_tests.sh
           uv cache prune --ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgettextpo-dev libxml2-dev libxmlsec1-dev gettext hunspell-af
+        sudo apt-get install -y libgettextpo-dev gettext hunspell-af
     - name: Install Windows dependencies
       if: matrix.os == 'windows-latest'
       run: |


### PR DESCRIPTION
lxml has binary wheels, so there should be no need to install the xml dev packages.