### PR TITLE
docs: remove objects from toc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,11 @@ ogp_social_cards = {
 # The master toctree document.
 master_doc = "index"
 
+# Do not add every autodoc object to the table of contents. The generated API
+# pages document thousands of methods and attributes, and adding all of them to
+# navigation structures makes the HTML build much slower.
+toc_object_entries = False
+
 # -- Missing modules --------------------------------------------------
 
 autodoc_mock_imports = [


### PR DESCRIPTION
This heavily reduces its size making it easier to navigate and the docs faster to build.