### PR TITLE
Use ternary operator in po2txt.run()

### DIFF
--- a/translate/convert/po2txt.py
+++ b/translate/convert/po2txt.py
@@ -135,7 +135,9 @@ class po2txt:
         if not self.should_output_store:
             return False
 
-        outputstring = self.convert_store() if self.template_file is None else self.merge_stores()
+        outputstring = (
+            self.convert_store() if self.template_file is None else self.merge_stores()
+        )
 
         self.output_file.write(outputstring.encode("utf-8"))
         return True

--- a/translate/convert/po2txt.py
+++ b/translate/convert/po2txt.py
@@ -135,10 +135,7 @@ class po2txt:
         if not self.should_output_store:
             return False
 
-        if self.template_file is None:
-            outputstring = self.convert_store()
-        else:
-            outputstring = self.merge_stores()
+        outputstring = self.convert_store() if self.template_file is None else self.merge_stores()
 
         self.output_file.write(outputstring.encode("utf-8"))
         return True


### PR DESCRIPTION
Simplify the template_file conditional assignment in `po2txt.run()` to a single-line ternary expression per ruff SIM108 guidance.

This is a small, safe code quality improvement that makes the converter more idiomatic without changing behavior.

## Files changed
- `translate/convert/po2txt.py`

## Verification
- `python3 -m py_compile translate/convert/po2txt.py` passes