### PR TITLE
fix(tests): remove ruamel.yaml version check

### DIFF
--- a/tests/translate/storage/test_yaml.py
+++ b/tests/translate/storage/test_yaml.py
@@ -1,5 +1,4 @@
 import pytest
-import ruamel.yaml
 
 from translate.misc.multistring import multistring
 from translate.storage import base, yaml
@@ -348,10 +347,6 @@ foo: "Hello \n World."
 """
         )
 
-    @pytest.mark.skipif(
-        ruamel.yaml.version_info < (0, 16, 6),  # ty:ignore[unsupported-operator]
-        reason="Empty keys serialization broken in ruamel.yaml<0.16.6",
-    )
     def test_empty_key(self) -> None:
         yaml_source = b"""'': Jedna
 foo:


### PR DESCRIPTION
We now require recent enough version for the recursion limits.