### PR TITLE
feat(markdown): add value-only YAML front matter translation mode

### DIFF
--- a/tests/translate/storage/test_markdown.py
+++ b/tests/translate/storage/test_markdown.py
@@ -1130,6 +1130,28 @@ class TestMarkdownFrontmatterTranslateValues(TestCase):
         assert "# a comment" in store.filesrc
         assert "title: (Hi)" in store.filesrc
 
+    def test_empty_front_matter_emits_no_unit(self) -> None:
+        # Empty front matter must not serialize a synthetic ``null`` document.
+        store = self.parse("---\n---\nBody\n")
+        assert self.sources(store) == ["Body"]
+        assert "null" not in store.filesrc
+        assert self.front_matter_of(store.filesrc) == "---\n---\n"
+
+    def test_comment_only_front_matter_preserved(self) -> None:
+        # Comment-only front matter has no scalar values: emit no unit, keep the
+        # comment, and do not serialize a synthetic ``null`` document.
+        store = self.parse("---\n# just a comment\n---\nBody\n")
+        assert self.sources(store) == ["Body"]
+        assert "null" not in store.filesrc
+        assert self.front_matter_of(store.filesrc) == "---\n# just a comment\n---\n"
+
+    def test_empty_string_value_preserved_without_unit(self) -> None:
+        # An empty scalar value is preserved verbatim but emits no unit.
+        store = self.parse("---\ntitle: ''\nname: Hi\n---\nBody\n")
+        assert self.sources(store) == ["Hi", "Body"]
+        assert "title: ''" in store.filesrc
+        assert "name: (Hi)" in store.filesrc
+
     def test_malformed_yaml_falls_back_to_blob(self) -> None:
         # An unterminated quote is invalid YAML; the whole block becomes one unit.
         store = self.parse('---\ntitle: "unterminated\nheading: x\n---\nBody\n')

--- a/tests/translate/storage/test_markdown.py
+++ b/tests/translate/storage/test_markdown.py
@@ -1229,6 +1229,18 @@ class TestMarkdownFrontmatterTranslateValues(TestCase):
         assert "  (one\n  two)\n" in out
         assert "strip: |-\n  (trimmed)\n" in out
 
+    def test_kept_block_scalar_trailing_blank_lines_preserved(self) -> None:
+        """A trailing ``|+`` keep block scalar round-trips its blank lines."""
+        front_matter = (
+            "---\ntitle: Hello\nnotes: |+\n  first line\n  second line\n\n\n---\n"
+        )
+        store = self.parse(front_matter + "\nBody\n", callback=lambda x: x)
+        out = self.front_matter_of(store.filesrc)
+        # No spurious document-end marker leaks in, and the kept blank lines
+        # survive byte-for-byte on an identity translation.
+        assert "..." not in out
+        assert out == front_matter
+
     def test_quoted_block_sequence_indentation_preserved(self) -> None:
         """Block sequence dashes keep their two-space source indentation."""
         store = self.parse(

--- a/tests/translate/storage/test_markdown.py
+++ b/tests/translate/storage/test_markdown.py
@@ -1033,3 +1033,184 @@ More text
     @staticmethod
     def get_translated_output(store):
         return store.filesrc
+
+
+class TestMarkdownFrontmatterTranslateValues(TestCase):
+    """Tests for the value-only front matter mode (frontmatter_translate_values=True)."""
+
+    # A realistic fixture resembling the pro6pp news front matter: literal block
+    # scalars, single-quoted scalars, a block sequence and a nested mapping.
+    REALISTIC_FRONT_MATTER = (
+        "---\n"
+        "metaTitle: |\n"
+        "  Discover the best deals\n"
+        "  in your neighborhood.\n"
+        "metaDescription: |\n"
+        "  Save money every day\n"
+        "  with local offers.\n"
+        "heading: 'Discover Amazing Deals'\n"
+        "date: '2024-07-25'\n"
+        "draft: false\n"
+        "order: 3\n"
+        "authors:\n"
+        "  - 'Kees'\n"
+        "  - 'Jan'\n"
+        "seo:\n"
+        "  description: 'Nested deals'\n"
+        "  keywords:\n"
+        "    - 'deals'\n"
+        "    - 'local'\n"
+        "---\n"
+    )
+
+    @staticmethod
+    def parse(md, callback=None, **kwargs):
+        inputfile = BytesIO(md.encode())
+        inputfile.name = "file.md"
+        return markdown.MarkdownFile(
+            inputfile=inputfile,
+            callback=callback or (lambda x: f"({x})"),
+            frontmatter_translate_values=True,
+            **kwargs,
+        )
+
+    @staticmethod
+    def sources(store):
+        return [tu.source for tu in store.units]
+
+    @staticmethod
+    def front_matter_of(text):
+        """Return the front matter block (fences included, body excluded)."""
+        return text.split("\n---\n", 1)[0] + "\n---\n"
+
+    def test_keys_preserved_values_translated(self) -> None:
+        store = self.parse(
+            "---\nmetaTitle: Welcome\npublisherName: ACME\n---\n\n# Heading\n"
+        )
+        # One unit per scalar value, plus the heading.
+        assert self.sources(store) == ["Welcome", "ACME", "Heading"]
+        # Keys are preserved; only the values are wrapped by the callback.
+        assert store.filesrc == (
+            "---\nmetaTitle: (Welcome)\npublisherName: (ACME)\n---\n\n# (Heading)\n"
+        )
+
+    def test_location_and_docpath_use_key_path(self) -> None:
+        store = self.parse("---\nmetaTitle: Welcome\n---\nBody\n")
+        unit = store.units[0]
+        assert unit.source == "Welcome"
+        assert unit.getlocations() == ["file.md:frontmatter.metaTitle"]
+        assert unit.getdocpath() == "frontmatter.metaTitle"
+
+    def test_non_string_scalars_not_translated(self) -> None:
+        store = self.parse("---\ntitle: Hi\ndraft: false\norder: 3\n---\nBody\n")
+        # bool and int values are left untouched.
+        assert self.sources(store) == ["Hi", "Body"]
+        assert "draft: false" in store.filesrc
+        assert "order: 3" in store.filesrc
+
+    def test_nested_map_and_list(self) -> None:
+        store = self.parse(
+            "---\nauthors:\n  - Alice\n  - Bob\nseo:\n  description: Deals\n---\nBody\n"
+        )
+        assert self.sources(store) == ["Alice", "Bob", "Deals", "Body"]
+        docpaths = [tu.getdocpath() for tu in store.units[:3]]
+        assert docpaths == [
+            "frontmatter.authors[0]",
+            "frontmatter.authors[1]",
+            "frontmatter.seo.description",
+        ]
+
+    def test_quoting_style_preserved(self) -> None:
+        store = self.parse("---\ndouble: \"Hello\"\nsingle: 'World'\n---\nBody\n")
+        assert 'double: "(Hello)"' in store.filesrc
+        assert "single: '(World)'" in store.filesrc
+
+    def test_comments_preserved(self) -> None:
+        store = self.parse("---\n# a comment\ntitle: Hi\n---\nBody\n")
+        assert "# a comment" in store.filesrc
+        assert "title: (Hi)" in store.filesrc
+
+    def test_malformed_yaml_falls_back_to_blob(self) -> None:
+        # An unterminated quote is invalid YAML; the whole block becomes one unit.
+        store = self.parse('---\ntitle: "unterminated\nheading: x\n---\nBody\n')
+        assert store.units[0].getdocpath() == "frontmatter[1]"
+        assert store.units[0].source.startswith("---\n")
+        assert self.sources(store)[1:] == ["Body"]
+
+    def test_no_frontmatter_is_noop(self) -> None:
+        store = self.parse("# Heading\nBody text.\n")
+        assert self.sources(store) == ["Heading", "Body text."]
+
+    def test_default_mode_keeps_blob_behavior(self) -> None:
+        # Without the flag the front matter is still a single opaque unit.
+        inputfile = BytesIO(b"---\ntitle: Example\n---\n\nBody\n")
+        store = markdown.MarkdownFile(inputfile=inputfile, callback=lambda x: f"({x})")
+        assert store.units[0].getdocpath() == "frontmatter[1]"
+        assert store.units[0].source == "---\ntitle: Example\n---\n\n"
+
+    def test_identity_round_trip_is_byte_identical(self) -> None:
+        """An identity translation reproduces the front matter byte-for-byte."""
+        store = self.parse(
+            self.REALISTIC_FRONT_MATTER + "\n# Body\n", callback=lambda x: x
+        )
+        assert self.front_matter_of(store.filesrc) == self.REALISTIC_FRONT_MATTER
+
+    def test_translation_changes_only_values(self) -> None:
+        """
+        Translating wraps every value but touches nothing else.
+
+        Verified by a reversible marker translation: wrapping each value in
+        sentinels and then stripping the sentinels from the serialized output
+        must reproduce the byte-identical identity round-trip. Any change to a
+        key, fence, quote, comment, block-scalar style or list indentation would
+        survive the strip and break the comparison.
+        """
+        open_marker, close_marker = "QQOPEN_", "_CLOSEQQ"
+        store = self.parse(
+            self.REALISTIC_FRONT_MATTER + "\n# Body\n",
+            callback=lambda x: f"{open_marker}{x}{close_marker}",
+        )
+        stripped = (
+            self.front_matter_of(store.filesrc)
+            .replace(open_marker, "")
+            .replace(close_marker, "")
+        )
+        assert stripped == self.REALISTIC_FRONT_MATTER
+
+    def test_block_scalar_is_single_translatable_unit(self) -> None:
+        """A literal block scalar is one unit with its newlines intact."""
+        store = self.parse(self.REALISTIC_FRONT_MATTER + "\n# Body\n")
+        meta_title = store.units[0]
+        assert meta_title.getdocpath() == "frontmatter.metaTitle"
+        assert meta_title.source == "Discover the best deals\nin your neighborhood."
+
+    def test_block_scalar_style_and_chomping_preserved(self) -> None:
+        """Literal/folded style and the clip/strip/keep indicator survive."""
+        front_matter = (
+            "---\n"
+            "clip: |\n"
+            "  one\n"
+            "  two\n"
+            "strip: |-\n"
+            "  trimmed\n"
+            "folded: >\n"
+            "  fold me\n"
+            "  please\n"
+            "---\n"
+        )
+        store = self.parse(front_matter + "\nBody\n")
+        out = self.front_matter_of(store.filesrc)
+        assert "clip: |\n" in out
+        assert "strip: |-\n" in out
+        assert "folded: >\n" in out
+        # The clip indicator survives a translation that wraps the value.
+        assert "  (one\n  two)\n" in out
+        assert "strip: |-\n  (trimmed)\n" in out
+
+    def test_quoted_block_sequence_indentation_preserved(self) -> None:
+        """Block sequence dashes keep their two-space source indentation."""
+        store = self.parse(
+            "---\nauthors:\n  - 'Kees'\n  - 'Jan'\n---\nBody\n", callback=lambda x: x
+        )
+        out = self.front_matter_of(store.filesrc)
+        assert out == "---\nauthors:\n  - 'Kees'\n  - 'Jan'\n---\n"

--- a/translate/storage/markdown.py
+++ b/translate/storage/markdown.py
@@ -100,7 +100,7 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
           for translation. If False, it is preserved as-is.
         :param frontmatter_translate_values: if True, front matter is parsed as
           YAML and one translation unit is emitted per scalar string value, using
-          the key path as the unit location/context (e.g. ``frontmatter.metaTitle``).
+          the key path as the unit location and docpath (e.g. ``frontmatter.metaTitle``).
           On serialization the YAML structure, keys, quoting style and comments are
           preserved and only the values are replaced by their translations. If
           False (default), ``extract_frontmatter`` governs front matter handling and
@@ -221,6 +221,9 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
           * If the body fails to parse as YAML, fall back to the opaque-blob
             behavior so a malformed file never raises here.
         """
+        # Imported lazily: ruamel.yaml is in the optional ``yaml`` extra, not
+        # ``markdown``, so a top-level import would break ``[markdown]``-only
+        # installs that never enable this flag.
         from ruamel.yaml import YAML, YAMLError  # noqa: PLC0415
 
         # In the source the last body line is followed by a newline before the
@@ -251,6 +254,14 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
             unit.setdocpath("frontmatter[1]")
             self.addunit(unit)
             return self.callback(front_matter)
+
+        if data is None:
+            # Empty or comment-only front matter: nothing to translate. Re-emit
+            # the original block verbatim so comments survive and we do not
+            # serialize a synthetic ``null`` document.
+            return "\n".join(
+                chain([open_fence], body_lines, [close_fence], trailing_lines, [""])
+            )
 
         self._walk_frontmatter(data, "frontmatter")
 
@@ -303,6 +314,12 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
             else:
                 content = str(value)
                 trailing_newlines = ""
+
+            if not content.strip():
+                # Empty or blank scalars are preserved verbatim and never emit a
+                # unit: an empty source would serialize as a spurious ``msgid ""``
+                # and a wrapping callback would corrupt the value.
+                return
 
             unit = self.addsourceunit(content)
             if self.filename:

--- a/translate/storage/markdown.py
+++ b/translate/storage/markdown.py
@@ -269,9 +269,17 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
         buffer = StringIO()
         yaml.dump(data, buffer)
         rendered_body = buffer.getvalue()
-        # ruamel terminates the dump with a trailing newline; the fence lines and
-        # any preserved trailing blank lines are added back explicitly.
-        rendered_body = rendered_body.rstrip("\n")
+        if rendered_body.endswith("\n...\n"):
+            # When the final value is a kept block scalar (``|+`` / ``>+``), ruamel
+            # appends an explicit document-end marker (``...``) so the scalar's
+            # trailing blank lines are not lost. Drop the marker and the single
+            # terminating newline only; the blank lines stay part of the body and
+            # the join below re-adds one newline before the close fence.
+            rendered_body = rendered_body[: -len("\n...\n")]
+        else:
+            # ruamel terminates the dump with a trailing newline; the fence lines
+            # and any preserved trailing blank lines are added back explicitly.
+            rendered_body = rendered_body.rstrip("\n")
         parts = [open_fence]
         if rendered_body:
             parts.append(rendered_body)

--- a/translate/storage/markdown.py
+++ b/translate/storage/markdown.py
@@ -224,6 +224,7 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
         # Imported lazily: ruamel.yaml is in the optional ``yaml`` extra, not
         # ``markdown``, so a top-level import would break ``[markdown]``-only
         # installs that never enable this flag.
+        # pylint: disable-next=import-outside-toplevel
         from ruamel.yaml import YAML, YAMLError  # noqa: PLC0415
 
         # In the source the last body line is followed by a newline before the
@@ -293,6 +294,7 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
 
     def _translate_frontmatter_child(self, container, key, path: str) -> None:
         """Translate or recurse into a single child of a map/list container."""
+        # pylint: disable-next=import-outside-toplevel
         from ruamel.yaml.scalarstring import (  # noqa: PLC0415
             FoldedScalarString,
             LiteralScalarString,

--- a/translate/storage/markdown.py
+++ b/translate/storage/markdown.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import re
 from contextlib import contextmanager
+from io import StringIO
 from itertools import chain
 from typing import TYPE_CHECKING
 
@@ -81,6 +82,7 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
         max_line_length=None,
         extract_code_blocks=True,
         extract_frontmatter=True,
+        frontmatter_translate_values=False,
         no_placeholders=False,
     ) -> None:
         """
@@ -96,6 +98,14 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
           for translation. If False, code blocks are left as-is.
         :param extract_frontmatter: if True (default), front matter is extracted
           for translation. If False, it is preserved as-is.
+        :param frontmatter_translate_values: if True, front matter is parsed as
+          YAML and one translation unit is emitted per scalar string value, using
+          the key path as the unit location/context (e.g. ``frontmatter.metaTitle``).
+          On serialization the YAML structure, keys, quoting style and comments are
+          preserved and only the values are replaced by their translations. If
+          False (default), ``extract_frontmatter`` governs front matter handling and
+          the whole block is treated as a single opaque unit. Requires the optional
+          ``ruamel.yaml`` dependency; takes precedence over ``extract_frontmatter``.
         :param no_placeholders: if True, inline elements (links, images, HTML
           spans, autolinks) are rendered verbatim in translation units instead
           of being replaced by {n} placeholder markers. Sub-attribute extraction
@@ -108,6 +118,7 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
         self.max_line_length = max_line_length
         self.extract_code_blocks = extract_code_blocks
         self.extract_frontmatter = extract_frontmatter
+        self.frontmatter_translate_values = frontmatter_translate_values
         self.no_placeholders = no_placeholders
         self.filesrc = ""
         if inputfile is not None:
@@ -133,13 +144,24 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
                 break
 
         if front_matter_end:
+            # front_matter_end indexes the closing fence line ("---" or "...").
+            close_fence_idx = front_matter_end
             # Include trailing space in the front matter
             if front_matter_end + 1 < len(lines) and (
                 not lines[front_matter_end + 1] or lines[front_matter_end + 1].isspace()
             ):
                 front_matter_end += 1
             front_matter = "\n".join(chain(lines[: front_matter_end + 1], [""]))
-            if self.extract_frontmatter:
+            if self.frontmatter_translate_values:
+                # Value-only mode: parse the YAML and emit one unit per scalar
+                # value, preserving keys/structure/quoting on serialization.
+                front_matter = self._translate_frontmatter_values(
+                    open_fence=lines[0],
+                    body_lines=lines[1:close_fence_idx],
+                    close_fence=lines[close_fence_idx],
+                    trailing_lines=lines[close_fence_idx + 1 : front_matter_end + 1],
+                )
+            elif self.extract_frontmatter:
                 # Keep front matter as a normal translation unit.
                 unit = self.UnitClass(front_matter)
                 if self.filename:
@@ -159,6 +181,159 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
         ) as renderer:
             document = block_token.Document(lines)
             self.filesrc = front_matter + renderer.render(document)
+
+    def _translate_frontmatter_values(
+        self,
+        open_fence: str,
+        body_lines: list[str],
+        close_fence: str,
+        trailing_lines: list[str],
+    ) -> str:
+        """
+        Parse the YAML front matter, emit one translation unit per scalar string
+        value, and re-serialize with keys/structure/quoting/comments preserved.
+
+        :param open_fence: the opening fence line (e.g. ``---``).
+        :param body_lines: the YAML body lines between the fences.
+        :param close_fence: the closing fence line (e.g. ``---`` or ``...``).
+        :param trailing_lines: blank lines that followed the closing fence and
+          were considered part of the front matter block.
+        :return: the rendered (translated) front matter, terminated by a newline,
+          ready to be prepended to the rendered document body.
+
+        Serialization is tuned so that only the translated values change and the
+        YAML formatting stays byte-stable on an identity translation:
+
+          * The block indentation is fixed at two-space mappings with a two-space
+            sequence offset (``yaml.indent(mapping=2, sequence=4, offset=2)``),
+            matching the front matter style of the target files, so block
+            sequences keep their source indentation (``  - item`` is not
+            flattened to ``- item``).
+          * Block scalars (``|`` / ``>``) keep their style, chomping indicator
+            and first-line comment: the trailing-newline pattern that drives
+            chomping is split off before translation and re-appended afterwards,
+            and the comment / fold positions are carried over to the re-wrapped
+            node. See ``_translate_frontmatter_child``.
+          * Only scalar *string* values are translated. Numbers, booleans, dates
+            and ``null`` are left untouched on purpose.
+          * Nested maps and lists are walked recursively; list items use a
+            ``[i]`` index segment in the location/docpath.
+          * If the body fails to parse as YAML, fall back to the opaque-blob
+            behavior so a malformed file never raises here.
+        """
+        from ruamel.yaml import YAML, YAMLError  # noqa: PLC0415
+
+        # In the source the last body line is followed by a newline before the
+        # closing fence, so terminate the body with one. Without it a trailing
+        # block scalar loses its final newline and its chomping indicator drifts
+        # (e.g. ``>`` would be emitted as ``>-``).
+        body = "\n".join(body_lines) + "\n"
+        yaml = YAML()
+        yaml.preserve_quotes = True
+        yaml.width = 2**31  # avoid reflowing/wrapping translated values
+        # Match the target front matter style: two-space mapping indentation with
+        # block-sequence dashes indented two spaces under their key. ruamel
+        # expresses this as a four-space sequence indent with a two-space offset
+        # for the dash, which keeps "  - item" intact instead of flattening it.
+        yaml.indent(mapping=2, sequence=4, offset=2)
+
+        try:
+            data = yaml.load(body) if body.strip() else None
+        except YAMLError:
+            # Malformed YAML: keep the original block as a single opaque unit so
+            # we never lose content or raise during parsing.
+            front_matter = "\n".join(
+                chain([open_fence], body_lines, [close_fence], trailing_lines, [""])
+            )
+            unit = self.UnitClass(front_matter)
+            if self.filename:
+                unit.addlocation(f"{self.filename}:1")
+            unit.setdocpath("frontmatter[1]")
+            self.addunit(unit)
+            return self.callback(front_matter)
+
+        self._walk_frontmatter(data, "frontmatter")
+
+        buffer = StringIO()
+        yaml.dump(data, buffer)
+        rendered_body = buffer.getvalue()
+        # ruamel terminates the dump with a trailing newline; the fence lines and
+        # any preserved trailing blank lines are added back explicitly.
+        rendered_body = rendered_body.rstrip("\n")
+        parts = [open_fence]
+        if rendered_body:
+            parts.append(rendered_body)
+        parts.extend([close_fence, *trailing_lines, ""])
+        return "\n".join(parts)
+
+    def _walk_frontmatter(self, node, path: str) -> None:
+        """
+        Recursively walk a parsed YAML node, translating scalar string values
+        in place. ``path`` is the dotted/indexed key path used as the unit
+        location and docpath (e.g. ``frontmatter.metaTitle`` or
+        ``frontmatter.authors[0]``).
+        """
+        if isinstance(node, dict):
+            for key in list(node.keys()):
+                self._translate_frontmatter_child(node, key, f"{path}.{key}")
+        elif isinstance(node, list):
+            for index in range(len(node)):
+                self._translate_frontmatter_child(node, index, f"{path}[{index}]")
+
+    def _translate_frontmatter_child(self, container, key, path: str) -> None:
+        """Translate or recurse into a single child of a map/list container."""
+        from ruamel.yaml.scalarstring import (  # noqa: PLC0415
+            FoldedScalarString,
+            LiteralScalarString,
+            ScalarString,
+        )
+
+        value = container[key]
+        if isinstance(value, (dict, list)):
+            self._walk_frontmatter(value, path)
+        elif isinstance(value, str):
+            # bool/int/float are not str, so only genuine strings are translated.
+            is_block = isinstance(value, (LiteralScalarString, FoldedScalarString))
+            if is_block:
+                # Block scalars (| and >): the trailing-newline run encodes the
+                # chomping indicator (none -> "-" strip, one -> clip, more ->
+                # "+" keep). Split it off so the unit holds only the content and
+                # the indicator survives an arbitrary translation unchanged.
+                content, trailing_newlines = self._split_trailing_newlines(str(value))
+            else:
+                content = str(value)
+                trailing_newlines = ""
+
+            unit = self.addsourceunit(content)
+            if self.filename:
+                unit.addlocation(f"{self.filename}:{path}")
+            else:
+                unit.addlocation(path)
+            unit.setdocpath(path)
+            translated = self.callback(content)
+
+            if is_block:
+                # Re-wrap in the same block subtype, restore the chomping via the
+                # trailing newlines, and carry over the first-line comment and
+                # (for folded scalars) the fold positions so an identity
+                # translation re-emits byte-for-byte.
+                new_value = type(value)(translated + trailing_newlines)
+                if hasattr(value, "comment"):
+                    new_value.comment = value.comment
+                if isinstance(value, FoldedScalarString) and hasattr(value, "fold_pos"):
+                    new_value.fold_pos = value.fold_pos
+                container[key] = new_value
+            elif isinstance(value, ScalarString):
+                # Preserve the original quoting style for flow scalars.
+                container[key] = type(value)(translated)
+            else:
+                container[key] = translated
+
+    @staticmethod
+    def _split_trailing_newlines(text: str) -> tuple[str, str]:
+        """Split ``text`` into its content and its trailing run of newlines."""
+        stripped = text.rstrip("\n")
+        return stripped, text[len(stripped) :]
 
     @staticmethod
     def _dummy_callback(text: str) -> str:

--- a/translate/storage/mdxfile.py
+++ b/translate/storage/mdxfile.py
@@ -54,6 +54,7 @@ class MDXFile(MarkdownFile):
         max_line_length=None,
         extract_code_blocks=True,
         extract_frontmatter=True,
+        frontmatter_translate_values=False,
         no_placeholders=False,
     ) -> None:
         """
@@ -72,6 +73,7 @@ class MDXFile(MarkdownFile):
             max_line_length=max_line_length,
             extract_code_blocks=extract_code_blocks,
             extract_frontmatter=extract_frontmatter,
+            frontmatter_translate_values=frontmatter_translate_values,
             no_placeholders=no_placeholders,
         )
 


### PR DESCRIPTION
https://github.com/translate/translate/pull/6282 implemented initial MDX support. It doesn't quite work for me without this PR yet.

Add an opt-in frontmatter_translate_values flag to MarkdownFile. When enabled, YAML front matter is parsed with ruamel.yaml (round-trip mode) and one translation unit is emitted per scalar string value, using the key path as the unit location/docpath (e.g. frontmatter.metaTitle, frontmatter.authors[0]). On serialization the keys, structure, quoting style and comments are preserved and only values are replaced by their translations. Malformed YAML falls back to the existing opaque-blob behavior.

The flag defaults to False, so the existing extract_frontmatter blob behavior is unchanged. ruamel.yaml is imported lazily so the markdown extra keeps working without it when the flag is off. The flag is also threaded through MDXFile.

First cut: block scalars, block-sequence indentation, and non-string scalars are handled per the documented TODOs.

Assisted-by: AI assistant