### PR TITLE
chore: move docpath handling into the base class

### DIFF
--- a/translate/storage/asciidoc.py
+++ b/translate/storage/asciidoc.py
@@ -48,21 +48,12 @@ class AsciiDocUnit(base.TranslationUnit):
         self._element_type: str = "paragraph"
         self._prefix: str = ""
         self._suffix: str = ""
-        self._docpath: str = ""
 
     def addlocation(self, location: str) -> None:
         self.locations.append(location)
 
     def getlocations(self) -> list[str]:
         return self.locations
-
-    def getdocpath(self) -> str:
-        """Get the logical location path within the document structure."""
-        return self._docpath
-
-    def setdocpath(self, docpath: str) -> None:
-        """Set the logical location path within the document structure."""
-        self._docpath = docpath
 
     def set_element_info(
         self, element_type: str, prefix: str = "", suffix: str = ""

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -149,6 +149,7 @@ class TranslationUnit:
         """Constructs a TranslationUnit containing the given source string."""
         if source is not None:
             self.source = source
+        self._docpath = ""
 
     @property
     def line_number(self) -> int | None:
@@ -351,30 +352,20 @@ class TranslationUnit:
         else:
             self.addlocation(location)
 
-    @staticmethod
-    def getdocpath() -> str:
+    def getdocpath(self) -> str:
         """
         A logical location path within the document structure.
 
         Unlike :meth:`~.TranslationUnit.getlocations`, which may include
         line numbers that differ between translations, the document path
         provides a stable structural identifier based on the logical
-        position within the document (e.g. ``/body/h1[1]/p[2]``).
-
-        .. note::
-
-           Shouldn't be implemented if the format doesn't support it.
+        position within the document (e.g. ``body/h1[1]/p[2]``).
         """
-        return ""
+        return self._docpath
 
     def setdocpath(self, docpath: str) -> None:
-        """
-        Set the logical location path within the document structure.
-
-        .. note::
-
-           Shouldn't be implemented if the format doesn't support it.
-        """
+        """Set the logical location path within the document structure."""
+        self._docpath = docpath
 
     def getcontext(self) -> str:
         """Get the message context."""

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -39,7 +39,6 @@ class htmlunit(base.TranslationUnit):
         super().__init__(source)
         self.locations = []
         self._context = ""
-        self._docpath = ""
 
     def addlocation(self, location) -> None:
         self.locations.append(location)
@@ -47,14 +46,6 @@ class htmlunit(base.TranslationUnit):
     def getlocations(self):
         """Get the list of locations for this unit."""
         return self.locations
-
-    def getdocpath(self) -> str:
-        """Get the logical location path within the document structure."""
-        return self._docpath
-
-    def setdocpath(self, docpath: str) -> None:
-        """Set the logical location path within the document structure."""
-        self._docpath = docpath
 
     def getcontext(self):
         """Get the message context."""

--- a/translate/storage/markdown.py
+++ b/translate/storage/markdown.py
@@ -62,21 +62,12 @@ class MarkdownUnit(base.TranslationUnit):
     def __init__(self, source=None) -> None:
         super().__init__(source)
         self.locations = []
-        self._docpath = ""
 
     def addlocation(self, location) -> None:
         self.locations.append(location)
 
     def getlocations(self):
         return self.locations
-
-    def getdocpath(self) -> str:
-        """Get the logical location path within the document structure."""
-        return self._docpath
-
-    def setdocpath(self, docpath: str) -> None:
-        """Set the logical location path within the document structure."""
-        self._docpath = docpath
 
 
 class MarkdownFrontmatterUnit(MarkdownUnit):


### PR DESCRIPTION
There is no good reason to reimplement this for every class.