### PR TITLE
fix(yaml): bump minimal ruamel.yaml dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ toml = [
   "tomlkit>=0.13.0,<0.15.0"
 ]
 yaml = [
-  "ruamel.yaml>=0.18.0,<0.20.0"
+  "ruamel.yaml>=0.19.1,<0.20.0"
 ]
 
 [project.readme]

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -21,7 +21,6 @@ r"""Class that manages YAML data files for translation."""
 from __future__ import annotations
 
 import uuid
-from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from ruamel.yaml import YAML, YAMLError
@@ -162,9 +161,7 @@ class YAMLFile(base.DictStore[YAMLUnit]):
     @property
     def yaml(self):
         yaml = YAML()
-        yaml_with_parser_options: Any = yaml
-        with suppress(AttributeError):
-            yaml_with_parser_options.max_depth = 128
+        yaml.max_depth = 128
         for arg, value in self.dump_args.items():
             setattr(yaml, arg, value)
         return yaml
@@ -296,8 +293,6 @@ class YAMLFile(base.DictStore[YAMLUnit]):
             input = input.decode("utf-8")
         try:
             self._original = self.yaml.load(input)
-        except RecursionError as e:
-            raise base.ParseError("YAML document nesting is too deep") from e
         except YAMLError as e:
             message = getattr(e, "problem", getattr(e, "message", str(e)))
             if hasattr(e, "problem_mark"):


### PR DESCRIPTION
This avoids special casing old library.