### PR TITLE
chore: use RapidFuzz for Levenshtein implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,10 +107,10 @@ files, but has not yet been tested as extensively. Feedback is most welcome.
 The package iniparse is necessary for ini2po and po2ini:
 <https://pypi.org/project/iniparse/>
 
-The python-Levenshtein package will improve performance for fuzzy matching if
+The RapidFuzz package will improve performance for fuzzy matching if
 it is available. This can improve the performance of pot2po, for example.  It
 is optional and no functionality is lost if it is not installed, only speed.
-<http://sourceforge.net/projects/translate/files/python-Levenshtein/>
+<https://pypi.org/project/RapidFuzz/>
 
 Functions in the `lang.data` module can supply functions to translate language
 names using the `pycountry` package. It can even translate names in the format

--- a/docs/commands/levenshtein_distance.rst
+++ b/docs/commands/levenshtein_distance.rst
@@ -9,9 +9,9 @@ can be supplied to the code that does the matching.
 
 This code is used in :doc:`pot2po` and `Virtaal
 <http://virtaal.org>`_. It is implemented in the toolkit, but can optionally use
-the fast C implementation provided by `python-Levenshtein
-<https://pypi.python.org/pypi/python-Levenshtein>`_ if it is installed. It is
-strongly recommended to have **python-levenshtein** installed.
+the fast C implementation provided by `RapidFuzz
+<https://pypi.org/project/RapidFuzz/>`_ if it is installed. It is
+strongly recommended to have **RapidFuzz** installed.
 
 To exercise the code the classfile *"Levenshtein.py"* can be executed directly
 with:

--- a/docs/commands/pot2po.rst
+++ b/docs/commands/pot2po.rst
@@ -111,7 +111,7 @@ Performance
 ===========
 
 Fuzzy matches are usually of good quality. Installation of the
-`python-Levenshtein <https://pypi.python.org/pypi/python-Levenshtein>`_ package
+`RapidFuzz <https://pypi.org/project/RapidFuzz/>`_  package
 will speed up fuzzy matching. Without this a Python based matcher is used which
 is considerably slower.
 

--- a/docs/commands/pretranslate.rst
+++ b/docs/commands/pretranslate.rst
@@ -85,7 +85,6 @@ Performance
 ===========
 
 Fuzzy matches are usually of good quality. Installation of the
-`python-Levenshtein
-<https://pypi.python.org/pypi/python-Levenshtein>`_
+`RapidFuzz <https://pypi.org/project/RapidFuzz/>`_
 package will speed up fuzzy matching. Without this a Python based matcher is
 used which is considerably slower.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ autodoc_mock_imports = [
     "lxml",
     "phply",
     "ruamel",
-    "Levenshtein",
+    "rapidfuzz",
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ ini = [
   "iniparse==0.5"
 ]
 levenshtein = [
-  "python-Levenshtein>=0.21.0"
+  "RapidFuzz>=3.14.0"
 ]
 markdown = [
   "mistletoe>=1.4.0,<1.6.0"

--- a/translate/search/lshtein.py
+++ b/translate/search/lshtein.py
@@ -22,9 +22,8 @@ distance.
 
 .. seealso:: :wp:`Levenshtein_distance`
 
-If available, the `python-Levenshtein
-<https://pypi.python.org/pypi/python-Levenshtein>`_ will be used which will
-provide better performance as it is implemented natively.
+If available, the `RapidFuzz <https://pypi.org/project/RapidFuzz/>`_
+will be used which will provide better performance as it is implemented natively.
 """
 
 import logging
@@ -74,12 +73,12 @@ def native_distance(a, b, stopvalue=0):
 
 
 try:
-    import Levenshtein
+    from rapidfuzz.distance import Levenshtein
 
     distance = native_distance
 except ImportError:
     logger.warning(
-        "Python-Levenshtein not found. Continuing with built-in (slower) fuzzy matching."
+        "RapidFuzz not found. Continuing with built-in (slower) fuzzy matching."
     )
     distance = python_distance
 


### PR DESCRIPTION
It provides binary wheels for most of the platforms making the installation simpler.