### PR TITLE
fix(yaml): limit yaml depth

### DIFF
--- a/tests/translate/storage/test_yaml.py
+++ b/tests/translate/storage/test_yaml.py
@@ -472,6 +472,15 @@ location_batch:
         with pytest.raises(base.ParseError):
             store.parse("key: other\x08string")
 
+    def test_deep_nesting(self) -> None:
+        content = "root:\n" + "\n".join(
+            f"{'  ' * (level + 1)}-" for level in range(512)
+        )
+        content = f"{content} value\n"
+
+        with pytest.raises(base.ParseError):
+            self.StoreClass().parse(content)
+
     def test_quotes_roundtrip(self) -> None:
         data = """locales:
   quoted: "Quoted"

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -21,6 +21,7 @@ r"""Class that manages YAML data files for translation."""
 from __future__ import annotations
 
 import uuid
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from ruamel.yaml import YAML, YAMLError
@@ -161,6 +162,9 @@ class YAMLFile(base.DictStore[YAMLUnit]):
     @property
     def yaml(self):
         yaml = YAML()
+        yaml_with_parser_options: Any = yaml
+        with suppress(AttributeError):
+            yaml_with_parser_options.max_depth = 128
         for arg, value in self.dump_args.items():
             setattr(yaml, arg, value)
         return yaml
@@ -292,6 +296,8 @@ class YAMLFile(base.DictStore[YAMLUnit]):
             input = input.decode("utf-8")
         try:
             self._original = self.yaml.load(input)
+        except RecursionError as e:
+            raise base.ParseError("YAML document nesting is too deep") from e
         except YAMLError as e:
             message = getattr(e, "problem", getattr(e, "message", str(e)))
             if hasattr(e, "problem_mark"):


### PR DESCRIPTION
This avoids crashing on the Python intepreter limits while parsing.