### PR TITLE
fix(po): preserve existing header order

### DIFF
--- a/docs/commands/md2po.rst
+++ b/docs/commands/md2po.rst
@@ -51,8 +51,8 @@ Options (md2po):
                       (default: 'single'; if set to 'onefile', a single po/pot
                       file will be written. 'toplevel' not used.)
 -m MAXLENGTH, --maxlinelength=MAXLENGTH
-                      wrap PO output to the given maximum line length. set to
-                      0 to disable
+                      wrap PO output so quoted string content is at most
+                      MAXLENGTH characters. set to 0 to disable
 
 
 Options (po2md):

--- a/docs/commands/pot2po.rst
+++ b/docs/commands/pot2po.rst
@@ -51,8 +51,8 @@ Options:
 -s MIN_SIMILARITY, --similarity=MIN_SIMILARITY   The minimum similarity for inclusion (default: 75%)
 --nofuzzymatching    Disable all fuzzy matching
 -m MAXLENGTH, --maxlinelength=MAXLENGTH
-                      wrap PO output to the given maximum line length. set to
-                      0 to disable
+                      wrap PO output so quoted string content is at most
+                      MAXLENGTH characters. set to 0 to disable
 
 
 .. _pot2po#examples:

--- a/tests/cli/__snapshots__/test_cli_snapshots.ambr
+++ b/tests/cli/__snapshots__/test_cli_snapshots.ambr
@@ -794,8 +794,8 @@
         "MIME-Version: 1.0\n"
         "Content-Type: text/plain; charset=UTF-8\n"
         "Content-Transfer-Encoding: 8bit\n"
-        "X-Accelerator-Marker: &\n"
         "X-Generator: @X-GENERATOR@\n"
+        "X-Accelerator-Marker: &\n"
         "X-Merge-On: location\n"
         
         #: DIALOGEX.IDD_REGGHC_DIALOG.CAPTION

--- a/tests/translate/convert/test_pot2po.py
+++ b/tests/translate/convert/test_pot2po.py
@@ -32,7 +32,7 @@ class TestPOT2PO:
             if line.startswith('"') and line.endswith('"')
         ]
 
-    def test_max_line_length_wraps_output(self) -> None:
+    def test_max_line_length_wraps_quoted_payloads(self) -> None:
         long_text = (
             "This sentence contains enough words to require wrapping in PO output."
         )
@@ -485,6 +485,54 @@ msgstr ""
         print(f"Expected Header:\n{expected}")
         assert bytes(newpo).decode("utf-8") == expected
 
+    def test_header_initialisation_preserves_template_order(self) -> None:
+        """Existing PO headers keep their order when merged with a POT header."""
+        potsource = r"""msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: new@example.com\n"
+"POT-Creation-Date: 2006-11-11 11:11+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"X-Generator: Translate Toolkit 0.10rc2\n"
+"""
+        posource = r"""msgid ""
+msgstr ""
+"Language-Team: Pig Latin <piglatin@example.com>\n"
+"Project-Id-Version: Pootle 0.10\n"
+"POT-Creation-Date: 2006-01-01 01:01+0100\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Report-Msgid-Bugs-To: old@example.com\n"
+"PO-Revision-Date: 2006-09-09 09:09+0900\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Last-Translator: Joe Translate <joe@example.com>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Translate Toolkit 0.9\n"
+"""
+        expected = r"""msgid ""
+msgstr ""
+"Language-Team: Pig Latin <piglatin@example.com>\n"
+"Project-Id-Version: Pootle 0.10\n"
+"POT-Creation-Date: 2006-11-11 11:11+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Report-Msgid-Bugs-To: new@example.com\n"
+"PO-Revision-Date: 2006-09-09 09:09+0900\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Last-Translator: Joe Translate <joe@example.com>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Translate Toolkit 0.10rc2\n"
+"""
+        newpo = self.convertpot(potsource, posource)
+
+        assert bytes(newpo).decode("utf-8") == expected
+
     def test_merging_comments(self) -> None:
         """Test that we can merge comments correctly."""
         potsource = """#. Don't do it!\n#: file.py:1\nmsgid "One"\nmsgstr ""\n"""
@@ -867,8 +915,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Accelerator-Marker: &\n"
 "X-Generator: Translate Toolkit 0.10rc2\n"
+"X-Accelerator-Marker: &\n"
 "X-Merge-On: location\n"
 
 #: new_disassociated_mozilla_accesskey

--- a/tests/translate/storage/test_poheader.py
+++ b/tests/translate/storage/test_poheader.py
@@ -47,6 +47,22 @@ def test_update() -> None:
         "POT-Creation-Date",
         "Test",
     ]
+    d = poheader.update(
+        {
+            "Language-Team": "LANGUAGE <LL@li.org>",
+            "Project-Id-Version": "abc",
+        },
+        add=True,
+        preserve_order=True,
+        Project_Id_Version="def",
+        Language="af",
+    )
+    assert list(d.keys()) == [
+        "Language-Team",
+        "Project-Id-Version",
+        "Language",
+    ]
+    assert d["Project-Id-Version"] == "def"
 
 
 def poparse(posource):
@@ -165,6 +181,33 @@ msgstr ""
 """
     pofile = poparse(posource)
     compare(pofile)
+
+
+def test_updateheader_preserves_existing_order() -> None:
+    """Updating a parsed header should not reorder existing fields."""
+    posource = r"""msgid ""
+msgstr ""
+"Language-Team: Pig Latin <piglatin@example.com>\n"
+"Project-Id-Version: Pootle 0.10\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Last-Translator: Joe Translate <joe@example.com>\n"
+"""
+    pofile = poparse(posource)
+    pofile.updateheader(
+        add=True,
+        Project_Id_Version="Pootle 0.11",
+        Language="af",
+    )
+
+    assert pofile.units[0].target == (
+        "Language-Team: Pig Latin <piglatin@example.com>\n"
+        "Project-Id-Version: Pootle 0.11\n"
+        "Content-Type: text/plain; charset=UTF-8\n"
+        "Content-Transfer-Encoding: 8bit\n"
+        "Last-Translator: Joe Translate <joe@example.com>\n"
+        "Language: af\n"
+    )
 
 
 ## TODO: enable this code if PoXliffFile is able to parse a header

--- a/translate/convert/convert.py
+++ b/translate/convert/convert.py
@@ -148,7 +148,8 @@ class ConvertOptionParser(optrecurse.RecursiveOptionParser):
             default=None,
             metavar="MAXLENGTH",
             help=(
-                "wrap PO output to the given maximum line length. set to 0 to disable"
+                "wrap PO output so quoted string content is at most MAXLENGTH "
+                "characters. set to 0 to disable"
             ),
         )
         self.passthrough.append("maxlength")

--- a/translate/convert/pot2po.py
+++ b/translate/convert/pot2po.py
@@ -243,7 +243,9 @@ def _do_poheaders(input_store, output_store, template_store) -> None:
     plural_forms = None
     kwargs = {}
 
+    template_header = None
     if template_store is not None and isinstance(template_store, poheader.poheader):
+        template_header = template_store.header()
         templateheadervalues = template_store.parseheader()
         for key, value in templateheadervalues.items():
             if key == "Project-Id-Version":
@@ -286,6 +288,13 @@ def _do_poheaders(input_store, output_store, template_store) -> None:
         else:
             kwargs[key] = value
 
+    if template_header is not None:
+        output_header = output_store.header()
+        if output_header is None:
+            output_header = output_store.makeheader()
+            output_store._insert_header(output_header)
+        output_header.target = template_header.target
+
     output_header = output_store.init_headers(
         charset=charset,
         encoding=encoding,
@@ -301,16 +310,14 @@ def _do_poheaders(input_store, output_store, template_store) -> None:
 
     # Get the header comments and fuzziness state
     # override some values from input file
-    if template_store is not None:
-        template_header = template_store.header()
-        if template_header is not None:
-            if template_header.getnotes("translator"):
-                output_header.addnote(
-                    template_header.getnotes("translator"),
-                    "translator",
-                    position="replace",
-                )
-            output_header.markfuzzy(template_header.isfuzzy())
+    if template_header is not None:
+        if template_header.getnotes("translator"):
+            output_header.addnote(
+                template_header.getnotes("translator"),
+                "translator",
+                position="replace",
+            )
+        output_header.markfuzzy(template_header.isfuzzy())
 
 
 def main(argv=None) -> None:

--- a/translate/storage/poheader.py
+++ b/translate/storage/poheader.py
@@ -69,15 +69,35 @@ def format_key(key: str) -> str:
     return key
 
 
-def update(existing: dict[str, str], add: bool = False, **kwargs) -> dict[str, str]:
+def update(
+    existing: dict[str, str],
+    add: bool = False,
+    *,
+    preserve_order: bool = False,
+    **kwargs,
+) -> dict[str, str]:
     """
     Update an existing header dictionary with the values in kwargs, adding
     new values only if add is true.
 
     :return: Updated dictionary of header entries
     """
-    headerargs = {}
     fixedargs = cidict((format_key(key), value) for key, value in kwargs.items())
+    if preserve_order:
+        headerargs = {}
+        for key, value in existing.items():
+            if key in fixedargs:
+                headerargs[key] = fixedargs.pop(key)
+            else:
+                headerargs[key] = value
+        if add:
+            for key in poheader.header_order:
+                if key in fixedargs:
+                    headerargs[key] = fixedargs.pop(key)
+            headerargs.update(fixedargs)
+        return headerargs
+
+    headerargs = {}
     removed = set()
     for key in poheader.header_order:
         if key in existing:
@@ -230,7 +250,7 @@ class poheader:
                 header = self.makeheader(**kwargs)
                 self._insert_header(header)
         else:
-            headeritems = update(self.parseheader(), add, **kwargs)
+            headeritems = update(self.parseheader(), add, preserve_order=True, **kwargs)
             keys = headeritems.keys()
             if (
                 "Content-Type" not in keys


### PR DESCRIPTION
Keep GNU gettext ordering for generated headers while retaining the order of headers from existing PO files during updates.

Clarify that --maxlinelength applies to quoted string content without changing its behavior.