### PR TITLE
fix(po2prop): honor strings personality option

### DIFF
--- a/tests/translate/convert/test_po2prop.py
+++ b/tests/translate/convert/test_po2prop.py
@@ -557,3 +557,46 @@ class TestPO2PropCommand(test_convert.TestConvertCommand, TestPO2Prop):
         "--removeuntranslated",
         "--nofuzzy",
     ]
+
+    def test_strings_output_uses_strings_personality_by_default(self) -> None:
+        """Check .strings output still uses the strings personality by default."""
+        self.create_testfile(
+            "translations.po",
+            """#: greeting
+msgid "Hello"
+msgstr "Ahoj"
+""",
+        )
+        self.create_testfile(
+            "template.strings", '"greeting" = "Hello";\n'.encode("utf-16")
+        )
+
+        self.run_command(
+            "translations.po", "output.strings", template="template.strings"
+        )
+
+        assert self.read_testfile("output.strings").decode("utf-16") == (
+            '"greeting" = "Ahoj";\n'
+        )
+
+    def test_strings_output_honors_personality_option(self) -> None:
+        """Check .strings output passes the personality option through."""
+        self.create_testfile(
+            "translations.po",
+            """#: greeting
+msgid "Hello"
+msgstr "Ahoj"
+""",
+        )
+        self.create_testfile("template.strings", '"greeting" = "Hello";')
+
+        self.run_command(
+            "translations.po",
+            "output.strings",
+            template="template.strings",
+            personality="strings-utf8",
+        )
+
+        assert self.read_testfile("output.strings").decode() == (
+            '"greeting" = "Ahoj";\n'
+        )

--- a/translate/convert/po2prop.py
+++ b/translate/convert/po2prop.py
@@ -232,7 +232,7 @@ def convertstrings(
     inputfile,
     outputfile,
     templatefile,
-    personality="strings",
+    personality=None,
     includefuzzy=False,
     encoding=None,
     outputthreshold=None,
@@ -243,7 +243,7 @@ def convertstrings(
         inputfile,
         outputfile,
         templatefile,
-        personality="strings",
+        personality=personality or "strings",
         includefuzzy=includefuzzy,
         encoding=encoding,
         outputthreshold=outputthreshold,
@@ -275,12 +275,13 @@ def convertprop(
     inputfile,
     outputfile,
     templatefile,
-    personality="java",
+    personality=None,
     includefuzzy=False,
     encoding=None,
     remove_untranslated=False,
     outputthreshold=None,
 ) -> bool:
+    personality = personality or "java"
     inputstore = po.pofile(inputfile)
 
     if not convert.should_output_store(inputstore, outputthreshold):
@@ -312,7 +313,7 @@ def main(argv=None) -> None:
         "",
         "--personality",
         dest="personality",
-        default=properties.default_dialect,
+        default=None,
         type="choice",
         choices=list(properties.dialects),
         help=f"override the input file format: {', '.join(properties.dialects)} (for .properties files, default: {properties.default_dialect})",


### PR DESCRIPTION
Preserve the default strings personality for .strings output while passing explicit personality values such as strings-utf8 through to the converter.

Fixes #5247