### PR TITLE
feat(tbx): honor languages in termEntry

### DIFF
--- a/docs/commands/tbx2po.rst
+++ b/docs/commands/tbx2po.rst
@@ -37,6 +37,10 @@ Options (tbx2po):
 -x EXCLUDE, --exclude=EXCLUDE    exclude names matching EXCLUDE from input paths
 -o OUTPUT, --output=OUTPUT   write to OUTPUT in tbx format
 -S, --timestamp      skip conversion if the output file has newer timestamp
+-l LANG, --language=LANG
+                      set target language code (e.g. af-ZA)
+--source-language=LANG
+                      set source language code
 
 
 .. _tbx2po#examples:
@@ -49,6 +53,10 @@ These examples demonstrate the use of tbx2po::
   tbx2po terms.tbx terms.po
 
 to simply convert *terms.tbx* to *terms.po*.
+
+To choose source and target languages from a multilingual TBX file::
+
+  tbx2po --source-language=en --language=es terms.tbx terms.po
 
 To convert a directory recursively to another directory with the same structure
 of files::

--- a/tests/translate/convert/test_tbx2po.py
+++ b/tests/translate/convert/test_tbx2po.py
@@ -1,0 +1,61 @@
+from translate.convert import tbx2po
+from translate.storage import po
+
+from . import test_convert
+
+
+class TestTBX2POCommand(test_convert.TestConvertCommand):
+    """Tests running actual tbx2po commands on files."""
+
+    convertmodule = tbx2po
+
+    expected_options = [
+        "-l LANG, --language=LANG",
+        "--source-language=LANG",
+    ]
+
+    @staticmethod
+    def multilingual_tbx() -> str:
+        return """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry id="testid">
+                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>
+                <langSet xml:lang="en"><tig><term>color</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term>color espanol</term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>
+"""
+
+    def test_language_options_select_terms(self) -> None:
+        self.create_testfile("terms.tbx", self.multilingual_tbx())
+        self.run_command("terms.tbx", "terms.po", source_language="en", language="es")
+
+        with self.open_testfile("terms.po") as handle:
+            store = po.pofile(handle)
+        unit = store.findunit("color")
+
+        assert unit is not None
+        assert unit.target == "color espanol"
+
+    def test_without_language_options_uses_langset_order(self) -> None:
+        self.create_testfile("terms.tbx", self.multilingual_tbx())
+        self.run_command("terms.tbx", "terms.po")
+
+        with self.open_testfile("terms.po") as handle:
+            store = po.pofile(handle)
+        unit = store.findunit("Farbe")
+
+        assert unit is not None
+        assert unit.target == "color"

--- a/tests/translate/storage/test_tbx.py
+++ b/tests/translate/storage/test_tbx.py
@@ -1,3 +1,6 @@
+from io import BytesIO
+
+from translate.misc.xml_helpers import getXMLlang
 from translate.storage import tbx
 
 from . import test_base
@@ -9,6 +12,28 @@ class TestTBXUnit(test_base.TestTranslationUnit):
 
 class TestTBXfile(test_base.TestTranslationStore):
     StoreClass = tbx.tbxfile
+
+    @staticmethod
+    def language_selection_tbx(langsets: str) -> str:
+        return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry id="testid">
+{langsets}
+            </termEntry>
+        </body>
+    </text>
+</martif>
+"""
 
     def test_basic(self) -> None:
         tbxfile = tbx.tbxfile()
@@ -73,6 +98,18 @@ class TestTBXfile(test_base.TestTranslationStore):
 </martif>
 """
         )
+
+    def test_new_units_use_configured_languages(self) -> None:
+        tbxfile = tbx.tbxfile(sourcelanguage="de", targetlanguage="fr")
+        tbxunit = tbxfile.addsourceunit("Farbe")
+
+        tbxunit.target = "couleur"
+
+        assert [getXMLlang(node) for node in tbxunit.getlanguageNodes()] == [
+            "de",
+            "fr",
+        ]
+        assert tbxunit.gettarget("fr") == "couleur"
 
     def test_descrip(self) -> None:
         tbxdata = """<?xml version="1.0" encoding="UTF-8"?>
@@ -203,3 +240,175 @@ class TestTBXfile(test_base.TestTranslationStore):
         assert unit.source == "SYS_ERR_406"
         assert not unit.isobsolete()
         assert not unit.istranslatable()
+
+    def test_multilingual_target_language_selection(self) -> None:
+        tbxdata = self.language_selection_tbx(
+            """                <langSet xml:lang="en"><tig><term>color</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term>color espanol</term></tig></langSet>"""
+        )
+
+        tbxfile = tbx.tbxfile.parsestring(
+            tbxdata, sourcelanguage="en", targetlanguage="es"
+        )
+        unit = tbxfile.units[0]
+
+        assert unit.source == "color"
+        assert unit.target == "color espanol"
+        assert unit.gettarget("de") == "Farbe"
+
+    def test_bilingual_target_language_mismatch_is_tolerated(self) -> None:
+        tbxdata = self.language_selection_tbx(
+            """                <langSet xml:lang="en"><tig><term>color</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>"""
+        )
+
+        tbxfile = tbx.tbxfile.parsestring(
+            tbxdata, sourcelanguage="en", targetlanguage="es"
+        )
+        assert tbxfile.units[0].target == "Farbe"
+
+        tbxfile = tbx.tbxfile.parsestring(tbxdata, sourcelanguage="en")
+        assert tbxfile.units[0].target == "Farbe"
+
+        tbxdata = self.language_selection_tbx(
+            """                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>
+                <langSet xml:lang="en"><tig><term>color</term></tig></langSet>"""
+        )
+        tbxfile = tbx.tbxfile.parsestring(
+            tbxdata, sourcelanguage="en", targetlanguage="es"
+        )
+        assert tbxfile.units[0].source == "color"
+        assert tbxfile.units[0].target == "Farbe"
+
+    def test_parsed_input_without_languages_uses_langset_order(self) -> None:
+        tbxdata = self.language_selection_tbx(
+            """                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>
+                <langSet xml:lang="en"><tig><term>color</term></tig></langSet>"""
+        )
+
+        tbxfile = tbx.tbxfile(BytesIO(tbxdata.encode()))
+        unit = tbxfile.units[0]
+
+        assert tbxfile.sourcelanguage is None
+        assert tbxfile.targetlanguage is None
+        assert unit.source == "Farbe"
+        assert unit.target == "color"
+
+        tbxfile = tbx.tbxfile.parsestring(tbxdata)
+        unit = tbxfile.units[0]
+
+        assert tbxfile.sourcelanguage is None
+        assert tbxfile.targetlanguage is None
+        assert unit.source == "Farbe"
+        assert unit.target == "color"
+
+    def test_parsed_input_with_language_uses_configured_source(self) -> None:
+        tbxdata = self.language_selection_tbx(
+            """                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>
+                <langSet xml:lang="en"><tig><term>color</term></tig></langSet>"""
+        )
+
+        tbxfile = tbx.tbxfile(BytesIO(tbxdata.encode()), sourcelanguage="en")
+        unit = tbxfile.units[0]
+
+        assert unit.source == "color"
+        assert unit.target == "Farbe"
+
+    def test_bilingual_target_clear_preserves_selected_source(self) -> None:
+        tbxdata = self.language_selection_tbx(
+            """                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>
+                <langSet xml:lang="en"><tig><term>color</term></tig></langSet>"""
+        )
+
+        tbxfile = tbx.tbxfile.parsestring(tbxdata, sourcelanguage="en")
+        unit = tbxfile.units[0]
+
+        assert unit.source == "color"
+        assert unit.target == "Farbe"
+
+        unit.target = None
+        assert unit.source == "color"
+        assert unit.target is None
+
+    def test_messed_up_language_data_is_best_effort(self) -> None:
+        tbxdata = self.language_selection_tbx(
+            """                <langSet><tig><term>color</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term>color espanol</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>"""
+        )
+
+        tbxfile = tbx.tbxfile.parsestring(
+            tbxdata, sourcelanguage="en", targetlanguage="es"
+        )
+        unit = tbxfile.units[0]
+
+        assert unit.source == "color"
+        assert unit.target == "color espanol"
+
+    def test_multilingual_missing_target_does_not_use_source_as_target(self) -> None:
+        tbxdata = self.language_selection_tbx(
+            """                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>
+                <langSet xml:lang="en"><tig><term>color</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term>color espanol</term></tig></langSet>"""
+        )
+
+        tbxfile = tbx.tbxfile.parsestring(
+            tbxdata, sourcelanguage="en", targetlanguage="fr"
+        )
+        unit = tbxfile.units[0]
+
+        assert unit.source == "color"
+        assert unit.target == "Farbe"
+
+    def test_multilingual_target_language_selection_without_source_match(self) -> None:
+        tbxdata = self.language_selection_tbx(
+            """                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term>color espanol</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>couleur</term></tig></langSet>"""
+        )
+
+        tbxfile = tbx.tbxfile.parsestring(
+            tbxdata, sourcelanguage="en", targetlanguage="fr"
+        )
+        unit = tbxfile.units[0]
+
+        assert unit.source == "Farbe"
+        assert unit.target == "couleur"
+
+        unit.source = "color"
+        assert unit.source == "color"
+        assert unit.target == "couleur"
+
+    def test_bilingual_source_setter_preserves_fallback_target(self) -> None:
+        tbxdata = self.language_selection_tbx(
+            """                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>
+                <langSet xml:lang="en-US"><tig><term>color</term></tig></langSet>"""
+        )
+
+        tbxfile = tbx.tbxfile.parsestring(
+            tbxdata, sourcelanguage="en", targetlanguage="de"
+        )
+        unit = tbxfile.units[0]
+
+        assert unit.source == "color"
+        assert unit.target == "Farbe"
+
+        unit.source = "colour"
+        assert unit.source == "colour"
+        assert unit.target == "Farbe"
+
+    def test_multilingual_first_target_language_without_source_match(self) -> None:
+        tbxdata = self.language_selection_tbx(
+            """                <langSet xml:lang="fr"><tig><term>couleur</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term>color espanol</term></tig></langSet>"""
+        )
+
+        tbxfile = tbx.tbxfile.parsestring(
+            tbxdata, sourcelanguage="en", targetlanguage="fr"
+        )
+        unit = tbxfile.units[0]
+
+        assert unit.source == "Farbe"
+        assert unit.target == "couleur"

--- a/translate/convert/tbx2po.py
+++ b/translate/convert/tbx2po.py
@@ -51,13 +51,21 @@ class tbx2po:
 
 
 def converttbx(
-    inputfile, outputfile, templatefile, charset=None, columnorder=None
+    inputfile,
+    outputfile,
+    templatefile,
+    charset=None,
+    columnorder=None,
+    sourcelanguage=None,
+    targetlanguage=None,
 ) -> int:
     """
     Reads in inputfile using tbx, converts using tbx2po, writes to
     outputfile.
     """
-    inputstore = tbx.tbxfile(inputfile)
+    inputstore = tbx.tbxfile(
+        inputfile, sourcelanguage=sourcelanguage, targetlanguage=targetlanguage
+    )
     convertor = tbx2po()
     outputstore = convertor.convertfile(inputstore)
     if len(outputstore.units) == 0:
@@ -66,14 +74,32 @@ def converttbx(
     return 1
 
 
-def main() -> None:
+def main(argv=None) -> None:
     formats = {
         ("tbx", None): ("po", converttbx),
     }
     parser = convert.ConvertOptionParser(
         formats, usetemplates=False, description=__doc__
     )
-    parser.run()
+    parser.add_option(
+        "-l",
+        "--language",
+        dest="targetlanguage",
+        default=None,
+        help="set target language code (e.g. af-ZA)",
+        metavar="LANG",
+    )
+    parser.add_option(
+        "",
+        "--source-language",
+        dest="sourcelanguage",
+        default=None,
+        help="set source language code",
+        metavar="LANG",
+    )
+    parser.passthrough.append("sourcelanguage")
+    parser.passthrough.append("targetlanguage")
+    parser.run(argv)
 
 
 if __name__ == "__main__":

--- a/translate/storage/tbx.py
+++ b/translate/storage/tbx.py
@@ -18,14 +18,23 @@
 
 """module for handling TBX glossary files."""
 
+from io import BytesIO
+
 from lxml import etree
 
 from translate.misc.xml_helpers import (
+    getXMLlang,
     getXMLspace,
     safely_set_text,
     setXMLlang,
 )
 from translate.storage import lisa
+
+
+def _normalize_language(language: str | None) -> str | None:
+    if not language:
+        return None
+    return language.replace("_", "-").lower()
 
 
 class tbxunit(lisa.LISAunit):
@@ -37,6 +46,136 @@ class tbxunit(lisa.LISAunit):
     rootNode = "termEntry"
     languageNode = "langSet"
     textNode = "term"
+
+    def _store_language(self, name: str) -> str | None:
+        store = getattr(self, "_store", None)
+        if store is None:
+            return None
+        return getattr(store, name, None)
+
+    def _store_language_or_default(self, name: str, default: str) -> str:
+        return self._store_language(name) or default
+
+    def _get_language_node(self, language: str | None):
+        language = _normalize_language(language)
+        if language is None:
+            return None
+        for node in self.getlanguageNodes():
+            if _normalize_language(getXMLlang(node)) == language:
+                return node
+        return None
+
+    def _get_source_language_node(self):
+        return self._get_language_node(self._store_language("sourcelanguage"))
+
+    def _get_target_language_node(self):
+        return self._get_language_node(self._store_language("targetlanguage"))
+
+    def _get_fallback_source_node(self):
+        language_nodes = self.getlanguageNodes()
+        target_node = self._get_target_language_node()
+        for node in language_nodes:
+            if node is not target_node:
+                return node
+        return self.getlanguageNode(lang=None, index=0)
+
+    def _get_fallback_target_node(self, language_nodes, source_node=None):
+        if len(language_nodes) < 2:
+            return None
+        target_node = self.getlanguageNode(lang=None, index=1)
+        if target_node is not None and target_node is not source_node:
+            return target_node
+        for node in language_nodes:
+            if node is not source_node:
+                return node
+        return None
+
+    def get_source_dom(self):
+        source_node = self._get_source_language_node()
+        if source_node is not None:
+            return source_node
+        return self._get_fallback_source_node()
+
+    def set_source_dom(self, dom_node) -> None:
+        source_node = self.get_source_dom()
+        if source_node is not None:
+            self.xmlelement.replace(source_node, dom_node)
+        else:
+            self.xmlelement.append(dom_node)
+
+    source_dom = property(get_source_dom, set_source_dom)
+
+    @property
+    def source(self):
+        return self.getNodeText(
+            self.source_dom, getXMLspace(self.xmlelement, self._default_xml_space)
+        )
+
+    @source.setter
+    def source(self, source) -> None:
+        self.setsource(source)
+
+    def setsource(self, text, sourcelang=None) -> None:
+        super().setsource(
+            text, sourcelang or self._store_language_or_default("sourcelanguage", "en")
+        )
+
+    def set_target_dom(self, dom_node, append=False) -> None:
+        language_nodes = self.getlanguageNodes()
+        target_node = self.get_target_dom()
+        if dom_node is None:
+            if not append and target_node is not None:
+                self.xmlelement.remove(target_node)
+            return
+
+        if append:
+            self.xmlelement.append(dom_node)
+        elif target_node is not None:
+            self.xmlelement.replace(target_node, dom_node)
+        elif not language_nodes:
+            self.xmlelement.append(dom_node)
+        else:
+            source_node = self.get_source_dom()
+            if source_node is None:
+                self.xmlelement.insert(1, dom_node)
+            else:
+                self.xmlelement.insert(self.xmlelement.index(source_node) + 1, dom_node)
+
+    def get_target_dom(self, lang=None):
+        if lang:
+            return self._get_language_node(lang)
+
+        language_nodes = self.getlanguageNodes()
+        if len(language_nodes) == 2:
+            source_node = self._get_source_language_node()
+            if source_node is not None:
+                return (
+                    language_nodes[1]
+                    if language_nodes[0] is source_node
+                    else language_nodes[0]
+                )
+            target_node = self._get_target_language_node()
+            if target_node is not None:
+                return target_node
+            return self._get_fallback_target_node(language_nodes)
+
+        if len(language_nodes) > 2:
+            source_node = self.get_source_dom()
+            target_node = self._get_target_language_node()
+            if target_node is not None and target_node is not source_node:
+                return target_node
+            return self._get_fallback_target_node(language_nodes, source_node)
+
+        return self._get_fallback_target_node(language_nodes)
+
+    target_dom = property(get_target_dom)
+
+    def settarget(self, target, lang=None, append=False) -> None:
+        super().settarget(
+            target,
+            lang or self._store_language_or_default("targetlanguage", "xx"),
+            append=append,
+        )
 
     def createlanguageNode(self, lang, text, purpose):  # ty:ignore[invalid-method-override]
         """Returns a langset xml Element setup with given parameters."""
@@ -188,6 +327,40 @@ class tbxfile(lisa.LISAfile[tbxunit]):
 <text><body></body></text>
 </martif>"""
     XMLindent = {"indent": "    ", "toplevel": False}
+
+    def __init__(
+        self, inputfile=None, sourcelanguage=None, targetlanguage=None, **kwargs
+    ) -> None:
+        if inputfile is None and sourcelanguage is None:
+            sourcelanguage = "en"
+        super().__init__(
+            inputfile,
+            sourcelanguage=sourcelanguage,
+            targetlanguage=targetlanguage,
+            **kwargs,
+        )
+        if inputfile is not None:
+            if sourcelanguage is not None:
+                self.setsourcelanguage(sourcelanguage)
+            if targetlanguage is not None:
+                self.settargetlanguage(targetlanguage)
+
+    @classmethod
+    def parsestring(cls, storestring, sourcelanguage=None, targetlanguage=None):
+        if isinstance(storestring, str):
+            storestring = storestring.encode(cls.default_encoding)
+        return cls(
+            BytesIO(storestring),
+            sourcelanguage=sourcelanguage,
+            targetlanguage=targetlanguage,
+        )
+
+    def addsourceunit(self, source):
+        unit = self.UnitClass(None)
+        unit._store = self
+        unit.source = source
+        self.addunit(unit)
+        return unit
 
     def addheader(self) -> None:
         """Initialise headers with TBX specific things."""


### PR DESCRIPTION
Attempt to honor language configred when parsing TBX, but allow mismatches for two lang files to keep compatiblity with inconsisten language files.

Partly addresses https://github.com/WeblateOrg/weblate/issues/850