### PR TITLE
fix(csv): make escaping optional

### DIFF
--- a/tests/translate/convert/test_csv2po.py
+++ b/tests/translate/convert/test_csv2po.py
@@ -242,6 +242,7 @@ class TestCSV2POCommand(test_convert.TestConvertCommand, TestCSV2PO):
         "--charset=CHARSET",
         "--columnorder=COLUMNORDER",
         "--duplicates=DUPLICATESTYLE",
+        "--unescape-formulas",
     ]
 
     def test_columnorder(self) -> None:
@@ -267,3 +268,13 @@ msgstr ""
 msgstr "Target"
 """
         )
+
+    def test_unescape_formulas(self) -> None:
+        csvcontent = '"source","target"\n"\'=SUM(1,1)","\'@target"\n'
+        self.create_testfile("test.csv", csvcontent)
+
+        self.run_command("test.csv", "test.po", unescape_formulas=True)
+        content = self.open_testfile("test.po", "r").read()
+
+        assert 'msgid "=SUM(1,1)"\n' in content
+        assert 'msgstr "@target"\n' in content

--- a/tests/translate/convert/test_po2csv.py
+++ b/tests/translate/convert/test_po2csv.py
@@ -168,6 +168,8 @@ class TestPO2CSVCommand(test_convert.TestConvertCommand, TestPO2CSV):
 
     expected_options = [
         "--columnorder=COLUMNORDER",
+        "--escape-formulas",
+        "--no-escape-formulas",
     ]
 
     def test_columnorder(self) -> None:
@@ -202,5 +204,19 @@ class TestPO2CSVCommand(test_convert.TestConvertCommand, TestPO2CSV):
             content
             == """"context","source","target"
 "Context","Same","Target"
+"""
+        )
+
+    def test_no_escape_formulas(self) -> None:
+        pocontent = 'msgid "=SUM(1,1)"\nmsgstr "@target"\n'
+        self.create_testfile("test.po", pocontent)
+
+        self.run_command("test.po", "test.csv", no_escape_formulas=True)
+        content = self.open_testfile("test.csv", "r").read()
+
+        assert (
+            content
+            == """"location","source","target"
+"","=SUM(1,1)","@target"
 """
         )

--- a/tests/translate/storage/test_csvl10n.py
+++ b/tests/translate/storage/test_csvl10n.py
@@ -301,7 +301,9 @@ GENERAL@2|Notes,"cable, motor, switch"
 
     def test_spreadsheet_formula_prefixes_are_escaped_on_write(self) -> None:
         """Test that CSV output escapes formula-like values without mutating imports."""
-        store = self.StoreClass(fieldnames=["context", "id", "source", "target"])
+        store = self.StoreClass(
+            fieldnames=["context", "id", "source", "target"], escape_formulas=True
+        )
         unit = store.addsourceunit("=SUM(1,1)")
         unit.target = "+cmd"
         unit.setcontext("@context")
@@ -320,6 +322,15 @@ GENERAL@2|Notes,"cable, motor, switch"
         assert newstore.units[0].id == "'-id"
         assert newstore.units[0].source == "'=SUM(1,1)"
         assert newstore.units[0].target == "'+cmd"
+
+    def test_spreadsheet_formula_prefixes_are_preserved_by_default(self) -> None:
+        """Test that default CSV serialization preserves formula-like values."""
+        content = b'"source","target","id"\n"sometest1","@bump1","sometest1"\n'
+        store = self.parse_store(content)
+
+        assert bytes(store).decode() == (
+            '"source","target","id"\r\n"sometest1","@bump1","sometest1"\r\n'
+        )
 
     def test_multistring_with_empty_first_string_serializes(self) -> None:
         """Test that plural values with an empty first string can be written."""

--- a/translate/convert/csv2po.py
+++ b/translate/convert/csv2po.py
@@ -65,11 +65,18 @@ class csv2po:
     file.
     """
 
-    def __init__(self, templatepo=None, charset=None, duplicatestyle="keep") -> None:
+    def __init__(
+        self,
+        templatepo=None,
+        charset=None,
+        duplicatestyle="keep",
+        unescape_formulas=False,
+    ) -> None:
         """Construct the converter..."""
         self.pofile = templatepo
         self.charset = charset
         self.duplicatestyle = duplicatestyle
+        self.unescape_formulas = unescape_formulas
         self.commentindex = {}
         self.sourceindex = {}
         self.simpleindex = {}
@@ -130,15 +137,22 @@ class csv2po:
             variants.append(normalized)
         return variants
 
-    @staticmethod
-    def convertunit(csvunit):
+    def maybe_unescape_spreadsheet_formula(self, value):
+        """Remove spreadsheet formula escaping when explicitly requested."""
+        if self.unescape_formulas:
+            return self.remove_spreadsheet_escape(value)
+        return value
+
+    def convertunit(self, csvunit):
         """Converts csv unit to po unit."""
         pounit = po.pounit(encoding="UTF-8")
         if csvunit.location:
-            pounit.addlocation(csvunit.location)
-        pounit.source = csvunit.source
-        pounit.target = csvunit.target
-        pounit.setcontext(csvunit.getcontext())
+            pounit.addlocation(
+                self.maybe_unescape_spreadsheet_formula(csvunit.location)
+            )
+        pounit.source = self.maybe_unescape_spreadsheet_formula(csvunit.source)
+        pounit.target = self.maybe_unescape_spreadsheet_formula(csvunit.target)
+        pounit.setcontext(self.maybe_unescape_spreadsheet_formula(csvunit.getcontext()))
         return pounit
 
     @staticmethod
@@ -243,9 +257,13 @@ class csv2po:
                 )
                 self.unmatched += 1
                 return
-            self.set_plural_target(pounit, plural_index, csvunit.target)
+            self.set_plural_target(
+                pounit,
+                plural_index,
+                self.maybe_unescape_spreadsheet_formula(csvunit.target),
+            )
         else:
-            pounit.target = csvunit.target
+            pounit.target = self.maybe_unescape_spreadsheet_formula(csvunit.target)
 
     def convertstore(self, thecsvfile):
         """
@@ -298,6 +316,7 @@ def convertcsv(
     charset=None,
     columnorder=None,
     duplicatestyle="msgctxt",
+    unescape_formulas=False,
 ) -> int:
     """
     Reads in inputfile using csvl10n, converts using csv2po, writes to
@@ -305,11 +324,18 @@ def convertcsv(
     """
     inputstore = csvl10n.csvfile(inputfile, fieldnames=columnorder)
     if templatefile is None:
-        convertor = csv2po(charset=charset, duplicatestyle=duplicatestyle)
+        convertor = csv2po(
+            charset=charset,
+            duplicatestyle=duplicatestyle,
+            unescape_formulas=unescape_formulas,
+        )
     else:
         templatestore = po.pofile(templatefile)
         convertor = csv2po(
-            templatestore, charset=charset, duplicatestyle=duplicatestyle
+            templatestore,
+            charset=charset,
+            duplicatestyle=duplicatestyle,
+            unescape_formulas=unescape_formulas,
         )
     outputstore = convertor.convertstore(inputstore)
     if outputstore.isempty():
@@ -350,8 +376,17 @@ def main(argv=None) -> None:
         help="specify the order and position of columns (location,source,target,context)",
     )
     parser.add_duplicates_option()
+    parser.add_option(
+        "",
+        "--unescape-formulas",
+        dest="unescape_formulas",
+        action="store_true",
+        default=False,
+        help="remove spreadsheet formula escaping from CSV values",
+    )
     parser.passthrough.append("charset")
     parser.passthrough.append("columnorder")
+    parser.passthrough.append("unescape_formulas")
     parser.run(argv)
 
 

--- a/translate/convert/po2csv.py
+++ b/translate/convert/po2csv.py
@@ -60,10 +60,12 @@ class po2csv:
         csvunit.target = inputunit.target.strings[1]
         return csvunit
 
-    def convertstore(self, inputstore, columnorder=None):
+    def convertstore(self, inputstore, columnorder=None, escape_formulas=True):
         if columnorder is None:
             columnorder = ["location", "source", "target"]
-        outputstore = csvl10n.csvfile(fieldnames=columnorder)
+        outputstore = csvl10n.csvfile(
+            fieldnames=columnorder, escape_formulas=escape_formulas
+        )
         for inputunit in inputstore.units:
             outputunit = self.convertunit(inputunit)
             if outputunit is not None:
@@ -75,14 +77,16 @@ class po2csv:
         return outputstore
 
 
-def convertcsv(inputfile, outputfile, templatefile, columnorder=None) -> int:
+def convertcsv(
+    inputfile, outputfile, templatefile, columnorder=None, escape_formulas=True
+) -> int:
     """Reads in inputfile using po, converts using po2csv, writes to outputfile."""
     # note that templatefile is not used, but it is required by the converter...
     inputstore = po.pofile(inputfile)
     if inputstore.isempty():
         return 0
     convertor = po2csv()
-    outputstore = convertor.convertstore(inputstore, columnorder)
+    outputstore = convertor.convertstore(inputstore, columnorder, escape_formulas)
     outputstore.serialize(outputfile)
     return 1
 
@@ -104,7 +108,23 @@ def main(argv=None) -> None:
         default=None,
         help="specify the order and position of columns (location,source,target,context)",
     )
+    parser.add_option(
+        "",
+        "--escape-formulas",
+        dest="escape_formulas",
+        action="store_true",
+        default=True,
+        help="escape spreadsheet formula-like values in CSV output (default)",
+    )
+    parser.add_option(
+        "",
+        "--no-escape-formulas",
+        dest="escape_formulas",
+        action="store_false",
+        help="preserve spreadsheet formula-like values in CSV output",
+    )
     parser.passthrough.append("columnorder")
+    parser.passthrough.append("escape_formulas")
     parser.run(argv)
 
 

--- a/translate/storage/csvl10n.py
+++ b/translate/storage/csvl10n.py
@@ -161,17 +161,20 @@ class csvunit(base.TranslationUnit):
 
     def todict(self, **kwargs):
         # FIXME: use apis?
+        def maybe_escape(value):
+            if kwargs.get("escape_formulas"):
+                return self.add_spreadsheet_escape(value)
+            return value
+
         return {
-            "location": self.add_spreadsheet_escape(self.location),
-            "source": self.add_spreadsheet_escape(self.source),
-            "target": self.add_spreadsheet_escape(self.target),
-            "id": self.add_spreadsheet_escape(self.id),
+            "location": maybe_escape(self.location),
+            "source": maybe_escape(self.source),
+            "target": maybe_escape(self.target),
+            "id": maybe_escape(self.id),
             "fuzzy": str(self.fuzzy),
-            "context": self.add_spreadsheet_escape(self.context),
-            "translator_comments": self.add_spreadsheet_escape(
-                self.translator_comments
-            ),
-            "developer_comments": self.add_spreadsheet_escape(self.developer_comments),
+            "context": maybe_escape(self.context),
+            "translator_comments": maybe_escape(self.translator_comments),
+            "developer_comments": maybe_escape(self.developer_comments),
         }
 
     def __str__(self) -> str:
@@ -308,7 +311,9 @@ class csvfile(base.TranslationStore):
     Mimetypes = ["text/comma-separated-values", "text/csv"]
     Extensions = ["csv"]
 
-    def __init__(self, inputfile=None, fieldnames=None, encoding="auto") -> None:
+    def __init__(
+        self, inputfile=None, fieldnames=None, encoding="auto", escape_formulas=False
+    ) -> None:
         super().__init__(encoding=encoding)
         if not fieldnames:
             self.fieldnames = [
@@ -325,6 +330,7 @@ class csvfile(base.TranslationStore):
             self.fieldnames = fieldnames
         self.filename = getattr(inputfile, "name", "")
         self.dialect = "default"
+        self.escape_formulas = escape_formulas
         self._automatic_encoding = encoding == "auto"
         if inputfile is not None:
             csvsrc = inputfile.read()
@@ -428,5 +434,5 @@ class csvfile(base.TranslationStore):
         )
         writer.writeheader()
         for ce in self.units:
-            writer.writerow(ce.todict())
+            writer.writerow(ce.todict(escape_formulas=self.escape_formulas))
         return output.getvalue()


### PR DESCRIPTION
Using CSV is tricky. With some special characters as a first ones the spreadsheet tools might interpret content a formula. The established approach for this is to escape it using apostrophe, but that actually changes the content, what makes it broken for localization. The CSV storage now supports both operations with the assumption that the storage is safe, but conversion is possibly dangerous. Users can override the behavior.

Fixes https://github.com/WeblateOrg/weblate/issues/20098