### PR TITLE
fix(storage): generalize support for previous messages

### DIFF
--- a/tests/translate/convert/test_po2xliff.py
+++ b/tests/translate/convert/test_po2xliff.py
@@ -239,6 +239,104 @@ msgstr "raro"
         assert xliff.units[0].isfuzzy()
         assert not xliff.units[1].isfuzzy()
 
+    def test_previous_msgid_becomes_alttrans(self) -> None:
+        minipo = r"""#, fuzzy
+#| msgctxt "old button"
+#| msgid "too many arguments"
+msgctxt "button"
+msgid "too few arguments"
+msgstr "trop d arguments"
+"""
+        xliff = self.po2xliff(minipo)
+        alternatives = xliff.units[0].getalttrans()
+        assert len(alternatives) == 1
+        assert alternatives[0].source == "too many arguments"
+        assert alternatives[0].target == "trop d arguments"
+        assert alternatives[0].getcontext() == "old button"
+
+    def test_previous_plural_msgid_becomes_alttrans(self) -> None:
+        minipo = r"""#, fuzzy
+#| msgctxt "animal"
+#| msgid "cow"
+#| msgid_plural "cows"
+msgctxt "young animal"
+msgid "calf"
+msgid_plural "calves"
+msgstr[0] "inkonyane"
+msgstr[1] "amankonyane"
+"""
+        xliff = self.po2xliff(minipo)
+        assert len(xliff.units) == 1
+        unit = xliff.units[0]
+        assert unit.hasplural()
+
+        alternatives = unit.getalttrans()
+        assert len(alternatives) == 1
+        assert alternatives[0].source.strings == ["cow", "cows"]
+        assert alternatives[0].target.strings == ["inkonyane", "amankonyane"]
+        assert alternatives[0].getcontext() == "animal"
+
+        singular_alternatives = unit.units[0].getalttrans()
+        assert len(singular_alternatives) == 1
+        assert singular_alternatives[0].source == "cow"
+        assert singular_alternatives[0].target == "inkonyane"
+        assert singular_alternatives[0].getcontext() == "animal"
+
+        plural_alternatives = unit.units[1].getalttrans()
+        assert len(plural_alternatives) == 1
+        assert plural_alternatives[0].source == "cows"
+        assert plural_alternatives[0].target == "amankonyane"
+        assert plural_alternatives[0].getcontext() == "animal"
+
+    def test_previous_singular_msgid_on_plural_unit_becomes_single_alttrans(
+        self,
+    ) -> None:
+        minipo = r"""#, fuzzy
+#| msgid "cow"
+msgid "calf"
+msgid_plural "calves"
+msgstr[0] "inkonyane"
+msgstr[1] "amankonyane"
+"""
+        xliff = self.po2xliff(minipo)
+        assert len(xliff.units) == 1
+        unit = xliff.units[0]
+        assert unit.hasplural()
+
+        alternatives = unit.getalttrans()
+        assert len(alternatives) == 1
+        assert alternatives[0].source == "cow"
+        assert alternatives[0].target == "inkonyane"
+
+        singular_alternatives = unit.units[0].getalttrans()
+        assert len(singular_alternatives) == 1
+        assert singular_alternatives[0].source == "cow"
+        assert singular_alternatives[0].target == "inkonyane"
+
+        assert unit.units[1].getalttrans() == []
+
+    def test_previous_plural_msgid_on_singular_unit_preserves_alttrans(
+        self,
+    ) -> None:
+        minipo = r"""#, fuzzy
+#| msgid "cow"
+#| msgid_plural "cows"
+msgid "calf"
+msgstr "inkonyane"
+"""
+        xliff = self.po2xliff(minipo)
+        assert len(xliff.units) == 1
+        unit = xliff.units[0]
+        assert not unit.hasplural()
+
+        alternatives = unit.getalttrans()
+        assert len(alternatives) == 2
+        assert [alternative.source for alternative in alternatives] == ["cow", "cows"]
+        assert [alternative.target for alternative in alternatives] == [
+            "inkonyane",
+            "inkonyane",
+        ]
+
     def test_germanic_plurals(self) -> None:
         minipo = r"""msgid "cow"
 msgid_plural "cows"

--- a/tests/translate/convert/test_pot2po.py
+++ b/tests/translate/convert/test_pot2po.py
@@ -69,6 +69,32 @@ msgstr[0] ""
         newpo = self.convertpot(potsource, posource)
         assert str(self.singleunit(newpo)) == posource
 
+    def test_fuzzy_merge_records_previous_msgid(self) -> None:
+        """Fuzzy reused translations should retain the old source as previous."""
+        potsource = """msgid "too few arguments"\nmsgstr ""\n"""
+        posource = """msgid "too many arguments"\nmsgstr "trop d arguments"\n"""
+        poexpected = """#, fuzzy
+#| msgid "too many arguments"
+msgid "too few arguments"
+msgstr "trop d arguments"
+"""
+        newpo = self.convertpot(potsource, posource)
+        assert str(self.singleunit(newpo)) == poexpected
+
+    def test_fuzzy_merge_records_previous_context(self) -> None:
+        """Fuzzy reused translations should retain the old context as previous."""
+        potsource = """msgctxt "new context"\nmsgid "Open"\nmsgstr ""\n"""
+        posource = """msgctxt "old context"\nmsgid "Open"\nmsgstr "Ouvrir"\n"""
+        poexpected = """#, fuzzy
+#| msgctxt "old context"
+#| msgid "Open"
+msgctxt "new context"
+msgid "Open"
+msgstr "Ouvrir"
+"""
+        newpo = self.convertpot(potsource, posource)
+        assert str(self.singleunit(newpo)) == poexpected
+
     def test_merging_plurals_with_fuzzy_matching(self) -> None:
         """Test that when we merge PO files with a fuzzy message that it remains fuzzy."""
         potsource = r"""#: file.cpp:2
@@ -121,7 +147,12 @@ msgstr[1] "%d handleidings."
         """
         potsource = f"""#: singlespace.label{po.lsep}singlespace.accesskey\nmsgid "&We have spaces"\nmsgstr ""\n"""
         posource = f"""#: doublespace.label{po.lsep}doublespace.accesskey\nmsgid "&We  have  spaces"\nmsgstr "&One  het  spasies"\n"""
-        poexpected = f"""#: singlespace.label{po.lsep}singlespace.accesskey\n#, fuzzy\nmsgid "&We have spaces"\nmsgstr "&One  het  spasies"\n"""
+        poexpected = f"""#: singlespace.label{po.lsep}singlespace.accesskey
+#, fuzzy
+#| msgid "&We  have  spaces"
+msgid "&We have spaces"
+msgstr "&One  het  spasies"
+"""
         newpo = self.convertpot(potsource, posource)
         print(newpo)
         assert str(self.singleunit(newpo)) == poexpected
@@ -139,8 +170,22 @@ msgstr[1] "%d handleidings."
         posource = (
             """#: location.c:1\n#: location.c:10\nmsgid "Source"\nmsgstr "Target"\n\n"""
         )
-        poexpected1 = """#: location.c:1\n#, fuzzy\nmsgid ""\n"_: location.c:1\\n"\n"Source"\nmsgstr "Target"\n"""
-        poexpected2 = """#: location.c:10\n#, fuzzy\nmsgid ""\n"_: location.c:10\\n"\n"Source"\nmsgstr "Target"\n"""
+        poexpected1 = """#: location.c:1
+#, fuzzy
+#| msgid "Source"
+msgid ""
+"_: location.c:1\\n"
+"Source"
+msgstr "Target"
+"""
+        poexpected2 = """#: location.c:10
+#, fuzzy
+#| msgid "Source"
+msgid ""
+"_: location.c:10\\n"
+"Source"
+msgstr "Target"
+"""
         newpo = self.convertpot(potsource, posource)
         print("Expected:\n", poexpected1, "Actual:\n", newpo.units[1])
         assert str(newpo.units[1]) == poexpected1
@@ -263,6 +308,7 @@ msgstr "Sertifikate"
 """
         expected = r"""#: pref.certs.title
 #, fuzzy
+#| msgid "Certificates"
 msgid ""
 "_: pref.certs.title\n"
 "Certificates"
@@ -342,7 +388,14 @@ msgstr "Sertifikate"
         )
         posource = """#~ msgid "About"\n#~ msgstr "Omtrent"\n"""
         expected1 = """#: resurrect1.c\nmsgid "About"\nmsgstr "Omtrent"\n"""
-        expected2 = """#: resurrect2.c\n#, fuzzy\nmsgid ""\n"_: resurrect2.c\\n"\n"About"\nmsgstr "Omtrent"\n"""
+        expected2 = """#: resurrect2.c
+#, fuzzy
+#| msgid "About"
+msgid ""
+"_: resurrect2.c\\n"
+"About"
+msgstr "Omtrent"
+"""
         newpo = self.convertpot(potsource, posource)
         print(newpo)
         assert len(newpo.units) == 3
@@ -424,7 +477,12 @@ msgstr ""
 
         potsource = """#: file.c:1\n#, c-format\nmsgid "%d computers"\nmsgstr ""\n"""
         posource = """#: file.c:2\n#, c-format\nmsgid "%s computers "\nmsgstr "%s-rekenaars"\n"""
-        poexpected = """#: file.c:1\n#, c-format, fuzzy\nmsgid "%d computers"\nmsgstr "%s-rekenaars"\n"""
+        poexpected = """#: file.c:1
+#, c-format, fuzzy
+#| msgid "%s computers "
+msgid "%d computers"
+msgstr "%s-rekenaars"
+"""
         newpo = self.convertpot(potsource, posource)
         newpounit = self.singleunit(newpo)
         assert newpounit.isfuzzy()
@@ -463,6 +521,8 @@ msgstr "sms"
 
 #: something.h:6
 #, fuzzy
+#| msgctxt "context0"
+#| msgid "text"
 msgctxt "context2"
 msgid "text"
 msgstr "teks"

--- a/tests/translate/storage/test_cpo.py
+++ b/tests/translate/storage/test_cpo.py
@@ -4,6 +4,7 @@ from typing import cast
 from pytest import importorskip, mark, raises
 
 from translate.misc.multistring import multistring
+from translate.storage import pypo
 
 from . import test_po
 
@@ -76,6 +77,28 @@ class TestCPOUnit(test_po.TestPOUnit):
         unit.addnote("# Double commented comment")
         assert unit.getnotes() == "# Double commented comment"
         assert not unit.hastypecomment("c-format")
+
+    def test_buildfromunit_preserves_previous_metadata(self) -> None:
+        """Native units should retain previous metadata copied from another PO unit."""
+        source_unit = pypo.pounit("new file")
+        source_unit.target = "fichier"
+        source_unit.setcontext("new context")
+        source_unit.prev_source = "old file"
+        source_unit.prev_context = "old context"
+        source_unit.markfuzzy()
+
+        unit = self.UnitClass.buildfromunit(source_unit)
+
+        assert unit.prev_source == "old file"
+        assert unit.prev_context == "old context"
+        assert str(unit) == (
+            "#, fuzzy\n"
+            '#| msgctxt "old context"\n'
+            '#| msgid "old file"\n'
+            'msgctxt "new context"\n'
+            'msgid "new file"\n'
+            'msgstr "fichier"\n'
+        )
 
 
 class TestCPOFile(test_po.TestPOFile):
@@ -212,6 +235,65 @@ class TestCPOFile(test_po.TestPOFile):
         print(pofile)
         assert len(pofile.units) == 1
         assert bytes(pofile).decode("utf-8") == posource
+
+    def test_previous_plural_metadata(self) -> None:
+        """Checks native parsing, API access and serialization of previous entries."""
+        posource = r"""#, fuzzy
+#| msgctxt "old context"
+#| msgid "old file"
+#| msgid_plural "old files"
+msgctxt "new context"
+msgid "new file"
+msgid_plural "new files"
+msgstr[0] "fichier"
+msgstr[1] "fichiers"
+"""
+        pofile = self.poparse(posource)
+        unit = pofile.units[0]
+
+        assert unit.prev_context == "old context"
+        assert isinstance(unit.prev_source, multistring)
+        assert [str(string) for string in unit.prev_source.strings] == [
+            "old file",
+            "old files",
+        ]
+        alternatives = unit.getalttrans()
+        assert len(alternatives) == 1
+        assert unit.getalttrans(origin="tm") == []
+        assert [str(string) for string in alternatives[0].source.strings] == [
+            "old file",
+            "old files",
+        ]
+        assert [str(string) for string in alternatives[0].target.strings] == [
+            "fichier",
+            "fichiers",
+        ]
+        assert bytes(pofile).decode("utf-8") == posource
+
+    def test_merge_sets_previous_metadata(self) -> None:
+        """Checks native merging records the reused message as previous."""
+        current = self.poparse('msgid "new file"\nmsgstr ""\n').units[0]
+        previous = self.poparse('msgid "old file"\nmsgstr "fichier"\n').units[0]
+
+        current.merge(previous, authoritative=True)
+
+        assert current.prev_source == "old file"
+        assert current.prev_context == ""
+        assert str(current) == (
+            '#, fuzzy\n#| msgid "old file"\nmsgid "new file"\nmsgstr "fichier"\n'
+        )
+
+    def test_msgidcomment_not_used_as_previous_context(self) -> None:
+        """KDE-style msgid comments should not become previous msgctxt."""
+        current = self.poparse('msgid "new file"\nmsgstr ""\n').units[0]
+        previous = self.poparse('msgid "old file"\nmsgstr "fichier"\n').units[0]
+        previous.msgidcomment = "certs.label"
+
+        current.merge(previous, authoritative=True)
+
+        assert current.prev_source == "old file"
+        assert current.prev_context == ""
+        assert "#| msgctxt" not in str(current)
 
     def test_multiline_obsolete(self) -> None:
         """Tests for correct output of multiline obsolete messages."""

--- a/tests/translate/storage/test_fpo.py
+++ b/tests/translate/storage/test_fpo.py
@@ -2,13 +2,21 @@ from io import BytesIO, StringIO
 
 from pytest import importorskip, raises
 
-from translate.storage import base
+from translate.misc.multistring import multistring
+from translate.storage import base, pypo
 
 fpo = importorskip("translate.storage.fpo", exc_type=ImportError)
 
 
 class TestFPOFile:
     StoreClass = fpo.pofile
+
+    def poparse(self, posource):
+        """Helper that parses po source without requiring files."""
+        dummyfile = BytesIO(
+            posource.encode() if isinstance(posource, str) else posource
+        )
+        return self.StoreClass(dummyfile, noheader=True)
 
     def test_bytesio_path_content_is_not_reopened(self, tmp_path) -> None:
         po_path = tmp_path / "payload.po"
@@ -36,3 +44,84 @@ class TestFPOFile:
                     'msgstr "café"\n'
                 )
             )
+
+    def test_buildfromunit_preserves_previous_metadata(self) -> None:
+        """FPO units should retain previous metadata copied from another PO unit."""
+        source_unit = pypo.pounit("new file")
+        source_unit.target = "fichier"
+        source_unit.setcontext("new context")
+        source_unit.prev_source = "old file"
+        source_unit.prev_context = "old context"
+        source_unit.markfuzzy()
+
+        unit = fpo.pounit.buildfromunit(source_unit)
+
+        assert unit.prev_source == "old file"
+        assert unit.prev_context == "old context"
+        assert str(unit) == (
+            "#, fuzzy\n"
+            '#| msgctxt "old context"\n'
+            '#| msgid "old file"\n'
+            'msgctxt "new context"\n'
+            'msgid "new file"\n'
+            'msgstr "fichier"\n'
+        )
+
+    def test_previous_plural_metadata(self) -> None:
+        """Checks FPO parsing, API access and serialization of previous entries."""
+        posource = r"""#, fuzzy
+#| msgctxt "old context"
+#| msgid "old file"
+#| msgid_plural "old files"
+msgctxt "new context"
+msgid "new file"
+msgid_plural "new files"
+msgstr[0] "fichier"
+msgstr[1] "fichiers"
+"""
+        pofile = self.poparse(posource)
+        unit = pofile.units[0]
+
+        assert unit.prev_context == "old context"
+        assert isinstance(unit.prev_source, multistring)
+        assert [str(string) for string in unit.prev_source.strings] == [
+            "old file",
+            "old files",
+        ]
+        alternatives = unit.getalttrans()
+        assert len(alternatives) == 1
+        assert unit.getalttrans(origin="tm") == []
+        assert [str(string) for string in alternatives[0].source.strings] == [
+            "old file",
+            "old files",
+        ]
+        assert [str(string) for string in alternatives[0].target.strings] == [
+            "fichier",
+            "fichiers",
+        ]
+        assert bytes(pofile).decode("utf-8") == posource
+
+    def test_merge_sets_previous_metadata(self) -> None:
+        """Checks FPO merging records the reused message as previous."""
+        current = self.poparse('msgid "new file"\nmsgstr ""\n').units[0]
+        previous = self.poparse('msgid "old file"\nmsgstr "fichier"\n').units[0]
+
+        current.merge(previous, authoritative=True)
+
+        assert current.prev_source == "old file"
+        assert current.prev_context == ""
+        assert str(current) == (
+            '#, fuzzy\n#| msgid "old file"\nmsgid "new file"\nmsgstr "fichier"\n'
+        )
+
+    def test_msgidcomment_not_used_as_previous_context(self) -> None:
+        """KDE-style msgid comments should not become previous msgctxt."""
+        current = self.poparse('msgid "new file"\nmsgstr ""\n').units[0]
+        previous = self.poparse('msgid "old file"\nmsgstr "fichier"\n').units[0]
+        previous.msgidcomment = "certs.label"
+
+        current.merge(previous, authoritative=True)
+
+        assert current.prev_source == "old file"
+        assert current.prev_context == ""
+        assert "#| msgctxt" not in str(current)

--- a/tests/translate/storage/test_poxliff.py
+++ b/tests/translate/storage/test_poxliff.py
@@ -159,6 +159,79 @@ class TestPOXLIFFUnit(test_xliff.TestXLIFFUnit):
             targets = list(child_unit.xmlelement.iterchildren(ns))
             assert len(targets) == 0
 
+    def test_empty_unit_getcontext_defaults_to_empty(self) -> None:
+        """Tests that parsed-empty units still have a default context."""
+        unit = self.UnitClass(None, empty=True)
+
+        assert unit.getcontext() == ""
+
+    def test_plural_alttrans_aggregates_complete_suggestions(self) -> None:
+        """Tests that aligned plural alternatives are exposed as one unit."""
+        unit = self.UnitClass(multistring(["cow", "cows"]))
+        unit.units[0].addalttrans("inkonyane", sourcetxt="calf")
+        unit.units[1].addalttrans("amankonyane", sourcetxt="calves")
+
+        alternatives = unit.getalttrans()
+
+        assert len(alternatives) == 1
+        assert alternatives[0].source.strings == ["calf", "calves"]
+        assert alternatives[0].target.strings == ["inkonyane", "amankonyane"]
+
+    def test_plural_alttrans_aggregated_suggestion_can_be_deleted(self) -> None:
+        """Tests that aggregated plural alternatives remain deletable."""
+        unit = self.UnitClass(multistring(["cow", "cows"]))
+        unit.units[0].addalttrans("inkonyane", sourcetxt="calf")
+        unit.units[1].addalttrans("amankonyane", sourcetxt="calves")
+
+        alternatives = unit.getalttrans()
+        unit.delalttrans(alternatives[0])
+
+        assert unit.getalttrans() == []
+        assert unit.units[0].getalttrans() == []
+        assert unit.units[1].getalttrans() == []
+
+    def test_plural_alttrans_preserves_partial_suggestions(self) -> None:
+        """Tests that alternatives are kept when not every plural child has one."""
+        unit = self.UnitClass(multistring(["cow", "cows"]))
+        unit.units[0].addalttrans("inkonyane", sourcetxt="calf")
+
+        alternatives = unit.getalttrans()
+
+        assert len(alternatives) == 1
+        assert alternatives[0].source == "calf"
+        assert alternatives[0].target == "inkonyane"
+
+    def test_plural_alttrans_preserves_extra_suggestions(self) -> None:
+        """Tests that extra child alternatives are not truncated."""
+        unit = self.UnitClass(multistring(["cow", "cows"]))
+        unit.units[0].addalttrans("inkonyane", origin="previous", sourcetxt="calf")
+        unit.units[1].addalttrans("amankonyane", origin="previous", sourcetxt="calves")
+        unit.units[0].addalttrans("thole", origin="tm", sourcetxt="young cow")
+
+        alternatives = unit.getalttrans()
+
+        assert len(alternatives) == 2
+        assert alternatives[0].source.strings == ["calf", "calves"]
+        assert alternatives[0].target.strings == ["inkonyane", "amankonyane"]
+        assert alternatives[1].source == "young cow"
+        assert alternatives[1].target == "thole"
+
+    def test_plural_alttrans_aggregates_by_metadata_not_order(self) -> None:
+        """Tests that differently ordered child alternatives are matched by metadata."""
+        unit = self.UnitClass(multistring(["cow", "cows"]))
+        unit.units[0].addalttrans("thole", origin="tm", sourcetxt="young cow")
+        unit.units[0].addalttrans("inkonyane", origin="previous", sourcetxt="calf")
+        unit.units[1].addalttrans("amankonyane", origin="previous", sourcetxt="calves")
+        unit.units[1].addalttrans("amathole", origin="tm", sourcetxt="young cows")
+
+        alternatives = unit.getalttrans()
+
+        assert len(alternatives) == 2
+        assert alternatives[0].source.strings == ["young cow", "young cows"]
+        assert alternatives[0].target.strings == ["thole", "amathole"]
+        assert alternatives[1].source.strings == ["calf", "calves"]
+        assert alternatives[1].target.strings == ["inkonyane", "amankonyane"]
+
 
 class TestPOXLIFFfile(test_xliff.TestXLIFFfile):
     StoreClass = poxliff.PoXliffFile

--- a/tests/translate/storage/test_pypo.py
+++ b/tests/translate/storage/test_pypo.py
@@ -673,6 +673,37 @@ msgstr[1] "toetse"
         assert bytes(pofile).decode("utf-8") == posource
         # spellchecker:on
 
+    def test_prevmsgid_plural_with_current_singular(self) -> None:
+        """Previous plural metadata should not depend on current plural state."""
+        posource = r"""#, fuzzy
+#| msgid "file"
+#| msgid_plural "files"
+msgid "one file"
+msgstr "fichier"
+"""
+        pofile = self.poparse(posource)
+        unit = pofile.units[0]
+        assert unit.prev_source == multistring(["file", "files"])
+        alternatives = unit.getalttrans()
+        assert len(alternatives) == 1
+        assert alternatives[0].source.strings == ["file", "files"]
+        assert alternatives[0].target.strings == ["fichier", "fichier"]
+        assert unit.getalttrans(origin="tm") == []
+        assert bytes(pofile).decode("utf-8") == posource
+
+    def test_msgidcomment_not_used_as_previous_context(self) -> None:
+        """KDE-style msgid comments should not become previous msgctxt."""
+        current = pypo.pounit("new file")
+        previous = pypo.pounit("old file")
+        previous.target = "fichier"
+        previous.setmsgidcomment("certs.label")
+
+        current.merge(previous, authoritative=True)
+
+        assert current.prev_source == "old file"
+        assert current.prev_context == ""
+        assert "#| msgctxt" not in str(current)
+
     def test_wrap(self) -> None:
         hello = " ".join(["Hello"] * 100)
         posource = f'msgid "{hello}"\nmsgstr "{hello}"\n'.encode()

--- a/tests/translate/tools/test_pomerge.py
+++ b/tests/translate/tools/test_pomerge.py
@@ -162,6 +162,17 @@ msgstr "Dimpled Ring"'''
         assert pounit.target == "Dimpled Ring"
         assert not pounit.isfuzzy()
 
+    def test_merging_fuzzy_preserves_previous_msgid(self) -> None:
+        """Merging a fuzzy snippet should preserve its previous source metadata."""
+        templatepo = """msgid "too few arguments"\nmsgstr ""\n"""
+        inputpo = """#, fuzzy
+#| msgid "too many arguments"
+msgid "too few arguments"
+msgstr "trop d arguments"
+"""
+        pofile = self.mergestore(templatepo, inputpo)
+        assert bytes(pofile).decode("utf-8") == inputpo
+
     def test_merging_locations(self) -> None:
         """
         Check that locations on separate lines are output in Gettext form

--- a/tests/translate/tools/test_pretranslate.py
+++ b/tests/translate/tools/test_pretranslate.py
@@ -133,7 +133,12 @@ msgstr[1] "%d handleidings."
         """
         input_source = f"""#: singlespace.label{po.lsep}singlespace.accesskey\nmsgid "&We have spaces"\nmsgstr ""\n"""
         template_source = f"""#: doublespace.label{po.lsep}doublespace.accesskey\nmsgid "&We  have  spaces"\nmsgstr "&One  het  spasies"\n"""
-        poexpected = f"""#: singlespace.label{po.lsep}singlespace.accesskey\n#, fuzzy\nmsgid "&We have spaces"\nmsgstr "&One  het  spasies"\n"""
+        poexpected = f"""#: singlespace.label{po.lsep}singlespace.accesskey
+#, fuzzy
+#| msgid "&We  have  spaces"
+msgid "&We have spaces"
+msgstr "&One  het  spasies"
+"""
         newpo = self.pretranslatepo(input_source, template_source)
         print(bytes(newpo))
         assert bytes(newpo).decode("utf-8") == poexpected
@@ -287,7 +292,12 @@ msgstr "36em"
 
         input_source = """#: file.c:1\n#, c-format\nmsgid "%d computers"\nmsgstr ""\n"""
         template_source = """#: file.c:2\n#, c-format\nmsgid "%s computers "\nmsgstr "%s-rekenaars"\n"""
-        poexpected = """#: file.c:1\n#, c-format, fuzzy\nmsgid "%d computers"\nmsgstr "%s-rekenaars"\n"""
+        poexpected = """#: file.c:1
+#, c-format, fuzzy
+#| msgid "%s computers "
+msgid "%d computers"
+msgstr "%s-rekenaars"
+"""
         newpo = self.pretranslatepo(input_source, template_source)
         newpounit = self.singleunit(newpo)
         assert newpounit.isfuzzy()

--- a/translate/convert/po2xliff.py
+++ b/translate/convert/po2xliff.py
@@ -24,10 +24,35 @@ for examples and usage instructions.
 """
 
 from translate.convert import convert
+from translate.misc.multistring import multistring
 from translate.storage import po, poxliff
 
 
 class po2xliff:
+    @staticmethod
+    def _string_list(value):
+        if isinstance(value, multistring):
+            return value.strings
+        return [value]
+
+    def addalttrans(self, unit, alternative) -> None:
+        """Add an alternate translation, preserving plural alternatives when possible."""
+        sources = self._string_list(alternative.source)
+        targets = self._string_list(alternative.target)
+        context = alternative.getcontext()
+        if unit.hasplural():
+            for index, source in enumerate(sources[: len(unit.units)]):
+                target = targets[index] if index < len(targets) else targets[-1]
+                unit.units[index].addalttrans(
+                    target, origin="previous", sourcetxt=source, context=context
+                )
+            return
+        for index, source in enumerate(sources):
+            target = targets[index] if index < len(targets) else targets[-1]
+            unit.addalttrans(
+                target, origin="previous", sourcetxt=source, context=context
+            )
+
     def convertunit(self, outputstore, inputunit, filename):
         """Creates a transunit node."""
         source = inputunit.source
@@ -43,6 +68,9 @@ class po2xliff:
                 unit.markfuzzy(inputunit.isfuzzy())
             else:
                 unit.markapproved(False)
+
+            for alternative in inputunit.getalttrans():
+                self.addalttrans(unit, alternative)
 
             # Handle #: location comments
             for location in inputunit.getlocations():

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -234,6 +234,10 @@ class TranslationUnit:
 
     def __init__(self, source=None) -> None:
         """Constructs a TranslationUnit containing the given source string."""
+        self._context = ""
+        self._prev_source = None
+        self._prev_context = ""
+        self._prev_target = None
         if source is not None:
             self.source = source
         self._docpath = ""
@@ -456,10 +460,88 @@ class TranslationUnit:
 
     def getcontext(self) -> str:
         """Get the message context."""
-        return ""
+        return getattr(self, "_context", "")
 
     def setcontext(self, context) -> None:
         """Set the message context."""
+        self._context = context or ""
+
+    def getpreviouscontext(self):
+        """Get the context value suitable for previous-message metadata."""
+        return self.getcontext()
+
+    @property
+    def prev_source(self):
+        """Previous source text for fuzzy/reused units, if available."""
+        return getattr(self, "_prev_source", None)
+
+    @prev_source.setter
+    def prev_source(self, source) -> None:
+        self._prev_source = source
+
+    @property
+    def prev_context(self):
+        """Previous source context for fuzzy/reused units, if available."""
+        return getattr(self, "_prev_context", "")
+
+    @prev_context.setter
+    def prev_context(self, context) -> None:
+        self._prev_context = context or ""
+
+    @property
+    def prev_target(self):
+        """Previous target text for formats that expose it."""
+        return getattr(self, "_prev_target", None)
+
+    @prev_target.setter
+    def prev_target(self, target) -> None:
+        self._prev_target = target
+
+    def has_previous(self) -> bool:
+        """Whether this unit has previous source/context metadata."""
+        return bool(self.prev_source or self.prev_context)
+
+    def clear_previous(self) -> None:
+        """Clear previous source/context metadata."""
+        self.prev_source = None
+        self.prev_context = ""
+        self.prev_target = None
+
+    def copy_previous(self, unit) -> None:
+        """Copy previous source/context metadata from another unit."""
+        if not unit.has_previous():
+            self.clear_previous()
+            return
+        self.prev_source = getattr(unit, "prev_source", None)
+        self.prev_context = getattr(unit, "prev_context", "")
+        self.prev_target = getattr(unit, "prev_target", None)
+
+    def set_as_previous(self, unit) -> None:
+        """Store another unit's current source/context as this unit's previous one."""
+        self.prev_source = unit.source
+        self.prev_context = unit.getpreviouscontext()
+        self.prev_target = unit.target
+
+    def getalttrans(self, origin=None):
+        """Return alternate translations derived from previous metadata."""
+        if origin is not None or not self.prev_source or not self.isfuzzy():
+            return []
+        unit = type(self)(self.prev_source)
+        target = self.target
+        if isinstance(self.prev_source, multistring):
+            count = len(self.prev_source.strings)
+            if isinstance(target, multistring):
+                target_strings = list(target.strings)
+                if len(target_strings) < count:
+                    target_strings += [target_strings[-1] if target_strings else ""] * (
+                        count - len(target_strings)
+                    )
+                target = multistring(target_strings[:count])
+            else:
+                target = multistring([target or ""] * count)
+        unit.target = target
+        unit.setcontext(self.prev_context)
+        return [unit]
 
     def getnotes(self, origin=None):
         """
@@ -623,6 +705,7 @@ class TranslationUnit:
         notes = unit.getnotes()
         if notes:
             newunit.addnote(notes)
+        newunit.copy_previous(unit)
         return newunit
 
     xid = property(lambda self: None, lambda self, value: None)

--- a/translate/storage/cpo.py
+++ b/translate/storage/cpo.py
@@ -460,6 +460,44 @@ class pounit(pocommon.pounit):
             gpo.po_message_set_msgid_plural(self._gpo_message, None)  # ty:ignore[unresolved-attribute]
 
     @property
+    def prev_source(self):
+        singular = gpo_decode(gpo.po_message_prev_msgid(self._gpo_message)) or ""  # ty:ignore[unresolved-attribute]
+        plural = gpo.po_message_prev_msgid_plural(self._gpo_message)  # ty:ignore[unresolved-attribute]
+        if plural:
+            return multistring([singular, gpo_decode(plural) or ""])
+        return singular
+
+    @prev_source.setter
+    def prev_source(self, source) -> None:
+        if source is None:
+            gpo.po_message_set_prev_msgid(self._gpo_message, None)  # ty:ignore[unresolved-attribute]
+            gpo.po_message_set_prev_msgid_plural(self._gpo_message, None)  # ty:ignore[unresolved-attribute]
+            return
+        if isinstance(source, multistring):
+            source = source.strings
+        if isinstance(source, list):
+            gpo.po_message_set_prev_msgid(self._gpo_message, gpo_encode(source[0]))  # ty:ignore[unresolved-attribute]
+            if len(source) > 1:
+                gpo.po_message_set_prev_msgid_plural(  # ty:ignore[unresolved-attribute]
+                    self._gpo_message, gpo_encode(source[1])
+                )
+            else:
+                gpo.po_message_set_prev_msgid_plural(self._gpo_message, None)  # ty:ignore[unresolved-attribute]
+        else:
+            gpo.po_message_set_prev_msgid(self._gpo_message, gpo_encode(source))  # ty:ignore[unresolved-attribute]
+            gpo.po_message_set_prev_msgid_plural(self._gpo_message, None)  # ty:ignore[unresolved-attribute]
+
+    @property
+    def prev_context(self):
+        return gpo_decode(gpo.po_message_prev_msgctxt(self._gpo_message)) or ""  # ty:ignore[unresolved-attribute]
+
+    @prev_context.setter
+    def prev_context(self, context) -> None:
+        gpo.po_message_set_prev_msgctxt(  # ty:ignore[unresolved-attribute]
+            self._gpo_message, gpo_encode(context) if context else None
+        )
+
+    @property
     def target(self):
         if self.hasplural():
             plurals = []
@@ -636,8 +674,10 @@ class pounit(pocommon.pounit):
                 self.source != otherpo.source
                 or self.getcontext() != otherpo.getcontext()
             ):
+                self.set_as_previous(otherpo)
                 self.markfuzzy()
             else:
+                self.copy_previous(otherpo)
                 self.markfuzzy(otherpo.isfuzzy())
         elif not otherpo.istranslated():
             if self.source != otherpo.source:
@@ -739,6 +779,13 @@ class pounit(pocommon.pounit):
             return gpo_decode(msgctxt)
         return self._extract_msgidcomments()
 
+    def getpreviouscontext(self):
+        """Get the real msgctxt without KDE-style msgidcomments."""
+        msgctxt = gpo.po_message_msgctxt(self._gpo_message)  # ty:ignore[unresolved-attribute]
+        if msgctxt:
+            return gpo_decode(msgctxt)
+        return ""
+
     def setcontext(self, context) -> None:
         gpo.po_message_set_msgctxt(self._gpo_message, gpo_encode(context))  # ty:ignore[unresolved-attribute]
 
@@ -758,6 +805,7 @@ class pounit(pocommon.pounit):
             context = unit.getcontext()
             if not newunit.msgidcomment and context:
                 newunit.setcontext(context)
+            newunit.copy_previous(unit)
 
             locations = unit.getlocations()
             if locations:

--- a/translate/storage/fpo.py
+++ b/translate/storage/fpo.py
@@ -249,8 +249,10 @@ class pounit(pocommon.pounit):
                 self.source != otherpo.source
                 or self.getcontext() != otherpo.getcontext()
             ):
+                self.set_as_previous(otherpo)
                 self.markfuzzy()
             else:
+                self.copy_previous(otherpo)
                 self.markfuzzy(otherpo.isfuzzy())
         elif not otherpo.istranslated():
             if self.source != otherpo.source:
@@ -363,6 +365,10 @@ class pounit(pocommon.pounit):
         """Get the message context."""
         return self._msgctxt + self.msgidcomment
 
+    def getpreviouscontext(self):
+        """Get the real msgctxt without KDE-style msgidcomments."""
+        return self._msgctxt
+
     def setcontext(self, context) -> None:
         self._msgctxt = context or ""
 
@@ -396,6 +402,7 @@ class pounit(pocommon.pounit):
             newunit.msgidcomment = unit._extract_msgidcomments()
             if not newunit.msgidcomment:
                 newunit.setcontext(unit.getcontext())
+            newunit.copy_previous(unit)
 
             locations = unit.getlocations()
             if locations:

--- a/translate/storage/poxliff.py
+++ b/translate/storage/poxliff.py
@@ -45,6 +45,7 @@ class PoXliffUnit(xliff.xliffunit):
     """A class to specifically handle the plural units created from a po file."""
 
     rich_parsers = general.parsers
+    XML_LANG = "{http://www.w3.org/XML/1998/namespace}lang"
 
     def __init__(self, source=None, empty=False, **kwargs) -> None:
         self._rich_source = None
@@ -204,6 +205,85 @@ class PoXliffUnit(xliff.xliffunit):
 
         for i, unit in enumerate(self.units):
             unit.target = targets[i]
+
+    def getalttrans(self, origin=None):
+        if not self.hasplural():
+            return super().getalttrans(origin=origin)
+
+        child_alternatives = [unit.getalttrans(origin=origin) for unit in self.units]
+        if not child_alternatives:
+            return []
+
+        alternatives = []
+        used_alternatives = [set() for _ in child_alternatives]
+        for key in self._aggregate_alttrans_keys(child_alternatives):
+            plural_alternatives = []
+            for child_index, child_units in enumerate(child_alternatives):
+                for unit_index, unit in enumerate(child_units):
+                    if self._alttrans_key(unit) == key:
+                        used_alternatives[child_index].add(unit_index)
+                        plural_alternatives.append(unit)
+                        break
+            contexts = {unit.getcontext() for unit in plural_alternatives}
+            alternative = base.TranslationUnit(
+                multistring([unit.source for unit in plural_alternatives])
+            )
+            alternative.target = multistring(
+                [unit.target for unit in plural_alternatives]
+            )
+            if contexts:
+                alternative.setcontext(contexts.pop())
+            alternative._xliff_alttrans_units = plural_alternatives  # ty:ignore[unresolved-attribute]
+            alternatives.append(alternative)
+        for child_index, child_units in enumerate(child_alternatives):
+            alternatives.extend(
+                unit
+                for unit_index, unit in enumerate(child_units)
+                if unit_index not in used_alternatives[child_index]
+            )
+        return alternatives
+
+    def _aggregate_alttrans_keys(self, child_alternatives):
+        """Return unambiguous alt-trans keys present in every plural child."""
+        if not child_alternatives:
+            return []
+
+        ordered_keys = []
+        for alternative in child_alternatives[0]:
+            key = self._alttrans_key(alternative)
+            if key not in ordered_keys:
+                ordered_keys.append(key)
+
+        return [
+            key
+            for key in ordered_keys
+            if all(
+                sum(
+                    1
+                    for alternative in alternatives
+                    if self._alttrans_key(alternative) == key
+                )
+                == 1
+                for alternatives in child_alternatives
+            )
+        ]
+
+    def _alttrans_key(self, alternative):
+        node = alternative.xmlelement
+        return (
+            node.get("origin"),
+            node.get("match-quality"),
+            node.get(self.XML_LANG),
+            alternative.getcontext(),
+        )
+
+    def delalttrans(self, alternative) -> None:
+        """Remove an alternate translation, including aggregated plural handles."""
+        for alt in getattr(alternative, "_xliff_alttrans_units", [alternative]):
+            xmlelement = alt.xmlelement
+            parent = xmlelement.getparent()
+            if parent is not None:
+                parent.remove(xmlelement)
 
     def addnote(self, text, origin=None, position="append") -> None:
         """Add a note specifically in a "note" tag."""

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -318,7 +318,11 @@ class pounit(pocommon.pounit):
 
     def _get_prev_source(self):
         """Returns the unescaped msgid."""
-        return self._get_source_vars(self.prev_msgid, self.prev_msgid_plural)
+        singular = unquotefrompo(self.prev_msgid)
+        if self.prev_msgid_plural:
+            pluralform = unquotefrompo(self.prev_msgid_plural)
+            return multistring([singular, pluralform])
+        return singular
 
     def _set_prev_source(self, source) -> None:
         """
@@ -326,9 +330,22 @@ class pounit(pocommon.pounit):
 
         :param source: an unescaped source string.
         """
+        if source is None:
+            self.prev_msgid = []
+            self.prev_msgid_plural = []
+            return
         self.prev_msgid, self.prev_msgid_plural = self._set_source_vars(source)
 
     prev_source = property(_get_prev_source, _set_prev_source)
+
+    @property
+    def prev_context(self):
+        """Returns the unescaped previous msgctxt."""
+        return unquotefrompo(self.prev_msgctxt)
+
+    @prev_context.setter
+    def prev_context(self, context) -> None:
+        self.prev_msgctxt = self.quote(context) if context else []
 
     @property
     def target(self):
@@ -371,19 +388,14 @@ class pounit(pocommon.pounit):
         else:
             self.msgstr = self.quote(target)
 
-    def getalttrans(self):
+    def getalttrans(self, origin=None):
         """
         Return a list of alternate units.
 
         Previous msgid and current msgstr is combined to form a single
         alternative unit.
         """
-        prev_source = self.prev_source
-        if prev_source and self.isfuzzy():
-            unit = type(self)(prev_source)
-            unit.target = self.target
-            return [unit]
-        return []
+        return super().getalttrans(origin=origin)
 
     def getnotes(self, origin: str | None = None) -> str:
         """
@@ -552,8 +564,10 @@ class pounit(pocommon.pounit):
                 self.source != otherunit.source
                 or self.getcontext() != otherunit.getcontext()
             ):
+                self.set_as_previous(otherunit)
                 self.markfuzzy()
             else:
+                self.copy_previous(otherunit)
                 self.markfuzzy(otherunit.isfuzzy())
         elif not otherunit.istranslated():
             if self.source != otherunit.source:
@@ -836,6 +850,10 @@ class pounit(pocommon.pounit):
     def getcontext(self):
         """Get the message context."""
         return unquotefrompo(self.msgctxt) + self._extract_msgidcomments()
+
+    def getpreviouscontext(self):
+        """Get the real msgctxt without KDE-style msgidcomments."""
+        return unquotefrompo(self.msgctxt)
 
     def setcontext(self, context) -> None:
         self.msgctxt = self.quote(context)

--- a/translate/storage/xliff.py
+++ b/translate/storage/xliff.py
@@ -118,6 +118,7 @@ class Xliff1Unit(XliffUnit):
         lang: str | None = None,
         sourcetxt: str | None = None,
         matchquality: str | None = None,
+        context: str | None = None,
     ) -> None:
         """
         Adds an alt-trans tag and alt-trans components to the unit.
@@ -132,6 +133,13 @@ class Xliff1Unit(XliffUnit):
             altsource.text = sourcetxt
         alttarget = etree.SubElement(alttrans, self.namespaced("target"))
         alttarget.text = txt
+        if context:
+            contextgroup = etree.SubElement(alttrans, self.namespaced("context-group"))
+            contextgroup.set("name", "po-entry")
+            contextgroup.set("purpose", "information")
+            contextnode = etree.SubElement(contextgroup, self.namespaced("context"))
+            contextnode.set("context-type", "x-po-msgctxt")
+            safely_set_text(contextnode, context)
         if matchquality:
             alttrans.set("match-quality", matchquality)
         if origin:
@@ -165,6 +173,15 @@ class Xliff1Unit(XliffUnit):
                 )
                 # TODO: support multiple targets better
                 # TODO: support notes in alt-trans
+                for context in node.iterdescendants(self.namespaced("context")):
+                    if context.get("context-type") == "x-po-msgctxt":
+                        newunit.setcontext(
+                            lisa.getText(
+                                context,
+                                getXMLspace(node, self._default_xml_space),
+                            )
+                        )
+                        break
                 newunit.xmlelement = node  # ty:ignore[unresolved-attribute]
 
                 translist.append(newunit)


### PR DESCRIPTION
- Added a shared previous-message API on translation units.
- Fixed PyPO previous plural handling and previous context access.
- Updated PO merge paths so fuzzy reused translations write #| msgid / #| msgctxt, and existing previous metadata is preserved.
- Added CPO/FPO preservation for previous metadata.
- Updated po2xliff to convert PO previous messages into XLIFF alt-trans entries.
- Added regression coverage for pot2po, pomerge, pretranslate, PyPO parsing, and po2xliff.

Fixes #267