### PR TITLE
fix(ci): reduce permissions needed for actions

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -92,6 +92,7 @@ jobs:
     needs:
     - setup
     runs-on: ubuntu-24.04
+    environment: pypi
     permissions:
       # this permission is mandatory for trusted publishing
       id-token: write

--- a/.github/workflows/test-qemu.yml
+++ b/.github/workflows/test-qemu.yml
@@ -13,9 +13,6 @@ permissions:
 
 jobs:
   build_job:
-    permissions:
-      # Needed for Docker container caching
-      packages: write
     runs-on: ubuntu-24.04
     name: test (${{ matrix.arch }}, ${{ matrix.distro }})
 
@@ -43,9 +40,6 @@ jobs:
       with:
         arch: ${{ matrix.arch }}
         distro: ${{ matrix.distro }}
-
-          # Not required, but speeds up builds
-        githubToken: ${{ github.token }}
 
         dockerRunArgs: |
           --volume "/tmp/setup-uv-cache:/tmp/setup-uv-cache"


### PR DESCRIPTION
This removes caching from qemu, but avoids possible risk of poisioning CI via pull requests.