### PR TITLE
Fix typos in documentation and pyproject comments

### DIFF
--- a/docs/commands/pocount.rst
+++ b/docs/commands/pocount.rst
@@ -174,7 +174,7 @@ Bugs
 * There are some miscounts related to word breaks.
 * When using the short output formats the columns may not be exactly aligned.
   This is because the number of digits in different columns is unknown before
-  all input files are processed. The chosen tradeoff here was instanteous
+  all input files are processed. The chosen tradeoff here was instantaneous
   output (after each processed file) instead of waiting for the last file to be
   processed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,12 +242,12 @@ ignore = [
   "tests/*/*/*/*",
   "tests/*/*/*/*/*",
   "tools/benchmark.py",  # Internal benchmarking
-  "tools/phase",  # TODO: investigate purpuse, it was never installed
-  "tools/phaselist2goals",  # TODO: investigate purpuse, it was never installed
-  "translate/convert/odfxml",  # TODO: investigate purpuse, it was never installed
-  "translate/convert/roundtrip-gaia",  # TODO: investigate purpuse, it was never installed
-  "translate/convert/roundtrip-mozilla",  # TODO: investigate purpuse, it was never installed
-  "translate/convert/roundtrip-OOo",  # TODO: investigate purpuse, it was never installed
+  "tools/phase",  # TODO: investigate purpose, it was never installed
+  "tools/phaselist2goals",  # TODO: investigate purpose, it was never installed
+  "translate/convert/odfxml",  # TODO: investigate purpose, it was never installed
+  "translate/convert/roundtrip-gaia",  # TODO: investigate purpose, it was never installed
+  "translate/convert/roundtrip-mozilla",  # TODO: investigate purpose, it was never installed
+  "translate/convert/roundtrip-OOo",  # TODO: investigate purpose, it was never installed
   "translate/storage/debug.properties"  # TODO: this should be converted to tests
 ]
 


### PR DESCRIPTION
### Motivation

- Correct minor typographical errors in the documentation and project metadata to improve readability and clarity.

### Description

- Fix typo in `docs/commands/pocount.rst` by changing "instanteous" to "instantaneous".
- Fix multiple occurrences of "purpuse" to "purpose" in comment strings inside `pyproject.toml`.

### Testing

- Ran the project's test suite with `pytest` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48a14f1d288329b2b302d5cb8f3a92)