### PR TITLE
chore(deps): bump lxml dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ classifiers = [
   "Topic :: Software Development :: Localization"
 ]
 dependencies = [
-  "lxml>=5.2.0,<6.2",
+  "lxml>=6.1.0,<7.0",
   "unicode-segmentation-rs>=0.2.0,<0.3"
 ]
 description = "Tools and API for translation and localization engineering."


### PR DESCRIPTION
- higher upper bound to make it easier to install security updates
- higher lower bound to cover CVE-2026-41066, even though we should not be affected