### PR TITLE
fix(tbx): remove notes from actual parent

### DIFF
--- a/tests/translate/storage/test_tbx.py
+++ b/tests/translate/storage/test_tbx.py
@@ -143,6 +143,161 @@ class TestTBXfile(test_base.TestTranslationStore):
             "Explanation", "Another explanation"
         )
 
+    def test_replace_nested_descrip(self) -> None:
+        tbxdata = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry id="testid">
+                <langSet xml:lang="en">
+                    <tig>
+                        <term>Concept</term>
+                        <descrip>Explanation</descrip>
+                    </tig>
+                </langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>
+"""
+        tbxfile = tbx.tbxfile.parsestring(tbxdata.encode())
+        unit = tbxfile.units[0]
+
+        assert unit.getnotes(origin="definition") == "Explanation"
+        unit.addnote("Another explanation", origin="definition", position="replace")
+
+        assert unit.getnotes(origin="definition") == "Another explanation"
+        assert unit.xmlelement.find("./langSet/tig/descrip") is None
+        assert len(unit.xmlelement.findall("./descrip")) == 1
+
+    def test_replace_definition_preserves_translation_needed(self) -> None:
+        tbxdata = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry id="testid">
+                <descrip>Explanation</descrip>
+                <descrip type="Translation needed">Yes</descrip>
+                <langSet xml:lang="en"><tig><term>Concept</term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>
+"""
+        tbxfile = tbx.tbxfile.parsestring(tbxdata.encode())
+        unit = tbxfile.units[0]
+
+        assert unit.istranslatable()
+        assert unit.getnotes(origin="definition") == "Explanation"
+
+        unit.addnote("Another explanation", origin="definition", position="replace")
+
+        assert unit.istranslatable()
+        assert unit.getnotes(origin="definition") == "Another explanation"
+        translation_needed = unit.xmlelement.find(
+            "./descrip[@type='Translation needed']"
+        )
+        assert translation_needed is not None
+        assert translation_needed.text == "Yes"
+
+    def test_replace_translator_note_preserves_nested_developer_note(self) -> None:
+        tbxdata = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry id="testid">
+                <langSet xml:lang="en">
+                    <tig>
+                        <term>Concept</term>
+                        <note from="developer">Developer note</note>
+                    </tig>
+                </langSet>
+                <note from="translator">Translator note</note>
+            </termEntry>
+        </body>
+    </text>
+</martif>
+"""
+        tbxfile = tbx.tbxfile.parsestring(tbxdata.encode())
+        unit = tbxfile.units[0]
+
+        unit.addnote("New translator note", origin="translator", position="replace")
+
+        assert unit.getnotes(origin="translator") == "New translator note"
+        assert unit.getnotes(origin="developer") == "Developer note"
+        nested_note = unit.xmlelement.find("./langSet/tig/note")
+        assert nested_note is not None
+        assert nested_note.get("from") == "developer"
+
+    def test_replace_pos_note_preserves_administrative_status(self) -> None:
+        tbxdata = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry id="testid">
+                <langSet xml:lang="en">
+                    <tig>
+                        <term>Concept</term>
+                        <termNote type="administrativeStatus">deprecated</termNote>
+                        <termNote type="partOfSpeech">old noun</termNote>
+                    </tig>
+                </langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>
+"""
+        tbxfile = tbx.tbxfile.parsestring(tbxdata.encode())
+        unit = tbxfile.units[0]
+
+        assert unit.isobsolete()
+        assert unit.getnotes(origin="pos") == "old noun"
+
+        unit.addnote("new noun", origin="pos", position="replace")
+
+        assert unit.getnotes(origin="pos") == "new noun"
+        assert unit.isobsolete()
+        assert (
+            unit.xmlelement.find("./langSet/tig/termNote[@type='partOfSpeech']") is None
+        )
+        administrative_status = unit.xmlelement.find(
+            "./langSet/tig/termNote[@type='administrativeStatus']"
+        )
+        assert administrative_status is not None
+        assert administrative_status.text == "deprecated"
+
     def test_note_from(self) -> None:
         tbxdata = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">

--- a/translate/storage/tbx.py
+++ b/translate/storage/tbx.py
@@ -199,18 +199,32 @@ class tbxunit(lisa.LISAunit):
     def setid(self, value):
         return self.xmlelement.set("id", value)
 
-    def _get_origin_element(self, origin: str):
+    def _get_origin_element(self, origin: str | None):
         if origin == "pos":
             return self.namespaced("termNote")
         if origin == "definition":
             return self.namespaced("descrip")
         return self.namespaced("note")
 
+    def _matches_note_origin(self, node, origin=None) -> bool:
+        return (
+            origin in {"pos", "definition", None} or node.get("from") == origin
+        ) and not (
+            self._is_administrative_status_term_node(node)
+            or self._is_translation_needed_node(node)
+        )
+
     def removenotes(self, origin=None) -> None:
         """Remove all the translator notes."""
-        notes = self.xmlelement.iterdescendants(self._get_origin_element(origin))  # ty:ignore[invalid-argument-type]
+        notes = [
+            note
+            for note in self._getnotenodes(origin=origin)
+            if self._matches_note_origin(note, origin)
+        ]
         for note in notes:
-            self.xmlelement.remove(note)
+            parent = note.getparent()
+            if parent is not None:
+                parent.remove(note)
 
     def addnote(self, text, origin=None, position="append") -> None:
         """Add a note specifically in a "note" tag."""
@@ -221,14 +235,14 @@ class tbxunit(lisa.LISAunit):
             text = text.strip()
         if not text:
             return
-        note = etree.SubElement(self.xmlelement, self._get_origin_element(origin))  # ty:ignore[invalid-argument-type]
+        note = etree.SubElement(self.xmlelement, self._get_origin_element(origin))
         safely_set_text(note, text)
         if origin and origin not in {"pos", "definition"}:
             note.set("from", origin)
 
     def _getnotenodes(self, origin=None):
         """Get all nodes matching ``origin`` in the XML document."""
-        return self.xmlelement.iterdescendants(self._get_origin_element(origin))  # ty:ignore[invalid-argument-type]
+        return self.xmlelement.iterdescendants(self._get_origin_element(origin))
 
     def _getnodetext(self, node):
         """
@@ -265,13 +279,7 @@ class tbxunit(lisa.LISAunit):
         initial_list = [
             self._getnodetext(node)
             for node in note_nodes
-            if (
-                (origin in {"pos", "definition", None} or node.get("from") == origin)
-                and not (
-                    self._is_administrative_status_term_node(node)
-                    or self._is_translation_needed_node(node)
-                )
-            )
+            if self._matches_note_origin(node, origin)
         ]
 
         # Remove duplicate entries from list:


### PR DESCRIPTION
Remove TBX notes from their direct XML parent so nested notes can be replaced safely.

Add regression coverage for replacing nested descrip notes.