### PR TITLE
fix: make the plural tags generation more robust

### DIFF
--- a/tests/translate/storage/test_applestrings_xliff.py
+++ b/tests/translate/storage/test_applestrings_xliff.py
@@ -330,6 +330,30 @@ class TestAppleStringsXliffFile(test_xliff.TestXLIFFfile):
         assert "<source>One item</source>" in output
         assert "<source>%d items</source>" in output
 
+    def test_unknown_language_single_plural_uses_other(self):
+        """A single plural form for unknown CLDR data writes the other category."""
+        store = self.StoreClass()
+        store.settargetlanguage("tok")
+        _add_plural(store, "items:count", ["the only form"])
+
+        output = bytes(store).decode("utf-8")
+        assert 'id="items:count:dict/other:dict/:string"' in output
+        assert 'id="items:count:dict/one:dict/:string"' not in output
+        assert 'id="items:count:dict/zero:dict/:string"' not in output
+
+    def test_unknown_language_two_plurals_use_zero_and_other(self):
+        """Two plural forms for unknown CLDR data write zero and other."""
+        store = self.StoreClass()
+        store.settargetlanguage("tok")
+        _add_plural(store, "items:count", ["No items", "%d items"])
+
+        output = bytes(store).decode("utf-8")
+        assert 'id="items:count:dict/zero:dict/:string"' in output
+        assert 'id="items:count:dict/other:dict/:string"' in output
+        assert 'id="items:count:dict/one:dict/:string"' not in output
+        assert "<source>No items</source>" in output
+        assert "<source>%d items</source>" in output
+
     # ------------------------------------------------------------------
     # Conversion: singular → plural
     # ------------------------------------------------------------------

--- a/tests/translate/storage/test_base.py
+++ b/tests/translate/storage/test_base.py
@@ -78,6 +78,20 @@ class JsonTranslationStore(base.TranslationStore):
         self.targetlanguage = store_data.get("targetlanguage")
 
 
+def test_unknown_language_single_plural_tags_use_other() -> None:
+    store = base.TranslationStore()
+    store.settargetlanguage("tok")
+
+    assert store.get_plural_tags(multistring(["the only form"])) == ["other"]
+
+
+def test_known_language_single_plural_tags_keep_language_mapping() -> None:
+    store = base.TranslationStore()
+    store.settargetlanguage("en")
+
+    assert store.get_plural_tags(multistring(["one form"])) == ["one", "other"]
+
+
 class TestTranslationUnit:
     """
     Tests a TranslationUnit.

--- a/tests/translate/storage/test_jsonl10n.py
+++ b/tests/translate/storage/test_jsonl10n.py
@@ -1275,6 +1275,19 @@ class TestI18NextV4Store(test_monolingual.TestMonolingualStore):
 
         assert bytes(store).decode() == EXPECTED
 
+    def test_unknown_language_single_plural_uses_other(self) -> None:
+        expected = """{
+    "simple_other": "the only form"
+}
+"""
+        store = self.StoreClass()
+        store.settargetlanguage("tok")
+
+        unit = self.StoreClass.UnitClass(multistring(["the only form"]), "simple")
+        store.addunit(unit)
+
+        assert bytes(store).decode() == expected
+
     def test_ru(self) -> None:
         data = """{
 "bet_one": "еще +{{count}} ставка",
@@ -1323,6 +1336,17 @@ class TestGoI18NJsonFile(test_monolingual.TestMonolingualStore):
         store.units[0].target = multistring(["{{.count}} tag"])
 
         assert '"other": ""' in bytes(store).decode()
+
+    def test_unknown_language_single_plural_uses_other(self) -> None:
+        store = self.StoreClass()
+        store.settargetlanguage("tok")
+
+        unit = self.StoreClass.UnitClass(multistring(["{{.count}} tag"]), "tag")
+        store.addunit(unit)
+
+        output = bytes(store).decode()
+        assert '"other": "{{.count}} tag"' in output
+        assert '"one"' not in output
 
     def test_invalid(self) -> None:
         store = self.StoreClass()

--- a/tests/translate/storage/test_stringsdict.py
+++ b/tests/translate/storage/test_stringsdict.py
@@ -172,6 +172,42 @@ class TestStringsDictFile(test_monolingual.TestMonolingualStore):
         plist = plistlib.load(bytes_io)
         assert plist["item"]["p"]["zero"]
 
+    def test_unknown_language_single_plural_uses_other(self) -> None:
+        store = self.StoreClass()
+        store.settargetlanguage("tok")
+        store.addsourceunit("item")
+
+        unit = store.UnitClass("item:p")
+        unit.target = multistring(["the only form"])
+        store.addunit(unit)
+
+        bytes_io = BytesIO()
+        store.serialize(bytes_io)
+        bytes_io.seek(0)
+
+        plural = plistlib.load(bytes_io)["item"]["p"]
+        assert plural["other"] == "the only form"
+        assert "one" not in plural
+        assert "zero" not in plural
+
+    def test_unknown_language_two_plurals_use_zero_and_other(self) -> None:
+        store = self.StoreClass()
+        store.settargetlanguage("tok")
+        store.addsourceunit("item")
+
+        unit = store.UnitClass("item:p")
+        unit.target = multistring(["no items", "items"])
+        store.addunit(unit)
+
+        bytes_io = BytesIO()
+        store.serialize(bytes_io)
+        bytes_io.seek(0)
+
+        plural = plistlib.load(bytes_io)["item"]["p"]
+        assert plural["zero"] == "no items"
+        assert plural["other"] == "items"
+        assert "one" not in plural
+
     def test_add_unit(self) -> None:
         store = self.StoreClass()
 

--- a/tests/translate/storage/test_toml.py
+++ b/tests/translate/storage/test_toml.py
@@ -512,6 +512,19 @@ other = "You have {{ .Count }} messages"
         assert 'one = "Un mensaje"' in result
         assert 'other = "{{ .Count }} mensajes"' in result
 
+    def test_unknown_language_single_plural_uses_other(self) -> None:
+        """Test that unknown one-form plurals serialize as CLDR other."""
+        store = self.StoreClass()
+        store.settargetlanguage("tok")
+
+        unit = self.StoreClass.UnitClass(multistring(["You have messages"]))
+        unit.setid("messages")
+        store.addunit(unit)
+
+        result = bytes(store).decode("utf-8")
+        assert '[messages]\nother = "You have messages"' in result
+        assert "one =" not in result
+
     def test_mixed_content(self) -> None:
         """Test file with both regular and pluralized entries."""
         data = """title = "My Application"

--- a/translate/lang/data.py
+++ b/translate/lang/data.py
@@ -878,6 +878,20 @@ plural_tags = {
     "zul": ["one", "other"],
 }
 
+
+def get_cldr_plural_tags(
+    locale: str | None, plural_count: int | None = None
+) -> list[str]:
+    """Return CLDR plural tags for locale, with a count-aware fallback."""
+    if locale:
+        tags = plural_tags.get(locale)
+        if tags is not None:
+            return tags
+    if plural_count == 1:
+        return ["other"]
+    return plural_tags["en"]
+
+
 # CLDR plurals with additional decimal tags
 DECIMAL_EXTRA_TAGS = {
     "be": ["other"],

--- a/translate/storage/applestrings_xliff.py
+++ b/translate/storage/applestrings_xliff.py
@@ -55,8 +55,7 @@ class AppleStringsXliffUnit(xliff.Xliff1Unit):
     Regular (non-plural) units behave identically to :class:`xliff.Xliff1Unit`.
 
     Plural units expose their source/target as :class:`~translate.misc.multistring.multistring`
-    objects whose strings list corresponds to the target language's plural forms
-    (always including "zero" as the first entry, per Apple convention).
+    objects whose strings list corresponds to the target language's plural forms.
     """
 
     format_value_type: str = ""
@@ -272,21 +271,35 @@ class AppleStringsXliffFile(xliff.Xliff1File):
 
         return target_lang
 
-    @property
-    def target_plural_tags(self) -> list[str]:
+    def _get_target_plural_tags(self, target=None) -> list[str]:
         """
         Return the plural tags for the target language.
 
-        "zero" is always included first (Apple convention).
+        "zero" is included first when there is room for optional forms.
         """
         target_lang = self.gettargetlanguage()
         if target_lang is None:
             return list(data.cldr_plural_categories)
 
-        tags = self.get_plural_tags().copy()
-        if "zero" not in tags:
+        tags = self.get_plural_tags(target).copy()
+        count = (
+            len(self.UnitClass.get_plural_strings(target))
+            if target is not None
+            else None
+        )
+        if (
+            count == 2
+            and data.plural_tags.get(self.get_base_locale_code()) is None
+            and "zero" not in tags
+        ):
+            return ["zero", "other"]
+        if "zero" not in tags and count != 1:
             tags.insert(0, "zero")
         return tags
+
+    @property
+    def target_plural_tags(self) -> list[str]:
+        return self._get_target_plural_tags()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -489,7 +502,7 @@ class AppleStringsXliffFile(xliff.Xliff1File):
         body.insert(marker_pos + 1, format_el)
 
         # --- Insert new form elements ---
-        plural_tags = self.target_plural_tags
+        plural_tags = self._get_target_plural_tags(unit._plural_target)
         source_strs = unit._plural_source.strings if unit._plural_source else []
         target_strs = unit._plural_target.strings if unit._plural_target else []
 

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -822,12 +822,11 @@ class AndroidResourceUnit(base.TranslationUnit):
                 else target_markup_mode
             )
 
-            plural_tags = self._store.get_plural_tags()  # ty:ignore[unresolved-attribute]
-
             # Sync plural_strings elements to plural_tags count.
             plural_target: str | multistring | list[str] = (
                 "" if target is None else target
             )
+            plural_tags = self._store.get_plural_tags(plural_target)  # ty:ignore[unresolved-attribute]
             plural_strings = self.sync_plural_count(plural_target, plural_tags)
 
             # Rebuild plurals.

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -39,7 +39,7 @@ from typing import (
     TypeVar,
 )
 
-from translate.lang.data import plural_tags
+from translate.lang.data import get_cldr_plural_tags
 from translate.misc.multistring import multistring
 from translate.storage.placeables import StringElem
 from translate.storage.placeables import parse as rich_parse
@@ -736,18 +736,21 @@ class TranslationUnit:
         """
 
     @staticmethod
+    def get_plural_strings(target: list[str] | str | multistring) -> list[str]:
+        """Get plural strings from target."""
+        if isinstance(target, multistring):
+            # Coerce all items to string, they might be multistrings
+            return [str(string) for string in target.strings]
+        if isinstance(target, list):
+            return [str(string) for string in target]
+        return [target]
+
+    @staticmethod
     def sync_plural_count(
         target: list[str] | str | multistring, plural_tags: list[str]
     ) -> list[str]:
         """Ensure that plural count in string matches tags definition."""
-        # Get string list to handle, wrapping non multistring/list targets into a list.
-        if isinstance(target, multistring):
-            # Coerce all items to string, they might be multistrings
-            plural_strings = [str(string) for string in target.strings]
-        elif isinstance(target, list):
-            plural_strings = target
-        else:
-            plural_strings = [target]
+        plural_strings = TranslationUnit.get_plural_strings(target)
 
         # Add missing strings
         missing = len(plural_tags) - len(plural_strings)
@@ -1271,9 +1274,14 @@ class TranslationStore(Generic[U]):
             locale.removeprefix("b+").replace("_", "-").replace("+", "-").split("-")[0]
         )
 
-    def get_plural_tags(self) -> list[str]:
+    def get_plural_tags(
+        self, target: list[str] | str | multistring | None = None
+    ) -> list[str]:
         locale = self.get_base_locale_code()
-        return plural_tags.get(locale, plural_tags["en"])
+        plural_count = None
+        if target is not None:
+            plural_count = len(self.UnitClass.get_plural_strings(target))
+        return get_cldr_plural_tags(locale, plural_count)
 
 
 class UnitId:

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -395,10 +395,10 @@ class I18NextUnit(JsonNestedUnit):
         if not isinstance(self.target, multistring):
             super().storevalues(output)
         else:
-            if len(self.target.strings) > len(self._store.get_plural_tags()):  # ty:ignore[unresolved-attribute]
+            plural_tags = self._store.get_plural_tags(self.target)  # ty:ignore[unresolved-attribute]
+            if len(self.target.strings) > len(plural_tags):
                 self.target.extra_strings = self.target.extra_strings[
-                    : len(self._store.get_plural_tags())  # ty:ignore[unresolved-attribute]
-                    - 1
+                    : len(plural_tags) - 1
                 ]
             self._fixup_item()
             for i, value in enumerate(self.target.strings):
@@ -486,7 +486,8 @@ class I18NextV4Unit(I18NextUnit):
 
     def _get_plural_labels(self, count):
         base_name = self._get_base_name()
-        return [f"{base_name}_{self._store.get_plural_tags()[i]}" for i in range(count)]  # ty:ignore[unresolved-attribute]
+        plural_tags = self._store.get_plural_tags(self.target)  # ty:ignore[unresolved-attribute]
+        return [f"{base_name}_{plural_tags[i]}" for i in range(count)]
 
 
 class I18NextV4File(JsonNestedFile):
@@ -609,7 +610,8 @@ class GoTextJsonUnit(BaseJsonUnit):
     def getvalue(self):
         target = self.target
         if isinstance(target, multistring):
-            strings = self.sync_plural_count(target, self._store.get_plural_tags())  # ty:ignore[unresolved-attribute]
+            plural_tags = self._store.get_plural_tags(target)  # ty:ignore[unresolved-attribute]
+            strings = self.sync_plural_count(target, plural_tags)
             target = {
                 "select": {
                     "feature": "plural",
@@ -619,7 +621,7 @@ class GoTextJsonUnit(BaseJsonUnit):
                 target["select"]["arg"] = self.placeholders[0]["id"]
             target["select"]["cases"] = {
                 plural: {"msg": strings[offset]}
-                for offset, plural in enumerate(self._store.get_plural_tags())  # ty:ignore[unresolved-attribute]
+                for offset, plural in enumerate(plural_tags)
             }  # ty:ignore[invalid-assignment]
         value = {"id": self._unitid.parts if self._unitid else self.getid()}
         if self.message:
@@ -721,10 +723,10 @@ class GoI18NJsonUnit(FlatJsonUnit):
     def getvalue(self):
         target = self.target
         if isinstance(target, multistring):
-            strings = self.sync_plural_count(target, self._store.get_plural_tags())  # ty:ignore[unresolved-attribute]
+            plural_tags = self._store.get_plural_tags(target)  # ty:ignore[unresolved-attribute]
+            strings = self.sync_plural_count(target, plural_tags)
             target = {
-                plural: strings[offset]
-                for offset, plural in enumerate(self._store.get_plural_tags())  # ty:ignore[unresolved-attribute]
+                plural: strings[offset] for offset, plural in enumerate(plural_tags)
             }
         value = {"id": self.getid()}
         if self.notes:
@@ -803,8 +805,9 @@ class GoI18NV2JsonUnit(FlatJsonUnit):
         if self.notes:
             target["description"] = self.notes
 
-        strings = self.sync_plural_count(self.target, self._store.get_plural_tags())  # ty:ignore[unresolved-attribute]
-        for offset, plural in enumerate(self._store.get_plural_tags()):  # ty:ignore[unresolved-attribute]
+        plural_tags = self._store.get_plural_tags(self.target)  # ty:ignore[unresolved-attribute]
+        strings = self.sync_plural_count(self.target, plural_tags)
+        for offset, plural in enumerate(plural_tags):
             target[plural] = strings[offset]
 
         return target

--- a/translate/storage/properties.py
+++ b/translate/storage/properties.py
@@ -695,7 +695,7 @@ class proppluralunit(base.TranslationUnit):
     def _get_language_mapping(lang):
         if lang:
             locale = lang.replace("_", "-").split("-")[0]
-            return data.plural_tags.get(locale, data.plural_tags["en"])
+            return data.get_cldr_plural_tags(locale)
         return None
 
     def _get_existing_mapping(self):
@@ -764,7 +764,7 @@ class proppluralunit(base.TranslationUnit):
         else:
             strings = [text]
         if mapping is None:
-            mapping = self._store.get_plural_tags()  # ty:ignore[unresolved-attribute]
+            mapping = self._store.get_plural_tags(text)  # ty:ignore[unresolved-attribute]
 
         strings = self._get_strings(strings, mapping)
         units = self._get_units(mapping)

--- a/translate/storage/stringsdict.py
+++ b/translate/storage/stringsdict.py
@@ -113,20 +113,34 @@ class StringsDictFile(base.DictStore):
 
         return target_lang
 
-    @property
-    def target_plural_tags(self):
+    def _get_target_plural_tags(self, target=None):
         """
         Get all supported plural tags for the target language.
-        Note that 'zero' is always supported.
+        Note that 'zero' is supported when there is room for optional forms.
         """
         target_lang = self.gettargetlanguage()
         if target_lang is None:
             return data.cldr_plural_categories
 
-        tags = self.get_plural_tags().copy()
-        if "zero" not in tags:
+        tags = self.get_plural_tags(target).copy()
+        count = (
+            len(self.UnitClass.get_plural_strings(target))
+            if target is not None
+            else None
+        )
+        if (
+            count == 2
+            and data.plural_tags.get(self.get_base_locale_code()) is None
+            and "zero" not in tags
+        ):
+            return ["zero", "other"]
+        if "zero" not in tags and count != 1:
             tags.insert(0, "zero")
         return tags
+
+    @property
+    def target_plural_tags(self):
+        return self._get_target_plural_tags()
 
     def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Read a .stringsdict file into a dictionary, and convert it to translation units."""
@@ -179,7 +193,7 @@ class StringsDictFile(base.DictStore):
                 plurals["NSStringFormatSpecTypeKey"] = "NSStringPluralRuleType"
                 plurals["NSStringFormatValueTypeKey"] = u.format_value_type
 
-                plural_tags = self.target_plural_tags
+                plural_tags = self._get_target_plural_tags(u.target)
 
                 # Sync plural_strings elements to plural_tags count.
                 plural_strings = self.UnitClass.sync_plural_count(u.target, plural_tags)

--- a/translate/storage/toml.py
+++ b/translate/storage/toml.py
@@ -281,7 +281,7 @@ class GoI18nTOMLUnit(TOMLUnit):
             # to preserve the table structure
             return {"other": self.target}
 
-        tags = self._store.get_plural_tags()  # ty:ignore[unresolved-attribute]
+        tags = self._store.get_plural_tags(self.target)  # ty:ignore[unresolved-attribute]
 
         # Sync plural_strings elements to plural_tags count.
         strings = self.sync_plural_count(self.target, tags)

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -320,7 +320,7 @@ class RubyYAMLUnit(YAMLUnit):
         if not isinstance(self.target, multistring):
             return self.target
 
-        tags = self._store.get_plural_tags()  # ty:ignore[unresolved-attribute]
+        tags = self._store.get_plural_tags(self.target)  # ty:ignore[unresolved-attribute]
 
         # Sync plural_strings elements to plural_tags count.
         strings = self.sync_plural_count(self.target, tags)


### PR DESCRIPTION
Better handle languages with unknown plural tags and having just a single plural by treating that as "other" rather than falling back to English and treating that as "one" and missing "other".

Fixes https://github.com/WeblateOrg/weblate/issues/19670