### PR TITLE
fix(ci): generate phply parsetab before runnning tests

### DIFF
--- a/.github/workflows/test-qemu.yml
+++ b/.github/workflows/test-qemu.yml
@@ -54,6 +54,8 @@ jobs:
           export UV_CACHE_DIR=/tmp/setup-uv-cache
           uv sync --group test --all-extras --no-dev
           source .venv/bin/activate
+          # Generate phply parser tables before pytest-xdist starts workers.
+          python -m phply.phpparse --generate
           # Native test jobs collect coverage; QEMU jobs focus on architecture coverage.
           pytest -r EfsxX -n auto --maxprocesses=4 --dist=worksteal
           ./tests/cli/run_tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,8 @@ jobs:
       run: sed -i '/^ *"/ s/>=/==/' pyproject.toml
     - name: Install pip dependencies
       run: uv sync --all-extras --dev
+    - name: Generate phply parser tables
+      run: uv run python -m phply.phpparse --generate
     - name: pytest
       run: make test
     - name: test-functional


### PR DESCRIPTION
The generation is not concurrency safe and can corrupt generated file with pytest-xdist.