### PR TITLE
fix(convert): preserve .strings key quote spacing

### DIFF
--- a/tests/translate/convert/test_po2prop.py
+++ b/tests/translate/convert/test_po2prop.py
@@ -76,6 +76,19 @@ class TestPO2Prop:
         print(propfile)
         assert propfile == propexpected
 
+    def test_escaped_backslash_key_spacing(self) -> None:
+        """Check that key-owned whitespace is not duplicated as delimiter padding."""
+        posource = """#: path%5C%5C+
+msgid "old"
+msgstr "new"
+"""
+        proptemplate = r"""path\\ =old
+"""
+        propexpected = r"""path\\ =new
+"""
+        propfile = self.merge2prop(proptemplate, posource)
+        assert propfile == propexpected
+
     def test_no_value(self) -> None:
         """Check that we can handle keys without value."""
         posource = """#: KEY\nmsgctxt "KEY"\nmsgid ""\nmsgstr ""\n"""
@@ -268,6 +281,29 @@ msgstr "translated"
             proptemplate, posource, personality="strings", encoding="utf-16"
         )
         assert propfile == propexpectedstrings
+
+    def test_strings_preserves_quoted_key_spacing(self) -> None:
+        """Check merging .strings entries whose quoted key starts or ends with spaces."""
+        posource = """#: +todo+
+msgid " todo "
+msgstr " translated "
+
+#: +for+
+msgid " for "
+msgstr " translated "
+"""
+        proptemplate = """/*  todo  */
+" todo " = " todo ";
+" for "=" for ";
+""".encode("utf-16")
+        propexpected = """/*  todo  */
+" todo " = " translated ";
+" for "=" translated ";
+"""
+        propfile = self.merge2prop(
+            proptemplate, posource, personality="strings", encoding="utf-16"
+        )
+        assert propfile == propexpected
 
     def test_merging_untranslated_simple(self) -> None:
         """Check merging untranslated entries in two 1) use English 2) drop key, value pair."""

--- a/translate/convert/po2prop.py
+++ b/translate/convert/po2prop.py
@@ -34,6 +34,29 @@ from translate.storage import po, properties
 eol = "\n"
 
 
+def _get_key_end(line, delimiter_pos, key, personality):
+    """Return where the output key ends in the template line."""
+    key_start = len(line[:delimiter_pos]) - len(line[:delimiter_pos].lstrip())
+    key_wrap_char = personality.key_wrap_char
+    if key_wrap_char and line[key_start : key_start + 1] == key_wrap_char:
+        key_end = key_start + 1
+        while key_end < delimiter_pos:
+            if line[key_end] == key_wrap_char and line[key_end - 1] != "\\":
+                return key_end + 1
+            key_end += 1
+    return min(key_start + len(key), delimiter_pos)
+
+
+def _get_delimiter_spacing(line, delimiter_pos, key_end):
+    """Return the whitespace around the delimiter."""
+    postspace_end = delimiter_pos + 1
+    while postspace_end < len(line) and line[postspace_end].isspace():
+        postspace_end += 1
+    postspace = line[delimiter_pos + 1 : postspace_end]
+
+    return line[key_end:delimiter_pos], postspace
+
+
 def applytranslation(key, propunit, inunit, mixedkeys):
     """Applies the translation for key in the po unit to the prop unit."""
     # this converts the po-style string to a prop-style string
@@ -190,15 +213,10 @@ class reprop:
                 delimiter = f" {self.personality.delimiters[0]} "
             else:
                 key = self.personality.key_strip(line[:delimiter_pos])
-                # Calculate space around the equal sign
-                prespace = line[line.find(" ", len(key)) : delimiter_pos]
-                postspacestart = len(line[delimiter_pos + 1 :])
-                postspaceend = len(line[delimiter_pos + 1 :].lstrip())
-                postspace = line[
-                    delimiter_pos + 1 : delimiter_pos
-                    + (postspacestart - postspaceend)
-                    + 1
-                ]
+                key_end = _get_key_end(line, delimiter_pos, key, self.personality)
+                prespace, postspace = _get_delimiter_spacing(
+                    line, delimiter_pos, key_end
+                )
                 delimiter = prespace + delimiter_char + postspace
             # Check for the special marker used for empty keys (e.g., "=value")
             lookup_key = key or EMPTY_KEY_MARKER


### PR DESCRIPTION
Calculate delimiter spacing from the template delimiter instead of the decoded key length so quoted .strings keys with surrounding spaces do not copy the closing quote into the output.

Fixes #3000