### PR TITLE
chore: reduce pre-commit auto-update frequency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,5 @@ repos:
     args: []
     require_serial: true
     pass_filenames: false
+ci:
+  autoupdate_schedule: quarterly


### PR DESCRIPTION
Renovate handles this better and there seems to be no way to disable this fully.