### PR TITLE
fix(fluent): use specific exception on serialization error

### DIFF
--- a/tests/translate/storage/test_fluent.py
+++ b/tests/translate/storage/test_fluent.py
@@ -25,7 +25,7 @@ from typing import Any
 
 from pytest import raises
 
-from translate.storage import fluent
+from translate.storage import base, fluent
 
 from . import test_monolingual
 
@@ -456,7 +456,7 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
         :param str error_msg: The expected syntax error for the unit.
         """
         with raises(
-            TypeError,
+            fluent.FluentContentError,
             match=f'^Error in source of FluentUnit "{error_unit.getid()}":\\n',
         ):
             self.fluent_serialize(fluent_file)
@@ -465,6 +465,12 @@ class TestFluentFile(test_monolingual.TestMonolingualStore):
         assert syntax_error is not None
         assert re.match(error_msg, syntax_error)
         assert error_unit.get_parts() is None
+
+    def test_exception_hierarchy(self) -> None:
+        """Test the shared storage exception hierarchy."""
+        assert issubclass(base.ParseError, base.TranslateToolkitError)
+        assert issubclass(base.SerializationError, base.TranslateToolkitError)
+        assert issubclass(fluent.FluentContentError, base.SerializationError)
 
     def test_simple_values(self) -> None:
         """Test a simple fluent Message and Term."""

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -66,12 +66,20 @@ class EncodingDict(TypedDict):
     confidence: float | None
 
 
-class ParseError(Exception):
+class TranslateToolkitError(Exception):
+    """Base class for toolkit-defined storage exceptions."""
+
+
+class ParseError(TranslateToolkitError):
     def __init__(self, inner_exc) -> None:
         self.inner_exc = inner_exc
 
     def __str__(self) -> str:
         return repr(self.inner_exc)
+
+
+class SerializationError(TranslateToolkitError):
+    """Raised when in-memory content cannot be serialized."""
 
 
 class TranslationUnit:

--- a/translate/storage/fluent.py
+++ b/translate/storage/fluent.py
@@ -38,6 +38,10 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
+class FluentContentError(base.SerializationError):
+    """Raised when a Fluent unit contains content that cannot be serialized."""
+
+
 class _SanitizeVisitor(visitor.Visitor):
     """
     Private class used to replace special characters at the start of Fluent
@@ -915,7 +919,9 @@ class FluentUnit(base.TranslationUnit):
         Convert the unit into a corresponding fluent AST Entry.
 
         :return: A new fluent AST Entry, if one was created.
-        :raises ValueError: if the unit source contains an error.
+        :raises FluentContentError: if the unit source contains invalid Fluent
+            content that cannot be serialized.
+        :raises ValueError: if the unit has an unsupported ``fluent_type``.
         """
         if self.fluent_type == "ResourceComment":
             # Create a comment, even if empty. Especially since empty
@@ -931,10 +937,15 @@ class FluentUnit(base.TranslationUnit):
         raise ValueError(f"Unhandled fluent_type: {self.fluent_type}")
 
     def _source_to_fluent_entry(self) -> ast.Entry | None:
-        """Convert a FluentUnit's source to a fluent Term or Message."""
+        """
+        Convert a FluentUnit's source to a fluent Term or Message.
+
+        :raises FluentContentError: if the unit source contains invalid Fluent
+            content that cannot be serialized.
+        """
         entry_or_error = self._try_source_to_fluent_entry()
         if isinstance(entry_or_error, str):
-            raise TypeError(
+            raise FluentContentError(
                 f'Error in source of FluentUnit "{self.getid()}":\n{entry_or_error}'
             )
         return entry_or_error


### PR DESCRIPTION
Generic TypeError makes it impossible to catch it.