### PR TITLE
fix(placeables): safer regex for JavaMessageFormatPlaceable

### DIFF
--- a/tests/translate/storage/placeables/test_general.py
+++ b/tests/translate/storage/placeables/test_general.py
@@ -328,4 +328,58 @@ def test_python_placeable() -> None:
     assert result[1] == pfp(["%(number)Ld"])
 
 
-# TODO: JavaMessageFormatPlaceable, UrlPlaceable, XMLTagPlaceable
+def test_java_message_format_placeable() -> None:
+    jmfp = general.JavaMessageFormatPlaceable
+    result = jmfp.parse("{0}")
+    assert result
+    assert result[0] == jmfp(["{0}"])
+
+    result = jmfp.parse("{0,number}")
+    assert result
+    assert result[0] == jmfp(["{0,number}"])
+
+    result = jmfp.parse("{0,number,integer}")
+    assert result
+    assert result[0] == jmfp(["{0,number,integer}"])
+
+    result = jmfp.parse("{0,number,percent}")
+    assert result
+    assert result[0] == jmfp(["{0,number,percent}"])
+
+    result = jmfp.parse("{0,date,short}")
+    assert result
+    assert result[0] == jmfp(["{0,date,short}"])
+
+    result = jmfp.parse("{0,time,yyyy-MM-dd}")
+    assert result
+    assert result[0] == jmfp(["{0,time,yyyy-MM-dd}"])
+
+    result = jmfp.parse("{0,choice,0#none|1#one|1<{1}}")
+    assert result
+    assert result[0] == jmfp(["{0,choice,0#none|1#one|1<{1}}"])
+
+
+def test_java_message_format_placeable_with_surrounding_text() -> None:
+    jmfp = general.JavaMessageFormatPlaceable
+    result = jmfp.parse("Before {0} after {1,number,percent}.")
+    assert result
+    assert str(result[0]) == "Before "
+    assert result[1] == jmfp(["{0}"])
+    assert str(result[2]) == " after "
+    assert result[3] == jmfp(["{1,number,percent}"])
+    assert str(result[4]) == "."
+
+
+def test_java_message_format_placeable_rejects_invalid_placeholders() -> None:
+    jmfp = general.JavaMessageFormatPlaceable
+    assert jmfp.parse("{name}") is None
+    assert jmfp.parse("{0,unknown}") is None
+    assert jmfp.parse("{0,choice,") is None
+
+
+def test_java_message_format_placeable_malformed_choice_is_linear() -> None:
+    jmfp = general.JavaMessageFormatPlaceable
+    assert jmfp.parse("{0,choice," + ("x" * 1000)) is None
+
+
+# TODO: UrlPlaceable, XMLTagPlaceable

--- a/tests/translate/tools/test_podebug.py
+++ b/tests/translate/tools/test_podebug.py
@@ -265,6 +265,15 @@ msgstr[1] "%d articles"
             == f"{rewrite_func('This is a ')}%s{rewrite_func(' test, hooray.')}"
         )
 
+    def test_malformed_java_message_format_choice(self) -> None:
+        postore = po.pofile(
+            ('msgid "' + ("{0,choice,x{" * 100) + '"\nmsgstr ""\n').encode()
+        )
+        debug = podebug.podebug(rewritestyle="xxx")
+        po_out = debug.convertstore(postore)
+
+        assert po_out.units[0].target == f"xxx{postore.units[0].source}xxx"
+
     def test_xliff_rewrite(self) -> None:
         debug = podebug.podebug(rewritestyle="xxx")
         xliff_out = debug.convertstore(self.xliffstore)

--- a/translate/storage/placeables/general.py
+++ b/translate/storage/placeables/general.py
@@ -162,7 +162,7 @@ class JavaMessageFormatPlaceable(RegexParseMixin, Ph):
       (,\s*                  # FormatType (optional) one of number,date,time,choice
         (number(,\s*(integer|currency|percent|[-0#.,E;%\u2030\u00a4']+)?)?|  # number FormatStyle (optional)
          (date|time)(,\s*(short|medium|long|full|.+?))?|                  # date/time FormatStyle (optional)
-         choice,([^{]+({.+})?)+)?                                      # choice with format, format required
+         choice,(?>(?:[^{}]+|{[^{}]*})+))?                              # choice with format, format required
       )?                     # END: (optional) FormatType
       }                      # END: MessageFormat"""
     )


### PR DESCRIPTION
Make it less likely to backtrack.