### PR TITLE
docs(md2po): document translated Markdown import

### DIFF
--- a/docs/commands/md2po.rst
+++ b/docs/commands/md2po.rst
@@ -14,18 +14,17 @@ Usage
 
 ::
 
-  md2po [options] <md-src> <po>
+  md2po [options] [-t <md-src>] <md-src-or-dest> <po>
   po2md [options] -i <po> -t <md-src> -o <md-dest>
 
 Where:
 
-+-----------+----------------------------------------------------------------------------------------+
-| <md-src>  | is a Markdown file or a directory of Markdown files, source language                   |
-+-----------+----------------------------------------------------------------------------------------+
-| <md-dest> | is a Markdown file or a directory of Markdown files, translated to the target language |
-+-----------+----------------------------------------------------------------------------------------+
-| <po>      | is a PO file or directory of PO files                                                  |
-+-----------+----------------------------------------------------------------------------------------+
+* <md-src> is a Markdown file or a directory of Markdown files, source language
+* <md-dest> is a Markdown file or a directory of Markdown files, translated to
+  the target language
+* <md-src-or-dest> is a source Markdown file, or a translated Markdown file when
+  -t is used
+* <po> is a PO file or directory of PO files
 
 Options (md2po):
 
@@ -39,6 +38,7 @@ Options (md2po):
 -i INPUT, --input=INPUT   read from INPUT in Markdown format
 -x EXCLUDE, --exclude=EXCLUDE  exclude names matching EXCLUDE from input paths
 -o OUTPUT, --output=OUTPUT  write to OUTPUT in po, pot formats
+-t TEMPLATE, --template=TEMPLATE   read from TEMPLATE in Markdown format
 -S, --timestamp      skip conversion if the output file has newer timestamp
 -P, --pot            output PO Templates (.pot) rather than PO files (.po)
 --duplicates=DUPLICATESTYLE
@@ -93,6 +93,17 @@ content) and place them in *pot*.
 See the :doc:`pot2po` command for more information about how to create PO files
 from the POT files, and to update existing PO files when the POT files have
 changed.
+
+If you already have translated Markdown and want to convert it back to PO, pass
+the translated Markdown as input and the source Markdown as template:
+
+::
+
+  md2po -i docs/index.nl.md -t docs/index.md -o i18n/nl/LC_MESSAGES/index.po
+
+The strings from *docs/index.md* will be written as ``msgid`` values, and the
+matching translated strings from *docs/index.nl.md* will be written as
+``msgstr`` values.
 
 Suppose you have created PO files for translation to Xhosa and placed them in
 the directory *xh*. You can then generate the translated version of the Markdown

--- a/tests/translate/convert/test_md2po.py
+++ b/tests/translate/convert/test_md2po.py
@@ -375,6 +375,37 @@ This text will also be translated.
         assert "World" in content  # source
         assert "Mundo" in content  # target
 
+    def test_translated_markdown_input_with_source_template(self) -> None:
+        """Test converting existing translated Markdown back to PO."""
+        self.create_testfile(
+            "docs/index.md",
+            "# Welcome\n\nRead the documentation before continuing.\n",
+        )
+        self.create_testfile(
+            "docs/index.nl.md",
+            "# Welkom\n\nLees de documentatie voordat u doorgaat.\n",
+        )
+
+        self.run_command(
+            "docs/index.nl.md",
+            "index.po",
+            template="docs/index.md",
+        )
+
+        output = pofile()
+        with open(self.get_testfilename("index.po"), "rb") as handle:
+            output.parse(handle)
+        units = {
+            unit.source: unit.target for unit in output.units if not unit.isheader()
+        }
+
+        assert units["Welcome"] == "Welkom"
+        assert (
+            units["Read the documentation before continuing."]
+            == "Lees de documentatie voordat u doorgaat."
+        )
+        assert "Welkom" not in units
+
     def test_markdown_with_template_complex(self):
         """Test md2po with template file for complex Markdown structure."""
         # Create template (source language)


### PR DESCRIPTION
Add regression coverage for converting translated Markdown with a source template.

Fixes #6253