### PR TITLE
chore: modernize readthedocs setup

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,5 @@
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.com/platform/stable/config-file/v2.html for details
 
 version: 2
 
@@ -10,18 +10,15 @@ sphinx:
 formats: []
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: '3.13'
+    python: '3.14'
   apt_packages:
   - libgettextpo0
-  jobs:
-    create_environment:
-    - asdf plugin add uv
-    - asdf install uv latest
-    - asdf global uv latest
-    install:
-    - uv sync --only-group docs
-    build:
-      html:
-      - .venv/bin/sphinx-build -T -b html -d docs/_build/doctrees --jobs auto docs $READTHEDOCS_OUTPUT/html
+
+python:
+  install:
+  - method: uv
+    command: sync
+    groups:
+    - docs


### PR DESCRIPTION
Use native uv support instead of installing it manually.