### PR TITLE
fix(html): properly escape translated HTML attributes

### DIFF
--- a/docs/commands/html2po.rst
+++ b/docs/commands/html2po.rst
@@ -132,6 +132,24 @@ Notes
 The :doc:`HTML format description </formats/html>` gives more details on the
 format of the localisable HTML content and the capabilities of this converter.
 
+Security
+--------
+
+``po2html`` inserts translated element content as HTML fragments. This is
+intentional: it lets translations preserve or adjust inline markup that was
+extracted from the template. It also means that PO files used to generate HTML
+must be trusted or reviewed before the generated pages are served.
+
+Translated HTML attribute values are escaped when written back to the template,
+so quote characters and other reserved characters in translated attributes
+remain part of the attribute value. This escaping does not sanitize element
+content, URLs, scripts, or other markup supplied through translations.
+
+The same trust model applies to other converters that generate rendered or
+executable formats from translations and templates: validate the translated
+output according to the security requirements of the target application before
+publishing it.
+
 **Translator Comments**
 
 Use the ``--keepcomments`` option to preserve HTML comments and

--- a/docs/formats/html.rst
+++ b/docs/formats/html.rst
@@ -24,6 +24,12 @@ Conformance
   - Content from HTML attributes uses the HTML entities ``&quot;`` (") or
     ``&apos;`` (').
 
+  During ``po2html`` conversion, translated attribute values are escaped when
+  they are written back to the HTML template. Element content is not sanitized:
+  it is inserted as an HTML fragment so that inline markup can be preserved.
+  Treat PO files used for HTML generation as trusted input, or review and
+  sanitize the generated HTML before publishing it.
+
 * Leading and trailing tags are removed from the localisable text,
   but only in matching pairs.
 

--- a/tests/translate/convert/test_po2html.py
+++ b/tests/translate/convert/test_po2html.py
@@ -103,6 +103,40 @@ sin.
         htmlexpected = """<li><a href="logoColor.eps" download>EPS color</a></li>"""
         assert htmlexpected in self.converthtml(posource, htmlsource)
 
+    def test_translated_attribute_values_are_escaped(self) -> None:
+        htmlsource = '<img alt="Title">'
+        posource = """#: test.html
+msgid "Title"
+msgstr "bad\\" autofocus onfocus=alert(1) x=\\""
+"""
+        result = self.converthtml(posource, htmlsource)
+        assert '<img alt="bad&quot; autofocus onfocus=alert(1) x=&quot;">' in result
+        assert '<img alt="bad" autofocus' not in result
+
+    def test_translated_attribute_entities_are_preserved(self) -> None:
+        htmlsource = '<input value="Search &amp; filter">'
+        posource = """#: test.html
+msgid "Search & filter"
+msgstr "Use &quot;search&quot; &brandShortName; & filter <now>"
+"""
+        expected = (
+            '<input value="Use &quot;search&quot; &brandShortName; '
+            '&amp; filter &lt;now&gt;">'
+        )
+        assert expected in self.converthtml(posource, htmlsource)
+
+    def test_translated_meta_content_is_escaped(self) -> None:
+        htmlsource = '<meta property="og:description" content="Summary">'
+        posource = """#: test.html
+msgid "Summary"
+msgstr "A \\"quoted\\" <summary> & details"
+"""
+        expected = (
+            '<meta property="og:description" '
+            'content="A &quot;quoted&quot; &lt;summary&gt; &amp; details">'
+        )
+        assert expected in self.converthtml(posource, htmlsource)
+
     def test_entities(self) -> None:
         """Tests that entities are handled correctly."""
         htmlsource = "<p>5 less than 6</p>"

--- a/translate/storage/html.py
+++ b/translate/storage/html.py
@@ -159,6 +159,10 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
 
     TRAILING_WHITESPACE_RE = re.compile(r"(\s+)$")
 
+    ATTRIBUTE_BARE_AMPERSAND_RE = re.compile(
+        r"&(?!(?:#[0-9]+|#[xX][0-9A-Fa-f]+|[A-Za-z][A-Za-z0-9._:-]*);)"
+    )
+
     ENCODING_RE = re.compile(
         rb"""<meta.*
                                 content.*=.*?charset=\s*?
@@ -546,7 +550,12 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
                     # Similar to how dir is automatically set, this intentionally overrides
                     # any explicit translation to maintain consistency.
                     if name == "og:locale" and self._translated_lang:
-                        result.append((attrname, self._translated_lang))
+                        result.append(
+                            (
+                                attrname,
+                                self.escape_attribute_value(self._translated_lang),
+                            )
+                        )
                         continue
                     if name in self.TRANSLATABLE_METADATA:
                         normalized_value = self.WHITESPACE_RE.sub(
@@ -554,7 +563,12 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
                         ).strip()
                         translated_value = self.callback(normalized_value)
                         if translated_value != normalized_value:
-                            result.append((attrname, translated_value))
+                            result.append(
+                                (
+                                    attrname,
+                                    self.escape_attribute_value(translated_value),
+                                )
+                            )
                             continue
                 # Only translate attributes that are translatable for this specific tag
                 if (
@@ -564,7 +578,9 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
                     normalized_value = self.WHITESPACE_RE.sub(" ", attrvalue).strip()
                     translated_value = self.callback(normalized_value)
                     if translated_value != normalized_value:
-                        result.append((attrname, translated_value))
+                        result.append(
+                            (attrname, self.escape_attribute_value(translated_value))
+                        )
                         continue
             result.append((attrname, attrvalue))
 
@@ -573,6 +589,16 @@ class htmlfile(html.parser.HTMLParser, base.TranslationStore):
             result.append(("dir", "rtl" if is_rtl(translated_lang) else "ltr"))
 
         return result
+
+    @staticmethod
+    def escape_attribute_value(value: str) -> str:
+        """Escape text for double-quoted HTML attributes, preserving entities."""
+        return (
+            htmlfile.ATTRIBUTE_BARE_AMPERSAND_RE.sub("&amp;", value)
+            .replace('"', "&quot;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+        )
 
     @staticmethod
     def create_start_tag(tag, attrs=None, startend=False) -> str:


### PR DESCRIPTION
- escape HTML attributes while translating
- document security impact of using po2html