### PR TITLE
fix(csv): improve escaping

### DIFF
--- a/tests/translate/convert/test_csv2po.py
+++ b/tests/translate/convert/test_csv2po.py
@@ -140,6 +140,14 @@ msgstr ""
         assert pofile.findunit("yellow pencil").target == "żółty\\nołówek"
         assert headerless_len(pofile.units) == 1
 
+    def test_formula_like_prefixes_are_preserved(self) -> None:
+        """Test that csv2po preserves literal leading quote and backslash characters."""
+        minicsv = '"source","target"\n"\'=SUM(1,1)","\\=2+2"'
+        pofile = self.csv2po(minicsv)
+        unit = self.singleelement(pofile)
+        assert unit.source == "'=SUM(1,1)"
+        assert unit.target == "\\=2+2"
+
     def test_line_numbers_in_errors(self, caplog) -> None:
         """Tests that line numbers are included in error messages."""
         # CSV with entries that won't be found in the template

--- a/tests/translate/convert/test_po2csv.py
+++ b/tests/translate/convert/test_po2csv.py
@@ -136,6 +136,19 @@ msgstr "Vind\\Opsies"
         assert unit.source == "Same"
         assert unit.target == "Same"
 
+    def test_spreadsheet_formulas_are_escaped_in_csv_output(self) -> None:
+        """Test that po2csv escapes formula-like values when writing CSV."""
+        minipo = 'msgid "=SUM(1,1)"\nmsgstr "=2+2"\n'
+        csvfile = self.po2csv(minipo)
+
+        unit = self.singleelement(csvfile)
+        assert unit.source == "=SUM(1,1)"
+        assert unit.target == "=2+2"
+
+        csvsource = bytes(csvfile).decode()
+        assert '"\'=SUM(1,1)"' in csvsource
+        assert '"\'=2+2"' in csvsource
+
 
 class TestPO2CSVCommand(test_convert.TestConvertCommand, TestPO2CSV):
     """Tests running actual po2csv commands on files."""

--- a/tests/translate/storage/test_csvl10n.py
+++ b/tests/translate/storage/test_csvl10n.py
@@ -298,6 +298,42 @@ GENERAL@2|Notes,"cable, motor, switch"
         assert newstore.units[0].target == "Updated Translation 1"
         assert newstore.units[1].target == "Translation 2"
 
+    def test_spreadsheet_formula_prefixes_are_escaped_on_write(self) -> None:
+        """Test that CSV output escapes formula-like values without mutating imports."""
+        store = self.StoreClass(fieldnames=["context", "id", "source", "target"])
+        unit = store.addsourceunit("=SUM(1,1)")
+        unit.target = "+cmd"
+        unit.setcontext("@context")
+        unit.id = "-id"
+
+        csvsource = bytes(store).decode()
+
+        assert '"\'@context"' in csvsource
+        assert '"\'-id"' in csvsource
+        assert '"\'=SUM(1,1)"' in csvsource
+        assert '"\'+cmd"' in csvsource
+
+        newstore = self.parse_store(csvsource.encode())
+        assert len(newstore.units) == 1
+        assert newstore.units[0].context == "'@context"
+        assert newstore.units[0].id == "'-id"
+        assert newstore.units[0].source == "'=SUM(1,1)"
+        assert newstore.units[0].target == "'+cmd"
+
+    def test_formula_like_prefixes_are_preserved_on_import(self) -> None:
+        """Test that import keeps literal leading quote and backslash characters."""
+        content = (
+            b'"context","id","source","target"\n'
+            b'"\'@context","\\-id","\'=SUM(1,1)","\\+cmd"'
+        )
+        store = self.parse_store(content)
+
+        assert len(store.units) == 1
+        assert store.units[0].context == "'@context"
+        assert store.units[0].id == "\\-id"
+        assert store.units[0].source == "'=SUM(1,1)"
+        assert store.units[0].target == "\\+cmd"
+
     def test_quote_nonnumeric_handling(self) -> None:
         """Test that CSV files with QUOTE_NONNUMERIC dialect are handled correctly."""
         # Simulate a CSV that the sniffer might detect as QUOTE_NONNUMERIC

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -39,7 +39,7 @@ csv.register_dialect("default", DefaultDialect)
 
 
 class csvunit(base.TranslationUnit):
-    spreadsheetescapes = [("+", "\\+"), ("-", "\\-"), ("=", "\\="), ("'", "\\'")]
+    spreadsheetescapes = {"+", "-", "=", "@"}
 
     def __init__(self, source=None) -> None:
         super().__init__(source)
@@ -131,23 +131,11 @@ class csvunit(base.TranslationUnit):
                 return False
         return some_value
 
-    def add_spreadsheet_escapes(self, source, target):
-        """Add common spreadsheet escapes to two strings."""
-        for unescaped, escaped in self.spreadsheetescapes:
-            if source.startswith(unescaped):
-                source = source.replace(unescaped, escaped, 1)
-            if target.startswith(unescaped):
-                target = target.replace(unescaped, escaped, 1)
-        return source, target
-
-    def remove_spreadsheet_escapes(self, source, target):
-        """Remove common spreadsheet escapes from two strings."""
-        for unescaped, escaped in self.spreadsheetescapes:
-            if source.startswith(escaped):
-                source = source.replace(escaped, unescaped, 1)
-            if target.startswith(escaped):
-                target = target.replace(escaped, unescaped, 1)
-        return source, target
+    def add_spreadsheet_escape(self, value):
+        """Add a spreadsheet escape to a string when it starts like a formula."""
+        if value and value[0] in self.spreadsheetescapes:
+            return f"'{value}"
+        return value
 
     def fromdict(self, cedict, encoding="utf-8") -> None:
         for key, value in cedict.items():
@@ -171,20 +159,19 @@ class csvunit(base.TranslationUnit):
             elif rkey == "developer_comments":
                 self.developer_comments = value
 
-        # self.source, self.target = self.remove_spreadsheet_escapes(self.source, self.target)
-
     def todict(self, **kwargs):
         # FIXME: use apis?
-        # source, target = self.add_spreadsheet_escapes(self.source, self.target)
         return {
-            "location": self.location,
-            "source": self.source,
-            "target": self.target,
-            "id": self.id,
+            "location": self.add_spreadsheet_escape(self.location),
+            "source": self.add_spreadsheet_escape(self.source),
+            "target": self.add_spreadsheet_escape(self.target),
+            "id": self.add_spreadsheet_escape(self.id),
             "fuzzy": str(self.fuzzy),
-            "context": self.context,
-            "translator_comments": self.translator_comments,
-            "developer_comments": self.developer_comments,
+            "context": self.add_spreadsheet_escape(self.context),
+            "translator_comments": self.add_spreadsheet_escape(
+                self.translator_comments
+            ),
+            "developer_comments": self.add_spreadsheet_escape(self.developer_comments),
         }
 
     def __str__(self) -> str:


### PR DESCRIPTION
Use standard apostrophe based escaping for formula like starts.