### PR TITLE
chore: use commonpath for path prefix calculation

### DIFF
--- a/translate/misc/optrecurse.py
+++ b/translate/misc/optrecurse.py
@@ -755,7 +755,7 @@ class RecursiveOptionParser(optparse.OptionParser):
         """Use a list of files, and find a common base directory for them."""
         # find a common base directory for the files to do everything
         # relative to
-        commondir = os.path.dirname(os.path.commonprefix(options.input))
+        commondir = os.path.dirname(os.path.commonpath(options.input))
         inputfiles = []
         for inputfile in options.input:
             if self.isexcluded(options, inputfile):


### PR DESCRIPTION
It operates on path components unlike the commonprefix which operates on characters and might split in the middle of the path component.