### PR TITLE
chore: simplify release workflow

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -27,6 +27,7 @@ jobs:
     - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
       with:
         enable-cache: false
+        version: 0.10.10
     - name: Install apt dependencies
       run: |
         sudo apt-get update
@@ -62,7 +63,8 @@ jobs:
         name: setup
     - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
-        path: ./dist/*
+        path: dist/*
+        name: dist
 
   pypi-publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
@@ -75,9 +77,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        # unpacks default artifact into dist/
-        # if `name: artifact` is omitted, the action will create extra parent dir
-        name: artifact
+        name: dist
         path: dist
 
     - name: Publish package distributions to PyPI
@@ -92,12 +92,15 @@ jobs:
       # this permission is mandatory for creating a release
       contents: write
     steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        # unpacks default artifact into dist/
-        # if `name: artifact` is omitted, the action will create extra parent dir
-        name: artifact
+        name: dist
         path: dist
-    - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-      with:
-        artifacts: dist/*
+    - env:
+        VERSION: ${{ github.ref_name }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release create "$VERSION" --verify-tag --generate-notes dist/*


### PR DESCRIPTION
- use gh release for creating the release
- avoid confusing artifact name and related comments