### PR TITLE
chore(markdown): add tests and extend documentation on hard line breaks

### DIFF
--- a/docs/formats/md.rst
+++ b/docs/formats/md.rst
@@ -28,7 +28,10 @@ Conformance
   the translated Markdown. The po2md converter has an option to do that.
 
 * Hard line breaks in the Markdown appear as hard line breaks in the translation
-  units (PO files), and vice versa.
+  units (PO files), and vice versa. A source hard break written as two trailing
+  spaces or as a trailing backslash is exposed in PO as a newline character
+  (``\n``). When writing Markdown, po2md may serialize that newline as a
+  backslash hard break.
 
 * Does not translate embedded HTML.
 

--- a/tests/translate/convert/test_md2po.py
+++ b/tests/translate/convert/test_md2po.py
@@ -142,6 +142,26 @@ def hello():
         sources = [unit.source for unit in output.units]
         assert not any("hello" in s for s in sources)
 
+    def test_markdown_hard_line_break_extraction(self) -> None:
+        self.given_markdown_file(
+            content=(
+                "- Use multiple keys: `OWC_ENCRYPTION_KEYS='Pj...48=,cx...Fw='`  \n"
+                "  If you use multiple keys, only the first one encrypts the data.\n"
+                "  The others are only used to decrypt the data.\n"
+            )
+        )
+        self.run_command("file.md", "test.po")
+        output = pofile()
+        with open(self.get_testfilename("test.po"), "rb") as handle:
+            output.parse(handle)
+
+        sources = [unit.source for unit in output.units]
+        assert (
+            "Use multiple keys: `OWC_ENCRYPTION_KEYS='Pj...48=,cx...Fw='`\n"
+            "If you use multiple keys, only the first one encrypts the data. "
+            "The others are only used to decrypt the data."
+        ) in sources
+
     def test_markdown_directory_ignores_txt_files(self) -> None:
         self.given_directory_of_markdown_files()
         self.create_testfile("mddir/notes.txt", "Text file content")

--- a/tests/translate/convert/test_po2md.py
+++ b/tests/translate/convert/test_po2md.py
@@ -267,6 +267,38 @@ You are only coming through in waves.
         assert "# Prehled" in output
         assert "Prelozeny obsah" in output
 
+    def test_markdown_hard_line_break_translation(self) -> None:
+        self.given_markdown_file(
+            content=(
+                "- Use multiple keys: `OWC_ENCRYPTION_KEYS='Pj...48=,cx...Fw='`  \n"
+                "  If you use multiple keys, only the first one encrypts the data.\n"
+                "  The others are only used to decrypt the data.\n"
+            )
+        )
+        self.given_translation_file(
+            lines=[
+                "#: file.md:1",
+                'msgid ""',
+                "\"Use multiple keys: `OWC_ENCRYPTION_KEYS='Pj...48=,cx...Fw='`\\n\"",
+                (
+                    '"If you use multiple keys, only the first one encrypts the data. '
+                    'The others are only used to decrypt the data."'
+                ),
+                'msgstr ""',
+                "\"Translated keys: `OWC_ENCRYPTION_KEYS='xx'`\\n\"",
+                '"The first key encrypts the data. The others decrypt it."',
+            ]
+        )
+        self.run_command(
+            "translation.po", "out.md", template="file.md", maxlinelength=0
+        )
+        output = self.read_testfile("out.md").decode()
+
+        assert output == (
+            "- Translated keys: `OWC_ENCRYPTION_KEYS='xx'`\\\n"
+            "  The first key encrypts the data. The others decrypt it.\n"
+        )
+
     def test_no_placeholders_simple_link(self) -> None:
         """po2md --no-placeholders: full-link msgid is translated correctly."""
         self.given_markdown_file(


### PR DESCRIPTION
This just extends test coverage and updates the documentation to describe current behavior.

Fixes #5514