### PR TITLE
chore: loosen type check for binary IO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ spellcheck = [
   "pyenchant==3.3.0"
 ]
 subtitles = [
-  "aeidon>=1.14.1,<1.16"
+  "aeidon>=1.15,<1.16"
 ]
 toml = [
   "tomlkit>=0.13.0,<0.15.0"

--- a/translate/convert/po2md.py
+++ b/translate/convert/po2md.py
@@ -27,10 +27,14 @@ from __future__ import annotations
 
 import os
 import sys
+from typing import TYPE_CHECKING
 
 from translate.convert import convert
 from translate.misc.optrecurse import ProgressBar
 from translate.storage import markdown, po
+
+if TYPE_CHECKING:
+    from translate.storage.base import TranslationStore
 
 DEFAULT_MAX_LINE_LENGTH = 80
 
@@ -38,7 +42,7 @@ DEFAULT_MAX_LINE_LENGTH = 80
 class MarkdownTranslator:
     def __init__(
         self,
-        inputstore: po.pofile,
+        inputstore: TranslationStore,
         includefuzzy: bool,
         outputthreshold: int | None,
         maxlength: int,

--- a/translate/convert/po2odf.py
+++ b/translate/convert/po2odf.py
@@ -27,13 +27,15 @@ for examples and usage instructions.
 """
 
 from io import BytesIO
-from typing import BinaryIO
+from typing import IO
 
 from translate.convert import convert, po2xliff, xliff2odf
 from translate.storage import po
 
 
-def convertpo(input_file: BinaryIO, output_file: BinaryIO, template: BinaryIO) -> int:
+def convertpo(
+    input_file: IO[bytes], output_file: IO[bytes], template: IO[bytes]
+) -> int:
     """Create a translated ODF using an ODF template and a PO file."""
     # Read the PO file
     inputstore = po.pofile(input_file)

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -25,9 +25,9 @@ import logging
 from io import BytesIO
 from itertools import starmap
 from typing import (
+    IO,
     TYPE_CHECKING,
     Any,
-    BinaryIO,
     ClassVar,
     Generic,
     Literal,
@@ -888,7 +888,7 @@ class TranslationStore(Generic[U]):
         self.serialize(out)
         return out.getvalue()
 
-    def serialize(self, out: BinaryIO) -> None:
+    def serialize(self, out: IO[bytes]) -> None:
         """
         Converts to a bytes representation that can be parsed back using
         :meth:`~.TranslationStore.parsestring`.

--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import hashlib
 import re
 import textwrap
-from typing import TYPE_CHECKING, BinaryIO
+from typing import IO, TYPE_CHECKING
 
 from fluent.syntax import FluentSerializer, ast, parse, serialize, visitor
 
@@ -1079,7 +1079,7 @@ class FluentFile(base.TranslationStore):
     Extensions = ["ftl"]
     UnitClass = FluentUnit
 
-    def __init__(self, inputfile: BinaryIO | None = None, **kwargs) -> None:
+    def __init__(self, inputfile: IO[bytes] | None = None, **kwargs) -> None:
         super().__init__(**kwargs)
         self.filename = getattr(inputfile, "name", "")
         if inputfile is not None:

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -75,6 +75,7 @@ import re
 import uuid
 from collections import defaultdict
 from typing import (
+    IO,
     TYPE_CHECKING,
     Any,
     BinaryIO,
@@ -1067,7 +1068,7 @@ class NextcloudJsonFile(JsonFile):
             unit.setid(key, unitid=self.UnitClass.IdClass.from_key(key))
             yield unit
 
-    def serialize(self, out: BinaryIO) -> None:
+    def serialize(self, out: IO[bytes]) -> None:
         """Serialize to Nextcloud JSON format."""
         # Build translations dictionary
         translations = {}

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -31,7 +31,7 @@ import re
 from functools import lru_cache
 from itertools import chain
 from string import punctuation
-from typing import TYPE_CHECKING, BinaryIO
+from typing import IO, TYPE_CHECKING
 
 from unicode_segmentation_rs import gettext_wrap
 
@@ -930,7 +930,7 @@ class pofile(pocommon.pofile[pounit]):
                 uniqueunits.append(thepo)
         self.units = uniqueunits
 
-    def serialize(self, out: BinaryIO) -> None:
+    def serialize(self, out: IO[bytes]) -> None:
         """Write to file."""
         at_start = True
         try:

--- a/translate/storage/toml.py
+++ b/translate/storage/toml.py
@@ -21,7 +21,7 @@ r"""Class that manages TOML data files for translation."""
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING, Any, BinaryIO, cast
+from typing import IO, TYPE_CHECKING, Any, cast
 
 from tomlkit import TOMLDocument, document, loads
 from tomlkit.exceptions import TOMLKitError
@@ -114,7 +114,7 @@ class TOMLFile(base.DictStore[TOMLUnit]):
         """Return an empty root node for serialization."""
         return document()
 
-    def serialize(self, out: BinaryIO) -> None:
+    def serialize(self, out: IO[bytes]) -> None:
         """Serialize the store to a file."""
         # Always start with valid root even if original file was empty
         if self._original is None:

--- a/translate/storage/xliff_common.py
+++ b/translate/storage/xliff_common.py
@@ -178,6 +178,9 @@ class XliffUnit(lisa.LISAunit):
         if comments:
             self.addnote(otherunit.getnotes())
 
+    def markapproved(self, value=True) -> None:
+        raise NotImplementedError
+
 
 U = TypeVar("U", bound=XliffUnit)
 


### PR DESCRIPTION
IO[bytes] is looser and provides all we need.