### PR TITLE
feat(mdx): safely extract simple JSX content

### DIFF
--- a/docs/formats/mdx.rst
+++ b/docs/formats/mdx.rst
@@ -24,12 +24,35 @@ Conformance
 * Import and export statements at the top level are preserved verbatim and
   are not extracted for translation.
 
-* Block-level JSX components (tags starting with an uppercase letter, e.g.
-  ``<Alert>``, ``<Tabs>``) are preserved verbatim. Their inner content is
-  *not* separately extracted for translation.
+* The MDX-specific extractor intentionally recognizes only JSX components that
+  begin at column zero and occupy complete physical lines. Component names must
+  start with an uppercase letter, and component blocks must be separated from
+  surrounding Markdown by blank lines.
 
-* Inline JSX expressions such as ``{variable}`` at the block level are
-  preserved verbatim.
+* Simple boolean and quoted string attributes on one-line component tags are
+  supported. Quoted values are extracted for translation, for example
+  ``<Step title="Open" />`` or ``<Callout title="Warning">``.
+
+* Markdown children are extracted only when a supported one-line opening tag
+  and its matching closing tag are separate, column-zero lines and the child
+  block contains no JSX, raw HTML, JavaScript expressions, or top-level ESM
+  outside fenced code blocks. The child is parsed as an isolated Markdown
+  document and its common indentation is restored after translation.
+
+* Syntax requiring JSX or JavaScript parsing is deliberately opaque. This
+  includes multiline tags, expression or spread attributes, same-line children,
+  nested components, fragments, and component-like literals in child content.
+  Such syntax is preserved without partial extraction when it forms a
+  blank-delimited block. Same-name nesting is recognized only on complete
+  physical lines.
+
+* Brace-containing paragraphs and standalone JavaScript expressions are
+  preserved without attempting to balance JavaScript tokens. Top-level import
+  and export statements are preserved through the next blank line.
+
+* Inline JSX and JSX after Markdown container markers are not interpreted by
+  the MDX-specific extractor. They remain subject to the inherited Markdown
+  handling and their attributes are not separately extracted.
 
 * Regular Markdown content between JSX blocks is extracted for translation
   in the same way as the plain Markdown converter.
@@ -38,7 +61,8 @@ Conformance
   element handling, optional code block extraction, optional front matter
   extraction, and maximum line length reflowing in ``po2mdx``.
 
-* Does not translate embedded HTML.
+* Does not provide dedicated embedded HTML extraction; HTML handling is
+  inherited from the Markdown parser.
 
 * Does not perform any checks that the translated text has the same formatting
   as the source.

--- a/tests/translate/convert/test_mdx2po.py
+++ b/tests/translate/convert/test_mdx2po.py
@@ -10,13 +10,18 @@ class TestMDX2PO:
     """Test MDX to PO conversion."""
 
     @staticmethod
-    def mdx2po(mdx_content: bytes) -> po.pofile:
+    def mdx2po(
+        mdx_content: bytes, template_content: bytes | None = None, **kwargs
+    ) -> po.pofile:
         """Helper to convert MDX bytes to a PO store."""
         inputfile = BytesIO(mdx_content)
+        templatefile = (
+            BytesIO(template_content) if template_content is not None else None
+        )
         outputfile = BytesIO()
         parser = MDX2POOptionParser()
         parser._extract_translation_units(
-            inputfile, outputfile, None, "msgctxt", "single"
+            inputfile, outputfile, templatefile, "msgctxt", "single", **kwargs
         )
         outputfile.seek(0)
         return po.pofile(outputfile)
@@ -29,20 +34,21 @@ class TestMDX2PO:
 
 This is a paragraph.
 
-<Alert type="info">
+<Alert title="Info">
   Important note
 </Alert>
 
 Another paragraph.
 """
         store = self.mdx2po(content)
-        sources = [u.source for u in store.units if u.source]
+        sources = [unit.source for unit in store.units if unit.source]
         assert "Welcome" in sources
         assert "This is a paragraph." in sources
+        assert "Info" in sources
+        assert "Important note" in sources
         assert "Another paragraph." in sources
-        # JSX content should not be extracted
-        assert not any("Alert" in s for s in sources)
-        assert not any("import" in s for s in sources)
+        assert not any("import" in source for source in sources)
+        assert not any("Alert" in source for source in sources)
 
     def test_no_code_blocks(self):
         """Code blocks can be excluded from extraction."""
@@ -54,114 +60,11 @@ const x = 1;
 
 Text.
 """
-        inputfile = BytesIO(content)
-        outputfile = BytesIO()
-        parser = MDX2POOptionParser()
-        parser._extract_translation_units(
-            inputfile, outputfile, None, "msgctxt", "single", extract_code_blocks=False
-        )
-        outputfile.seek(0)
-        store = po.pofile(outputfile)
-        sources = [u.source for u in store.units if u.source]
+        store = self.mdx2po(content, extract_code_blocks=False)
+        sources = [unit.source for unit in store.units if unit.source]
         assert "Title" in sources
         assert "Text." in sources
-        assert not any("const" in s for s in sources)
-
-    def test_no_placeholder_leakage(self):
-        """Internal MDX_BLOCK placeholder markers must not appear in PO sources."""
-        content = b"""import { Alert } from './Alert'
-
-# Title
-
-<Alert type="info">Important</Alert>
-
-Paragraph.
-"""
-        store = self.mdx2po(content)
-        sources = [u.source for u in store.units if u.source]
-        assert not any("MDX_BLOCK" in s for s in sources)
-
-    def test_jsx_in_code_fence_is_not_protected(self):
-        """JSX-like lines inside code fences are not silently removed."""
-        content = b"""# Title
-
-```jsx
-<MyComponent prop="value" />
-```
-
-Text.
-"""
-        store = self.mdx2po(content)
-        sources = [u.source for u in store.units if u.source]
-        assert "Title" in sources
-        assert "Text." in sources
-        # The code fence content should appear in the PO (extract_code_blocks=True)
-        assert any("MyComponent" in s for s in sources)
-
-    def test_export_statement_not_extracted(self):
-        """Export statements are not extracted as translation units."""
-        content = b"""export const meta = { title: 'Test', author: 'Jane' }
-
-# Heading
-
-Paragraph.
-"""
-        store = self.mdx2po(content)
-        sources = [u.source for u in store.units if u.source]
-        assert "Heading" in sources
-        assert "Paragraph." in sources
-        assert not any("export" in s for s in sources)
-        assert not any("meta" in s for s in sources)
-
-    def test_multiline_jsx_block_not_extracted(self):
-        """Multi-line JSX block components are not extracted."""
-        content = b"""# Title
-
-<Card>
-  <CardHeader>Header</CardHeader>
-  <CardBody>Body content</CardBody>
-</Card>
-
-Footer text.
-"""
-        store = self.mdx2po(content)
-        sources = [u.source for u in store.units if u.source]
-        assert "Title" in sources
-        assert "Footer text." in sources
-        assert not any("Card" in s for s in sources)
-        assert not any("Header" in s for s in sources)
-
-    def test_self_closing_jsx_not_extracted(self):
-        """Self-closing JSX tags are not extracted."""
-        content = b"""# Title
-
-<Divider />
-
-Paragraph.
-"""
-        store = self.mdx2po(content)
-        sources = [u.source for u in store.units if u.source]
-        assert "Title" in sources
-        assert "Paragraph." in sources
-        assert not any("Divider" in s for s in sources)
-
-    def test_multiline_import_not_extracted(self):
-        """Multi-line import statements are not extracted."""
-        content = b"""import {
-  Alert,
-  Button,
-} from './components'
-
-# Title
-
-Text.
-"""
-        store = self.mdx2po(content)
-        sources = [u.source for u in store.units if u.source]
-        assert "Title" in sources
-        assert "Text." in sources
-        assert not any("Alert" in s for s in sources)
-        assert not any("import" in s for s in sources)
+        assert not any("const" in source for source in sources)
 
     def test_no_frontmatter_option(self):
         """Front matter is not extracted when --no-frontmatter is given."""
@@ -173,26 +76,339 @@ title: My Page
 
 Paragraph.
 """
-        inputfile = BytesIO(content)
-        outputfile = BytesIO()
-        parser = MDX2POOptionParser()
-        parser._extract_translation_units(
-            inputfile,
-            outputfile,
-            None,
-            "msgctxt",
-            "single",
-            extract_frontmatter=False,
-        )
-        outputfile.seek(0)
-        store = po.pofile(outputfile)
-        sources = [u.source for u in store.units if u.source]
+        store = self.mdx2po(content, extract_frontmatter=False)
+        sources = [unit.source for unit in store.units if unit.source]
         assert "Heading" in sources
         assert "Paragraph." in sources
-        assert not any("title" in s for s in sources)
+        assert not any("title" in source for source in sources)
+
+    def test_inline_jsx_attribute_in_markdown_text_is_not_extracted(self):
+        """Inline MDX component attributes in Markdown are not extracted."""
+        content = b'See <Badge label="New" /> now.\n'
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "New" not in sources
+        assert "See {1} now." in sources
+
+    def test_inline_jsx_expression_prop_attribute_is_not_extracted(self):
+        """A brace-containing paragraph is conservatively opaque."""
+        content = b'Click <Button label="Save" icon={Icon} /> now.\n'
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "Save" not in sources
+        assert sources == []
+
+    def test_no_placeholders_inline_jsx_keeps_paragraph_unit(self):
+        """No-placeholders mode keeps inline JSX in the paragraph unit."""
+        content = b"""This is
+inline <Badge label="New" />
+paragraph.
+"""
+        store = self.mdx2po(content, no_placeholders=True)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "New" not in sources
+        assert len(sources) == 1
+        assert sources[0].replace("\n", " ") == (
+            'This is inline <Badge label="New" /> paragraph.'
+        )
+
+    def test_same_line_jsx_children_are_opaque(self):
+        """Same-line JSX children are preserved but not extracted."""
+        content = b"<Callout>Text</Callout>\n\nAfter.\n"
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "Text" not in sources
+        assert "After." in sources
+        assert not any("MDX_BLOCK" in source for source in sources)
+
+    def test_inline_jsx_expression_prop_children_are_opaque(self):
+        """Same-line JSX children with expression props stay opaque."""
+        content = b"Text <Callout kind={kind}>Child</Callout>\n\nAfter.\n"
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "Child" not in sources
+        assert "After." in sources
+
+    def test_unsupported_jsx_block_children_are_opaque(self):
+        """Unsupported JSX blocks do not expose child text."""
+        content = b"""<Callout>Intro
+More text
+</Callout>
+
+After.
+"""
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "Intro" not in sources
+        assert "More text" not in sources
+        assert "After." in sources
+
+    def test_nested_unsupported_jsx_block_children_are_opaque(self):
+        """Nested same-name JSX in unsupported blocks does not close early."""
+        content = b"""<Callout>Intro
+<Callout>Inner</Callout>
+More text
+</Callout>
+
+After.
+"""
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "Intro" not in sources
+        assert "Inner" not in sources
+        assert "More text" not in sources
+        assert "After." in sources
+
+    def test_marker_prefixed_same_line_jsx_is_markdown_owned(self):
+        """Container-prefixed JSX is not interpreted by the MDX preprocessor."""
+        content = b"""> <Callout>Text</Callout>
+> After.
+"""
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert len(sources) == 1
+        assert sources[0].replace("\n", " ") == "Text{1} After."
+
+    def test_multiline_standalone_jsx_block_is_opaque(self):
+        """Multiline opening tags are outside the supported subset."""
+        content = b"""<Callout
+  title="Open"
+>
+  Copy
+</Callout>
+"""
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert sources == []
+
+    def test_jsx_in_opaque_regions_is_not_scanned(self):
+        """Comments, expressions, raw HTML, and code stay opaque to JSX attrs."""
+        content = b"""<!--
+<Card title="Comment" />
+-->
+
+Before {items.map(
+  item => <Card title="Expression" />
+)} after.
+
+<span title="<Card title='HTML' />">hello</span>
+
+```jsx
+<Card title="Code" />
+```
+
+After.
+"""
+        store = self.mdx2po(content, extract_code_blocks=False)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "After." in sources
+        assert "Comment" not in sources
+        assert "Expression" not in sources
+        assert "HTML" not in sources
+        assert "Code" not in sources
+        assert not any("MDX_BLOCK" in source for source in sources)
+
+    def test_nested_jsx_html_comment_and_raw_html_are_not_code(self):
+        """Indented comments and raw HTML inside JSX children stay opaque."""
+        content = b"""<Outer>
+  <Inner>
+    <!--
+    <Card title="Draft" />
+    -->
+    <span>html</span>
+  </Inner>
+</Outer>
+
+After.
+"""
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "After." in sources
+        assert not any("Card" in source for source in sources)
+        assert not any("span" in source for source in sources)
+
+    def test_quoted_raw_html_blank_line_ends_block(self):
+        """Container-prefixed JSX attributes are not extracted."""
+        content = b"""> <span>
+> html
+>
+> <Badge label="New" />
+"""
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "New" not in sources
+
+    def test_jsx_in_script_after_blank_line_is_not_scanned(self):
+        """Script raw HTML blocks stay opaque across blank lines."""
+        content = b"""<script>
+
+<Card title="No" />
+</script>
+
+After.
+"""
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "No" not in sources
+        assert "After." in sources
+
+    def test_raw_html_child_does_not_keep_jsx_stack_open(self):
+        """Raw HTML inside JSX does not make following ESM translatable."""
+        content = b"""<Callout>
+  <span>html</span>
+</Callout>
+
+import { Thing } from './thing'
+
+After.
+"""
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "After." in sources
+        assert not any("import" in source for source in sources)
+
+    def test_indented_code_starting_with_jsx_is_not_scanned(self):
+        """Disabled indented code does not emit JSX attribute units."""
+        content = b"""    <Button label="Save" />
+
+After.
+"""
+        store = self.mdx2po(content, extract_code_blocks=False)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "Save" not in sources
+        assert "After." in sources
+
+    def test_no_code_blocks_preserves_jsx_child_indented_code(self):
+        """Indented code inside JSX children is not extracted when disabled."""
+        content = b"""<Callout>
+    const x = 1
+</Callout>
+
+After.
+"""
+        store = self.mdx2po(content, extract_code_blocks=False)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "const x = 1" not in sources
+        assert "After." in sources
+
+    def test_html_code_fence_does_not_affect_following_jsx(self):
+        """Raw HTML-looking code fence lines do not affect following JSX."""
+        content = b"""```html
+<div>
+```
+
+<Alert title="Hi" />
+
+After.
+"""
+        store = self.mdx2po(content, extract_code_blocks=False)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "Hi" in sources
+        assert "After." in sources
+
+    def test_nested_jsx_child_fence_is_opaque(self):
+        """Fenced code inside nested JSX children is not extracted."""
+        content = b"""<Steps>
+  <Step>
+    ```js
+    const x = 1
+    ```
+  </Step>
+</Steps>
+"""
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "const x = 1" not in sources
+        assert not any(source.startswith("```") for source in sources)
+
+    def test_translate_off_skips_jsx_attributes(self):
+        """translate:off regions are opaque before JSX attribute extraction."""
+        content = b"""<!-- translate:off -->
+<Card title="Do not translate">
+  Child
+</Card>
+<!-- translate:on -->
+
+After.
+"""
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "After." in sources
+        assert "Do not translate" not in sources
+        assert "Child" not in sources
+
+    def test_translate_off_text_is_not_control_comment(self):
+        """Literal mentions of translate:off remain translatable."""
+        content = b"""This paragraph mentions translate:off in prose.
+
+After.
+"""
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "This paragraph mentions translate:off in prose." in sources
+        assert "After." in sources
+
+    def test_jsx_like_text_in_link_metadata_is_not_protected(self):
+        """Markdown link metadata keeps JSX-looking literal text visible."""
+        content = b"""[text](https://example.com "<Title>")
+
+[<Bar>]: /url
+
+[text][<Bar>]
+"""
+        store = self.mdx2po(content)
+        sources = [unit.source for unit in store.units if unit.source]
+        assert "<Title>" in sources
+        assert "<Bar>" in sources
+        assert not any("MDX_BLOCK" in source for source in sources)
+
+    def test_merge_with_template(self):
+        """Merging a translated MDX with a template matches by docpath."""
+        template = b"""# Hello
+
+<Step title="Open" />
+
+World.
+"""
+        translated = b"""# Hallo
+
+<Step title="Ouvrir" />
+
+Welt.
+"""
+        store = self.mdx2po(translated, template)
+        units = {unit.source: unit.target for unit in store.units if unit.source}
+        assert units.get("Hello") == "Hallo"
+        assert units.get("Open") == "Ouvrir"
+        assert units.get("World.") == "Welt."
+
+    def test_merge_simple_component_children_with_template(self):
+        """Isolated child Markdown uses stable component docpaths."""
+        template = b"""<Callout title="Warning">
+  Source copy.
+</Callout>
+"""
+        translated = b"""<Callout title="Achtung">
+  Translated copy.
+</Callout>
+"""
+        store = self.mdx2po(translated, template)
+        units = {unit.source: unit.target for unit in store.units if unit.source}
+        assert units == {
+            "Warning": "Achtung",
+            "Source copy.": "Translated copy.",
+        }
+
+    def test_merge_attribute_positions_across_empty_value(self):
+        """Empty values still reserve their attribute docpath position."""
+        template = b'<Comp first="First" second="Second" />\n'
+        translated = b'<Comp first="" second="Deuxieme" />\n'
+        store = self.mdx2po(translated, template)
+        units = {unit.source: unit.target for unit in store.units if unit.source}
+        assert units.get("Second") == "Deuxieme"
 
     def test_complex_file(self):
-        """A realistic complex MDX file is correctly extracted."""
+        """A realistic MDX file extracts the supported subset."""
         content = b"""\
 ---
 title: Getting Started
@@ -200,89 +416,43 @@ sidebar_position: 1
 ---
 
 import { Callout, Steps } from '@docs/components'
-import DocImage from './assets/screenshot.png'
 
 export const toc = [{ value: 'Installation', id: 'installation', level: 2 }]
 
 # Getting Started
 
-Welcome to the **documentation**. Follow the steps below to get up and running.
+Welcome to the **documentation**.
 
-<Callout type="warning">
+<Callout type="warning" title="Warning">
   Make sure you have Node.js 18 or later installed before proceeding.
 </Callout>
 
 ## Installation
 
 <Steps>
-  <Steps.Step>
-
-Install the package:
-
-```bash
-npm install my-package
-```
-
-  </Steps.Step>
-  <Steps.Step>
-
-Configure your project by editing `my-package.config.js`:
-
-```js
-export default {
-  theme: 'light',
-}
-```
-
-  </Steps.Step>
+  <Step title="Install">
+    Install the package:
+  </Step>
 </Steps>
 
-{toc.map(item => <a key={item.id} href={`#${item.id}`}>{item.value}</a>)}
+{toc.map(item => <a key={item.id}>{item.value}</a>)}
 
-For more details, see the [API reference](/api) or open an [issue](https://github.com/example/repo/issues).
+For more details, see the [API reference](/api).
 """
         store = self.mdx2po(content)
-        sources = [u.source for u in store.units if u.source]
-
-        # Translatable prose is extracted
+        sources = [unit.source for unit in store.units if unit.source]
         assert "Getting Started" in sources
+        assert "Welcome to the **documentation**." in sources
+        assert "Warning" in sources
         assert (
-            "Welcome to the **documentation**. Follow the steps below to get up and running."
+            "Make sure you have Node.js 18 or later installed before proceeding."
             in sources
         )
         assert "Installation" in sources
-        # Prose inside JSX blocks is NOT extracted (the whole <Steps>…</Steps>
-        # block is protected as a single placeholder)
-        assert not any("Install the package" in s for s in sources)
-        assert not any("Configure your project" in s for s in sources)
-
-        # MDX-specific blocks are not extracted
-        assert not any("import" in s for s in sources)
-        assert not any("export" in s for s in sources)
-        assert not any("Callout" in s for s in sources)
-        assert not any("Steps" in s for s in sources)
-        assert not any("toc.map" in s for s in sources)
-        assert not any("MDX_BLOCK" in s for s in sources)
-
-    def test_merge_with_template(self):
-        """Merging a translated MDX with a template produces correctly merged PO."""
-        template = b"""# Hello
-
-World.
-"""
-        translated = b"""# Hallo
-
-Welt.
-"""
-        inputfile = BytesIO(translated)
-        templatefile = BytesIO(template)
-        outputfile = BytesIO()
-        parser = MDX2POOptionParser()
-        parser._extract_translation_units(
-            inputfile, outputfile, templatefile, "msgctxt", "single"
-        )
-        outputfile.seek(0)
-        store = po.pofile(outputfile)
-        units = {u.source: u.target for u in store.units if u.source}
-        assert units.get("Hello") == "Hallo"
-        assert units.get("World.") == "Welt."
+        assert "Install" not in sources
+        assert "Install the package:" not in sources
+        assert "For more details, see the {1} or open an {2}." not in sources
+        assert not any("import" in source for source in sources)
+        assert not any("export" in source for source in sources)
+        assert not any("toc.map" in source for source in sources)
+        assert not any("MDX_BLOCK" in source for source in sources)

--- a/tests/translate/convert/test_po2mdx.py
+++ b/tests/translate/convert/test_po2mdx.py
@@ -4,6 +4,7 @@ from io import BytesIO
 
 from translate.convert.po2mdx import MDXTranslator
 from translate.storage import po
+from translate.storage.mdxfile import MDXFile
 
 
 class TestPO2MDX:
@@ -18,6 +19,22 @@ class TestPO2MDX:
             unit.target = target
         return store
 
+    @classmethod
+    def translate(
+        cls, template: bytes, units: list[tuple[str, str]], **kwargs
+    ) -> bytes:
+        """Translate MDX bytes with a PO store."""
+        translator = MDXTranslator(
+            cls._make_po(units),
+            includefuzzy=False,
+            outputthreshold=None,
+            maxlength=0,
+            **kwargs,
+        )
+        outputfile = BytesIO()
+        translator.translate(BytesIO(template), outputfile)
+        return outputfile.getvalue()
+
     def test_basic_translation(self):
         """Basic MDX content is translated."""
         template = b"""import { Alert } from './Alert'
@@ -30,126 +47,173 @@ This is a paragraph.
 
 Another paragraph.
 """
-        postore = self._make_po(
+        output = self.translate(
+            template,
             [
-                ("Welcome", "Bienvenido"),
-                ("This is a paragraph.", "Este es un parrafo."),
-                ("Another paragraph.", "Otro parrafo."),
-            ]
-        )
-        translator = MDXTranslator(
-            postore,
-            includefuzzy=False,
-            outputthreshold=None,
-            maxlength=0,
-        )
-        outputfile = BytesIO()
-        translator.translate(BytesIO(template), outputfile)
-        output = outputfile.getvalue().decode()
+                ("Welcome", "Welcome translated"),
+                ("This is a paragraph.", "Paragraph translated."),
+                ("Another paragraph.", "Another paragraph translated."),
+            ],
+        ).decode()
         assert "import { Alert } from './Alert'" in output
-        assert "# Bienvenido" in output
-        assert "Este es un parrafo." in output
+        assert "# Welcome translated" in output
+        assert "Paragraph translated." in output
         assert '<Alert type="info" />' in output
-        assert "Otro parrafo." in output
+        assert "Another paragraph translated." in output
 
-    def test_jsx_block_preserved_in_translation(self):
-        """JSX block components are preserved during translation."""
+    def test_standalone_jsx_block_children_and_attrs_translate(self):
+        """Standalone JSX tag attrs and child Markdown are translated."""
         template = b"""# Title
 
-<Tabs>
-  <Tab label="One">
-    Tab content
-  </Tab>
-</Tabs>
+<Tab label="One">
+  Tab content
+</Tab>
 
 After tabs.
 """
-        postore = self._make_po(
+        output = self.translate(
+            template,
             [
-                ("Title", "Titulo"),
-                ("After tabs.", "Despues de tabs."),
-            ]
-        )
-        translator = MDXTranslator(
-            postore,
-            includefuzzy=False,
-            outputthreshold=None,
-            maxlength=0,
-        )
-        outputfile = BytesIO()
-        translator.translate(BytesIO(template), outputfile)
-        output = outputfile.getvalue().decode()
-        assert "# Titulo" in output
-        assert "<Tabs>" in output
-        assert "</Tabs>" in output
-        assert "Tab content" in output
-        assert "Despues de tabs." in output
+                ("Title", "Title translated"),
+                ("One", "One translated"),
+                ("Tab content", "Tab content translated"),
+                ("After tabs.", "After tabs translated."),
+            ],
+        ).decode()
+        assert "# Title translated" in output
+        assert '<Tab label="One translated">' in output
+        assert "Tab content translated" in output
+        assert "</Tab>" in output
+        assert "After tabs translated." in output
 
-    def test_untranslated_units_use_source(self):
-        """Untranslated units fall back to source text."""
-        template = b"""# Hello
+    def test_inline_jsx_attribute_translation_is_not_applied(self):
+        """Inline MDX component attributes in Markdown are not translated."""
+        template = b'See <Badge label="New" /> now.\n'
+        output = self.translate(template, [("New", "New translated")])
+        assert output == template
 
-World.
+    def test_inline_jsx_expression_prop_attribute_translation_is_not_applied(self):
+        """Expression props do not make inline JSX attributes translatable."""
+        template = b'Click <Button label="Save" icon={Icon} /> now.\n'
+        output = self.translate(template, [("Save", "Save translated")])
+        assert output == template
+
+    def test_no_placeholders_inline_jsx_uses_paragraph_lookup(self):
+        """Soft-wrapped inline JSX keeps no-placeholders paragraph context."""
+        template = b"""This is
+inline <Badge label="New" />
+paragraph.
 """
-        postore = self._make_po([("Hello", "Hola")])
-        translator = MDXTranslator(
-            postore,
-            includefuzzy=False,
-            outputthreshold=None,
-            maxlength=0,
+        source = (
+            MDXFile(inputfile=BytesIO(template), no_placeholders=True).units[0].source
         )
-        outputfile = BytesIO()
-        translator.translate(BytesIO(template), outputfile)
-        output = outputfile.getvalue().decode()
-        assert "# Hola" in output
-        assert "World." in output  # untranslated, kept as source
+        output = self.translate(
+            template,
+            [
+                (
+                    source,
+                    'Translated <Badge label="New translated" /> paragraph.',
+                )
+            ],
+            no_placeholders=True,
+        )
+        assert output == b'Translated <Badge label="New translated" /> paragraph.\n'
 
-    def test_export_preserved(self):
-        """Export statements are preserved in output."""
-        template = b"""export const meta = { title: 'Test' }
+    def test_no_placeholders_inline_jsx_attribute_fallback_is_not_applied(self):
+        """Attr-only translations do not apply to inline JSX."""
+        template = b'See <Badge label="New" /> now.\n'
+        output = self.translate(
+            template,
+            [("New", "New translated")],
+            no_placeholders=True,
+        )
+        assert output == template
 
-# Heading
+    def test_no_placeholders_inline_code_is_not_attr_fallback(self):
+        """Attr-only translations do not rewrite JSX-looking inline code."""
+        template = b'Use `<Badge label="New" />` literally.\n'
+        output = self.translate(
+            template,
+            [("New", "New translated")],
+            no_placeholders=True,
+        )
+        assert output == template
+
+    def test_no_placeholders_raw_html_is_not_attr_fallback(self):
+        """Attr-only translations do not rewrite JSX-looking raw HTML."""
+        template = b"Text <span title=\"<Card title='No' />\">hello</span>\n"
+        output = self.translate(
+            template,
+            [("No", "No translated")],
+            no_placeholders=True,
+        )
+        assert output == template
+
+    def test_same_line_jsx_children_are_opaque(self):
+        """Same-line JSX child text is not translated by the limited parser."""
+        template = b"<Callout>Text</Callout>\n\nAfter.\n"
+        output = self.translate(
+            template,
+            [("Text", "Changed"), ("After.", "After translated.")],
+        ).decode()
+        assert "<Callout>Text</Callout>" in output
+        assert "Changed" not in output
+        assert "After translated." in output
+
+    def test_inline_jsx_expression_prop_children_are_opaque(self):
+        """Same-line JSX children with expression props are not translated."""
+        template = b"Text <Callout kind={kind}>Child</Callout>\n\nAfter.\n"
+        output = self.translate(
+            template,
+            [("Child", "Child translated"), ("After.", "After translated.")],
+        ).decode()
+        assert "Child translated" not in output
+        assert "Text <Callout kind={kind}>Child</Callout>" in output
+        assert "After translated." in output
+
+    def test_nested_unsupported_jsx_block_children_are_opaque(self):
+        """Nested same-name JSX in unsupported blocks is not translated."""
+        template = b"""<Callout>Intro
+<Callout>Inner</Callout>
+More text
+</Callout>
+
+After.
 """
-        postore = self._make_po([("Heading", "Encabezado")])
-        translator = MDXTranslator(
-            postore,
-            includefuzzy=False,
-            outputthreshold=None,
-            maxlength=0,
-        )
-        outputfile = BytesIO()
-        translator.translate(BytesIO(template), outputfile)
-        output = outputfile.getvalue().decode()
-        assert "export const meta = { title: 'Test' }" in output
-        assert "# Encabezado" in output
+        output = self.translate(
+            template,
+            [
+                ("Intro", "Intro translated"),
+                ("Inner", "Inner translated"),
+                ("More text", "More translated"),
+                ("After.", "After translated."),
+            ],
+        ).decode()
+        assert "Intro translated" not in output
+        assert "Inner translated" not in output
+        assert "More translated" not in output
+        assert "More text" in output
+        assert "After translated." in output
 
-    def test_multiline_import_preserved(self):
-        """Multi-line import statements are preserved in output."""
-        template = b"""import {
-  Alert,
-  Button,
-} from './components'
+    def test_same_line_jsx_attributes_are_not_translated(self):
+        """Same-line opaque JSX does not translate simple attrs."""
+        template = b'<Callout title="Open">Text</Callout>\n'
+        output = self.translate(template, [("Open", "Open translated")])
+        assert output == template
 
-# Title
-
-Text.
+    def test_multiline_standalone_opening_tag_is_opaque(self):
+        """Multiline standalone tags are preserved without partial translation."""
+        template = b"""<Callout
+  title="Open"
+>
+  Copy
+</Callout>
 """
-        postore = self._make_po(
-            [("Title", "Titel"), ("Text.", "Text.")]  # codespell:ignore
-        )
-        translator = MDXTranslator(
-            postore,
-            includefuzzy=False,
-            outputthreshold=None,
-            maxlength=0,
-        )
-        outputfile = BytesIO()
-        translator.translate(BytesIO(template), outputfile)
-        output = outputfile.getvalue().decode()
-        assert "import {" in output
-        assert "Alert," in output
-        assert "} from './components'" in output
-        assert "# Titel" in output  # codespell:ignore
+        output = self.translate(
+            template,
+            [("Open", "Open translated"), ("Copy", "Copy translated")],
+        ).decode()
+        assert output == template.decode()
 
     def test_jsx_expression_block_preserved(self):
         """Standalone JSX expression blocks are preserved."""
@@ -159,32 +223,237 @@ Text.
 
 Text.
 """
-        postore = self._make_po([("Title", "Titulo"), ("Text.", "Texto.")])
-        translator = MDXTranslator(
-            postore,
-            includefuzzy=False,
-            outputthreshold=None,
-            maxlength=0,
-        )
-        outputfile = BytesIO()
-        translator.translate(BytesIO(template), outputfile)
-        output = outputfile.getvalue().decode()
+        output = self.translate(
+            template,
+            [("Title", "Title translated"), ("Text.", "Text translated.")],
+        ).decode()
         assert "{someVariable}" in output
-        assert "# Titulo" in output
-        assert "Texto." in output
+        assert "# Title translated" in output
+        assert "Text translated." in output
 
-    def test_fuzzy_unit_skipped_without_flag(self):
-        """Fuzzy units are not used when includefuzzy=False."""
+    def test_multiline_inline_expression_is_not_translated_as_jsx(self):
+        """Component-looking code inside multiline inline expressions is opaque."""
+        template = b"""Before {items.map(
+  item => <Card title="No" />
+)} after.
+
+After.
+"""
+        output = self.translate(
+            template,
+            [("No", "No translated"), ("After.", "After translated.")],
+        ).decode()
+        assert '<Card title="No" />' in output
+        assert "No translated" not in output
+        assert "After translated." in output
+
+    def test_translate_off_region_is_opaque(self):
+        """translate:off regions are not changed by JSX preprocessing."""
+        template = b"""<!-- translate:off -->
+<Card title="Do not translate">
+  Child
+</Card>
+<!-- translate:on -->
+
+After.
+"""
+        output = self.translate(
+            template,
+            [
+                ("Do not translate", "Translated"),
+                ("Child", "Translated"),
+                ("After.", "After translated."),
+            ],
+        ).decode()
+        assert 'title="Do not translate"' in output
+        assert "\n  Child\n" in output
+        assert "After translated." in output
+
+    def test_no_code_blocks_preserves_indented_code_with_inline_jsx(self):
+        """Inline JSX inside disabled code extraction is not translated."""
+        template = b"""    const button = <Button label="Save" />;
+
+After.
+"""
+        output = self.translate(
+            template,
+            [("Save", "Save translated"), ("After.", "After translated.")],
+            extract_code_blocks=False,
+        )
+        assert b'<Button label="Save" />' in output
+        assert b"Save translated" not in output
+        assert b"After translated." in output
+
+    def test_no_code_blocks_preserves_indented_code_starting_with_jsx(self):
+        """Line-start JSX inside disabled indented code is not translated."""
+        template = b"""    <Button label="Save" />
+
+After.
+"""
+        output = self.translate(
+            template,
+            [("Save", "Save translated"), ("After.", "After translated.")],
+            extract_code_blocks=False,
+        )
+        assert b'<Button label="Save" />' in output
+        assert b"Save translated" not in output
+        assert b"After translated." in output
+
+    def test_no_code_blocks_preserves_jsx_child_indented_code(self):
+        """Indented code inside JSX children stays opaque when code is disabled."""
+        template = b"""<Callout>
+    const x = 1
+</Callout>
+
+After.
+"""
+        output = self.translate(
+            template,
+            [("const x = 1", "const y = 2"), ("After.", "After translated.")],
+            extract_code_blocks=False,
+        )
+        assert b"\n    const x = 1\n" in output
+        assert b"const y = 2" not in output
+        assert b"After translated." in output
+
+    def test_nested_jsx_child_fence_is_opaque(self):
+        """Fenced code inside nested JSX children is preserved."""
+        template = b"""<Steps>
+  <Step>
+    ```js
+    const x = 1
+    ```
+  </Step>
+</Steps>
+"""
+        output = self.translate(template, [("const x = 1", "const y = 2")]).decode()
+        assert "const y = 2" not in output
+        assert "const x = 1" in output
+        assert "```js" in output
+
+    def test_raw_html_attribute_with_jsx_like_text_is_not_translated(self):
+        """JSX-looking text in raw HTML is not translated as JSX."""
+        template = b"""Text <span title="<Card title='No' />">hello</span>
+
+After.
+"""
+        output = self.translate(
+            template,
+            [("No", "No translated"), ("After.", "After translated.")],
+        ).decode()
+        assert "<Card title='No' />" in output
+        assert "No translated" not in output
+        assert "After translated." in output
+
+    def test_nested_jsx_html_comment_and_raw_html_are_not_code(self):
+        """Indented comments and raw HTML inside JSX children stay opaque."""
+        template = b"""<Outer>
+  <Inner>
+    <!--
+    <Card title="Draft" />
+    -->
+    <span>html</span>
+  </Inner>
+</Outer>
+
+After.
+"""
+        output = self.translate(
+            template,
+            [
+                ('<Card title="Draft" />', "Changed card"),
+                ("<span>html</span>", "Changed span"),
+                ("After.", "After translated."),
+            ],
+        ).decode()
+        assert '    <Card title="Draft" />' in output
+        assert "    <span>html</span>" in output
+        assert "Changed card" not in output
+        assert "Changed span" not in output
+        assert "After translated." in output
+
+    def test_script_after_blank_line_with_jsx_like_text_is_not_translated(self):
+        """Script raw HTML blocks remain opaque across blank lines."""
+        template = b"""<script>
+
+<Card title="No" />
+</script>
+
+After.
+"""
+        output = self.translate(
+            template,
+            [("No", "No translated"), ("After.", "After translated.")],
+        ).decode()
+        assert '<Card title="No" />' in output
+        assert "No translated" not in output
+        assert "After translated." in output
+
+    def test_raw_html_child_does_not_keep_jsx_stack_open(self):
+        """Raw HTML inside JSX does not make following ESM translatable."""
+        template = b"""<Callout>
+  <span>html</span>
+</Callout>
+
+import { Thing } from './thing'
+
+After.
+"""
+        output = self.translate(
+            template,
+            [
+                ("import { Thing } from './thing'", "changed import"),
+                ("After.", "After translated."),
+            ],
+        ).decode()
+        assert "import { Thing } from './thing'" in output
+        assert "changed import" not in output
+        assert "After translated." in output
+
+    def test_link_metadata_with_jsx_like_text_is_not_translated(self):
+        """JSX-looking text in Markdown link metadata is not translated as JSX."""
+        template = b"""[text](https://example.com "<Title>")
+
+[<Bar>]: /url
+
+[text][<Bar>]
+"""
+        output = self.translate(
+            template,
+            [("<Title>", "Title translated"), ("<Bar>", "Bar translated")],
+        ).decode()
+        assert "Title translated" in output
+        assert "Bar translated" in output
+        assert "MDX_BLOCK" not in output
+
+    def test_attribute_backslashes_preserved(self):
+        """Untranslated JSX attributes keep existing backslashes."""
+        template = b'<Comp path="C:\\\\tmp" />\n'
+        assert self.translate(template, []) == template
+
+    def test_attribute_escaped_quotes_preserved(self):
+        """Untranslated JSX attributes keep existing escaped quotes."""
+        template = b'<Comp title="A \\"quote\\"" />\n'
+        assert self.translate(template, []) == template
+
+    def test_untranslated_units_use_source(self):
+        """Untranslated units fall back to source text."""
         template = b"""# Hello
 
 World.
 """
+        output = self.translate(template, [("Hello", "Hello translated")]).decode()
+        assert "# Hello translated" in output
+        assert "World." in output
+
+    def test_fuzzy_unit_skipped_without_flag(self):
+        """Fuzzy units are not used when includefuzzy=False."""
         store = po.pofile()
         unit = store.addsourceunit("Hello")
-        unit.target = "Hola"
+        unit.target = "Hello translated"
         unit.markfuzzy(True)
         unit2 = store.addsourceunit("World.")
-        unit2.target = "Mundo."
+        unit2.target = "World translated."
 
         translator = MDXTranslator(
             store,
@@ -193,24 +462,17 @@ World.
             maxlength=0,
         )
         outputfile = BytesIO()
-        translator.translate(BytesIO(template), outputfile)
+        translator.translate(BytesIO(b"# Hello\n\nWorld.\n"), outputfile)
         output = outputfile.getvalue().decode()
-        # Fuzzy unit falls back to source
         assert "# Hello" in output
-        assert "Mundo." in output
+        assert "World translated." in output
 
     def test_fuzzy_unit_used_with_flag(self):
         """Fuzzy units are used when includefuzzy=True."""
-        template = b"""# Hello
-
-World.
-"""
         store = po.pofile()
         unit = store.addsourceunit("Hello")
-        unit.target = "Hola"
+        unit.target = "Hello translated"
         unit.markfuzzy(True)
-        unit2 = store.addsourceunit("World.")
-        unit2.target = "Mundo."
 
         translator = MDXTranslator(
             store,
@@ -219,118 +481,5 @@ World.
             maxlength=0,
         )
         outputfile = BytesIO()
-        translator.translate(BytesIO(template), outputfile)
-        output = outputfile.getvalue().decode()
-        assert "# Hola" in output
-        assert "Mundo." in output
-
-    def test_complex_file(self):
-        """A realistic complex MDX file is correctly translated end-to-end."""
-        template = b"""\
----
-title: Getting Started
-sidebar_position: 1
----
-
-import { Callout, Steps } from '@docs/components'
-import DocImage from './assets/screenshot.png'
-
-export const toc = [{ value: 'Installation', id: 'installation', level: 2 }]
-
-# Getting Started
-
-Welcome to the **documentation**. Follow the steps below to get up and running.
-
-<Callout type="warning">
-  Make sure you have Node.js 18 or later installed before proceeding.
-</Callout>
-
-## Installation
-
-<Steps>
-  <Steps.Step>
-
-Install the package:
-
-```bash
-npm install my-package
-```
-
-  </Steps.Step>
-  <Steps.Step>
-
-Configure your project by editing `my-package.config.js`:
-
-  </Steps.Step>
-</Steps>
-
-{toc.map(item => <a key={item.id} href={`#${item.id}`}>{item.value}</a>)}
-
-For more details, see the [API reference](/api).
-"""
-        postore = self._make_po(
-            [
-                ("Getting Started", "Erste Schritte"),
-                (
-                    "Welcome to the **documentation**. Follow the steps below to get up and running.",
-                    "Willkommen in der **Dokumentation**. Folge den Schritten, um loszulegen.",
-                ),
-                ("Installation", "Installation"),
-            ]
-        )
-        translator = MDXTranslator(
-            postore,
-            includefuzzy=False,
-            outputthreshold=None,
-            maxlength=0,
-        )
-        outputfile = BytesIO()
-        translator.translate(BytesIO(template), outputfile)
-        output = outputfile.getvalue().decode()
-
-        # Translated prose appears
-        assert "# Erste Schritte" in output
-        assert "Willkommen in der **Dokumentation**" in output
-        assert "## Installation" in output
-        # Prose inside <Steps> is not translated (whole block is a JSX placeholder)
-        assert "Install the package:" in output
-        assert "Configure your project" in output
-
-        # MDX structure is preserved verbatim
-        assert "import { Callout, Steps } from '@docs/components'" in output
-        assert "import DocImage from './assets/screenshot.png'" in output
-        assert "export const toc" in output
-        assert '<Callout type="warning">' in output
-        assert "</Callout>" in output
-        assert "<Steps>" in output
-        assert "</Steps>" in output
-        assert "toc.map" in output
-        assert "npm install my-package" in output
-
-    def test_no_placeholders_mode(self):
-        """no_placeholders mode preserves inline content verbatim."""
-        template = b"""# Title
-
-Check [the docs](https://example.com) for details.
-"""
-        postore = self._make_po(
-            [
-                ("Title", "Titel"),  # codespell:ignore
-                (
-                    "Check [the docs](https://example.com) for details.",
-                    "Bitte [die Docs](https://example.com) prüfen.",
-                ),
-            ]
-        )
-        translator = MDXTranslator(
-            postore,
-            includefuzzy=False,
-            outputthreshold=None,
-            maxlength=0,
-            no_placeholders=True,
-        )
-        outputfile = BytesIO()
-        translator.translate(BytesIO(template), outputfile)
-        output = outputfile.getvalue().decode()
-        assert "Bitte" in output
-        assert "Docs" in output
+        translator.translate(BytesIO(b"# Hello\n"), outputfile)
+        assert b"# Hello translated" in outputfile.getvalue()

--- a/tests/translate/storage/test_mdxfile.py
+++ b/tests/translate/storage/test_mdxfile.py
@@ -1,672 +1,623 @@
-"""Tests for MDX file storage."""
+"""Tests for the deliberately limited MDX storage contract."""
 
 from io import BytesIO
+
+import pytest
 
 from translate.storage.mdxfile import MDXFile
 
 
-class TestMDXFileParsing:
-    """Test extraction of translation units from MDX files."""
+def mdx_store(content: bytes, **kwargs) -> MDXFile:
+    """Parse MDX bytes and return the storage object."""
+    return MDXFile(inputfile=BytesIO(content), **kwargs)
+
+
+def sources(store: MDXFile) -> list[str]:
+    """Return source strings from all extracted units."""
+    return [str(unit.source) for unit in store.units]
+
+
+class TestSupportedSubset:
+    """Extraction supported without parsing JSX or JavaScript."""
 
     def test_plain_markdown(self):
-        """Plain markdown content is extracted normally."""
-        content = b"# Hello World\n\nThis is a paragraph.\n"
-        store = MDXFile(inputfile=BytesIO(content))
-        units = store.units
-        assert len(units) == 2
-        assert units[0].source == "Hello World"
-        assert units[1].source == "This is a paragraph."
+        store = mdx_store(b"# Hello World\n\nThis is a paragraph.\n")
+        assert sources(store) == ["Hello World", "This is a paragraph."]
 
-    def test_import_statements_preserved(self):
-        """Import statements are not extracted for translation."""
-        content = b"""import { Component } from './Component'
-import styles from './styles.module.css'
-
-# Title
-
-Some content here.
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Title" in sources
-        assert "Some content here." in sources
-        # imports should not appear as translation units
-        assert not any("import" in s for s in sources)
-
-    def test_export_statements_preserved(self):
-        """Export statements are not extracted for translation."""
-        content = b"""export const meta = { title: 'My Page' }
-
-# Title
-
-Paragraph text.
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Title" in sources
-        assert "Paragraph text." in sources
-        assert not any("export" in s for s in sources)
-
-    def test_jsx_self_closing_component(self):
-        """Self-closing JSX components are preserved."""
-        content = b"""# Title
-
-<MyComponent prop="value" />
-
-More text here.
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Title" in sources
-        assert "More text here." in sources
-        assert not any("MyComponent" in s for s in sources)
-
-    def test_jsx_block_component(self):
-        """Block JSX components with children are preserved."""
-        content = b"""# Title
-
-<Tabs>
-  <Tab label="First">
-    Content in tab
-  </Tab>
-  <Tab label="Second">
-    More content
-  </Tab>
-</Tabs>
-
-Text after component.
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Title" in sources
-        assert "Text after component." in sources
-        assert not any("Tabs" in s for s in sources)
-        assert not any("Content in tab" in s for s in sources)
-
-    def test_jsx_expression_block(self):
-        """JSX expression blocks are preserved."""
-        content = b"""# Title
-
-{/* This is a comment */}
-
-Paragraph after expression.
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Title" in sources
-        assert "Paragraph after expression." in sources
-        assert not any("comment" in s for s in sources)
-
-    def test_multiline_import(self):
-        """Multi-line imports are properly handled."""
+    def test_top_level_esm_is_opaque(self):
         content = b"""import {
-  Component1,
-  Component2,
-  Component3
+  Alert,
+  Button,
 } from './components'
+export const metadata = {title: 'Example'}
 
-# Hello
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Hello" in sources
-        assert not any("Component" in s for s in sources)
-
-    def test_mdx_roundtrip(self):
-        """MDX content is preserved during roundtrip."""
-        content = b"""import { Alert } from './Alert'
-
-# Welcome
-
-This is the intro.
-
-<Alert type="warning">
-  Be careful!
-</Alert>
-
-## Next Section
-
-More content.
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        output = store.filesrc
-        # The import and JSX should be preserved in output
-        assert "import { Alert } from './Alert'" in output
-        assert '<Alert type="warning">' in output
-        assert "Be careful!" in output
-        assert "</Alert>" in output
-
-    def test_frontmatter_with_mdx(self):
-        """Front matter is extracted along with MDX content."""
-        content = b"""---
-title: My Page
----
-
-import { Component } from './Component'
-
-# Hello
-
-World.
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        # Front matter should be extracted
-        assert any("title: My Page" in s for s in sources)
-        assert "Hello" in sources
-        assert "World." in sources
-
-    def test_markdown_between_components(self):
-        """Markdown between JSX components is extracted."""
-        content = b"""<Header />
-
-# Introduction
-
-First paragraph.
-
-<Divider />
-
-Second paragraph.
-
-<Footer />
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Introduction" in sources
-        assert "First paragraph." in sources
-        assert "Second paragraph." in sources
-
-    def test_translation_callback(self):
-        """Translation callback works with MDX files."""
-
-        def translate(text):
-            translations = {
-                "Hello": "Hola",
-                "World": "Mundo",
-            }
-            return translations.get(text, text)
-
-        content = b"""import { Box } from './Box'
-
-# Hello
-
-World
-"""
-        store = MDXFile(inputfile=BytesIO(content), callback=translate)
-        output = store.filesrc
-        assert "# Hola" in output
-        assert "Mundo" in output
-        assert "import { Box } from './Box'" in output
-
-
-class TestMDXEdgeCases:
-    """Edge cases in MDX JSX parsing."""
-
-    def test_nested_same_name_components(self):
-        """Nested components with same name are handled correctly."""
-        content = b"""# Title
-
-<Card>
-  <Card>
-    Inner
-  </Card>
-</Card>
-
-After.
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Title" in sources
-        assert "After." in sources
-        # None of the JSX block content should be extracted
-        assert not any("Inner" in s for s in sources)
-        assert not any("Card" in s for s in sources)
-        # The entire nested structure must be preserved verbatim in output
-        assert "<Card>\n  <Card>\n    Inner\n  </Card>\n</Card>" in store.filesrc
-        # Verify the outer Card consumed both open/close (depth returned to 0)
-        # by checking content after it is still present and not swallowed
-        assert store.filesrc.index("After.") > store.filesrc.index("</Card>")
-
-    def test_self_closing_inside_block(self):
-        """Self-closing tags inside block components don't break depth tracking."""
-        content = b"""# Title
-
-<Layout>
-  <Sidebar />
-  <Main />
-</Layout>
-
-Text.
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Title" in sources
-        assert "Text." in sources
-        assert not any("Sidebar" in s for s in sources)
-        assert "<Layout>" in store.filesrc
-        assert "</Layout>" in store.filesrc
-
-    def test_braces_in_jsx_strings(self):
-        """Braces inside JSX string props don't break parsing."""
-        content = b"""# Title
-
-<Component label="value with {braces}" />
+# Heading
 
 Paragraph.
 """
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Title" in sources
-        assert "Paragraph." in sources
-        assert not any("Component" in s for s in sources)
+        store = mdx_store(content)
+        assert sources(store) == ["Heading", "Paragraph."]
+        assert store.filesrc == content.decode()
 
-    def test_multiline_jsx_expression(self):
-        """Multi-line JSX expressions are protected."""
-        content = b"""# Title
+    def test_default_plus_namespace_import_is_opaque(self):
+        content = b"""import React, * as ReactDOM from 'react-dom'
 
-{items.map((item) => (
-  <li key={item.id}>{item.name}</li>
-))}
-
-After list.
+# Heading
 """
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Title" in sources
-        assert "After list." in sources
-        assert not any("items.map" in s for s in sources)
+        store = mdx_store(content)
+        assert sources(store) == ["Heading"]
+        assert store.filesrc == content.decode()
 
-    def test_component_with_jsx_props(self):
-        """Components with JSX expression props are handled."""
-        content = b"""# Title
+    def test_prose_starting_with_import_is_markdown(self):
+        store = mdx_store(b"import taxes before submitting the form.\n")
+        assert sources(store) == ["import taxes before submitting the form."]
 
-<Button onClick={() => alert('hi')} disabled={true} />
+    def test_self_closing_component_attribute(self):
+        content = b'<Step title="Open" optional />\n'
+        store = mdx_store(
+            content,
+            callback=lambda text: "Open translated" if text == "Open" else text,
+        )
+        assert sources(store) == ["Open"]
+        assert store.filesrc == '<Step title="Open translated" optional />\n'
+        assert store.units[0].getdocpath() == "jsx-attr[1]/Step.@title"
 
-Text.
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Title" in sources
-        assert "Text." in sources
-        assert not any("Button" in s for s in sources)
+    def test_simple_component_children_are_isolated_markdown(self):
+        content = b"""# Heading
 
-    def test_inline_jsx_not_on_own_line(self):
-        """Inline JSX within markdown paragraphs is passed through to markdown parser."""
-        content = b"""# Title
+<Callout title="Warning">
+  Text with **Markdown**.
 
-This has <em>emphasis</em> in it.
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Title" in sources
-        assert any("emphasis" in s for s in sources)
-
-    def test_export_default_function(self):
-        """Export default with multi-line function is protected."""
-        content = b"""export default function Layout({
-  children
-}) {
-  return <div>{children}</div>
-}
-
-# Page Title
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Page Title" in sources
-        assert not any("children" in s for s in sources)
-        assert "export default function Layout" in store.filesrc
-
-    def test_mixed_markdown_and_jsx(self):
-        """Complex interleaving of markdown and JSX."""
-        content = b"""import { Callout } from './Callout'
-
-# Getting Started
-
-Welcome to the tutorial.
-
-<Callout type="tip">
-  Remember this!
+  - First line
+    continued
 </Callout>
 
-## Step 1
-
-Do the first thing.
-
-<CodeExample />
-
-## Step 2
-
-Do the second thing.
+After.
 """
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Getting Started" in sources
-        assert "Welcome to the tutorial." in sources
-        assert "Step 1" in sources
-        assert "Do the first thing." in sources
-        assert "Step 2" in sources
-        assert "Do the second thing." in sources
-        assert not any("Callout" in s for s in sources)
-        assert not any("CodeExample" in s for s in sources)
-        assert not any("import" in s for s in sources)
+        translations = {
+            "Warning": "Warning translated",
+            "Text with **Markdown**.": "Translated **Markdown**.",
+            "First line continued": "Translated list item",
+        }
+        store = mdx_store(content, callback=lambda text: translations.get(text, text))
 
-    def test_paragraph_starting_with_import_word(self):
-        """A paragraph starting with 'import' is not treated as an import statement."""
-        content = b"""# Trade
+        assert sources(store) == [
+            "Heading",
+            "Warning",
+            "Text with **Markdown**.",
+            "First line continued",
+            "After.",
+        ]
+        assert '<Callout title="Warning translated">' in store.filesrc
+        assert "  Translated **Markdown**." in store.filesrc
+        assert "  - Translated list item" in store.filesrc
+        assert store.filesrc.endswith("\nAfter.\n")
 
-import duties have increased significantly this year.
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        assert "Trade" in sources
-        assert any("import duties" in s for s in sources)
-
-    def test_unclosed_jsx_block_does_not_swallow_remaining_content(self):
-        """An unclosed JSX tag does not consume all remaining content."""
-        content = b"""<Card>
-  inner
-
-# After
-"""
-        store = MDXFile(inputfile=BytesIO(content))
-        sources = [u.source for u in store.units]
-        # "After" must still be extracted despite the unclosed <Card>
-        assert "After" in sources
-
-
-class TestMakePlaceholder:
-    """Unit tests for MDXFile._make_placeholder indentation and line-count behaviour."""
-
-    def _store(self) -> MDXFile:
-        """Return a freshly initialised (empty) store."""
-        store = MDXFile()
-        store._mdx_block_counter = 0
-        store._mdx_blocks = {}
-        return store
-
-    def test_no_indent_single_line(self):
-        """A single-line block with no indentation produces a single-line placeholder."""
-        store = self._store()
-        content = "<Button />"
-        ph = store._make_placeholder(content)
-        assert ph == "<!-- MDX_BLOCK_1 -->"
-        assert "\n" not in ph
-
-    def test_leading_spaces_preserved(self):
-        """Leading spaces on the first content line are preserved after restoration."""
-        store = self._store()
-        content = "  <Card>\n  inner\n  </Card>"
-        store._make_placeholder(content)
-        key = "<!-- MDX_BLOCK_1 -->"
-        # The placeholder itself does NOT carry indentation (the renderer may
-        # change it); indentation is recovered from the stored content.
-        restored = store._restore_mdx_blocks(key)
-        assert restored.startswith("  <Card>")
-
-    def test_leading_tab_preserved(self):
-        """A leading tab on the first content line is kept after restoration."""
-        store = self._store()
-        content = "\t<Component />"
-        store._make_placeholder(content)
-        key = "<!-- MDX_BLOCK_1 -->"
-        restored = store._restore_mdx_blocks(key)
-        assert restored.startswith("\t<Component />")
-
-    def test_line_count_matches_original_single_line(self):
-        """A single-line block (no newlines) produces a placeholder with no trailing newlines."""
-        store = self._store()
-        content = "<Foo />"
-        ph = store._make_placeholder(content)
-        assert ph.count("\n") == 0
-
-    def test_line_count_matches_original_multiline(self):
-        """A multi-line block produces a placeholder with the same number of newlines."""
-        store = self._store()
-        content = "<Alert>\n  This is important.\n</Alert>"  # 2 newlines
-        ph = store._make_placeholder(content)
-        assert ph.count("\n") == 2
-
-    def test_line_count_matches_four_lines(self):
-        """Placeholder newline count equals the original block's newline count."""
-        store = self._store()
-        content = "line1\nline2\nline3\nline4"  # 3 newlines
-        ph = store._make_placeholder(content)
-        assert ph.count("\n") == 3
-
-    def test_key_stored_for_restoration(self):
-        """The block content is stored under the bare key (no indent)."""
-        store = self._store()
-        content = "<Widget prop='x' />"
-        store._make_placeholder(content)
-        key = "<!-- MDX_BLOCK_1 -->"
-        assert key in store._mdx_blocks
-        stored_content, _ = store._mdx_blocks[key]
-        assert stored_content == content
-
-    def test_counter_increments(self):
-        """Each call produces a unique, sequentially numbered key."""
-        store = self._store()
-        ph1 = store._make_placeholder("<A />")
-        ph2 = store._make_placeholder("<B />")
-        assert "MDX_BLOCK_1" in ph1
-        assert "MDX_BLOCK_2" in ph2
-
-    def test_indented_block_roundtrip(self):
-        """
-        An indented JSX block is protected and restored without losing indentation
-        and without extra blank lines being inserted (regression for the padding
-        newline double-count bug).
-        """
-        raw = "# Title\n\n  <Card>\n    Some nested content.\n  </Card>\n\nParagraph after.\n"
-        content = raw.encode()
-        store = MDXFile(inputfile=BytesIO(content))
-        # The serialised source must be byte-for-byte identical to the input.
-        assert store.filesrc == raw
-        # Normal translatable content must still be extracted.
-        sources = [u.source for u in store.units]
-        assert "Title" in sources
-        assert "Paragraph after." in sources
-
-    def test_multiline_indented_block_line_numbers(self):
-        """
-        The placeholder occupies the same number of lines as the original block,
-        so the line offset of content following the block is unchanged.
-
-        File layout (1-indexed):
-            1: # Heading
-            2: (blank)
-            3: <Card>
-            4:   Body
-            5: </Card>
-            6: (blank)
-            7: Trailing paragraph.
-        """
-        content = b"# Heading\n\n<Card>\n  Body\n</Card>\n\nTrailing paragraph.\n"
-        store = MDXFile(inputfile=BytesIO(content))
-        # Locate the "Trailing paragraph." unit and verify its line reference.
-        trailing = next(u for u in store.units if u.source == "Trailing paragraph.")
-        locations = trailing.getlocations()
-        assert locations, "unit must have at least one location"
-        # Location format is "filename:lineno"; take the last colon-separated part.
-        location_line = int(locations[0].rsplit(":", 1)[-1])
-        assert location_line == 7
-
-
-class TestCodeFenceBehaviour:
-    """
-    Tests for code-fence tracking in _protect_mdx_blocks.
-
-    CommonMark §4.5 rules exercised here:
-    - Closing fence must use the same character as the opener.
-    - Closing fence must be at least as long as the opener.
-    - A shorter fence of the same character does not close the block.
-    - A fence of a different character does not close the block.
-    - Tilde fences (~~~) are treated symmetrically to backtick fences.
-    - JSX-like lines inside a fenced block are not swallowed as MDX blocks.
-    """
-
-    @staticmethod
-    def _sources(content: bytes) -> list[str]:
-        store = MDXFile(inputfile=BytesIO(content))
-        return [u.source for u in store.units]
-
-    def test_basic_backtick_fence_not_swallowed(self):
-        """JSX inside a triple-backtick fence is not extracted as an MDX block."""
-        content = b"""# Title
-
-```jsx
-<MyComponent prop="value" />
-```
-
-Text.
-"""
-        sources = self._sources(content)
-        assert "Title" in sources
-        assert "Text." in sources
-
-    def test_basic_tilde_fence_not_swallowed(self):
-        """JSX inside a triple-tilde fence is not extracted as an MDX block."""
-        content = b"""# Title
-
-~~~jsx
-<MyComponent />
-~~~
-
-Text.
-"""
-        sources = self._sources(content)
-        assert "Title" in sources
-        assert "Text." in sources
-
-    def test_four_backtick_fence_closed_by_four(self):
-        """A 4-backtick opener is closed by a 4-backtick closing fence."""
+    def test_simple_child_locations_and_docpaths(self):
         content = b"""# Heading
 
-````js
-const x = <Foo />;
+<Callout title="Open">
+  Copy.
+</Callout>
+"""
+        store = mdx_store(content)
+        assert [unit.getlocations() for unit in store.units] == [
+            [":1"],
+            [":3"],
+            [":4"],
+        ]
+        assert store.units[2].getdocpath() == "jsx-block[1]/p[1]"
+
+    def test_units_follow_document_order(self):
+        content = b"""# Heading
+
+Body.
+
+<Step title="Open" />
+"""
+        assert sources(mdx_store(content)) == ["Heading", "Body.", "Open"]
+
+    def test_units_follow_document_order_after_frontmatter(self):
+        content = b"""---
+title: Metadata
+---
+
+# Heading
+
+<Step title="Open" />
+
+After.
+"""
+        store = mdx_store(content)
+        assert sources(store) == [
+            "---\ntitle: Metadata\n---\n\n",
+            "Heading",
+            "Open",
+            "After.",
+        ]
+
+    def test_no_placeholders_is_forwarded_to_child_markdown(self):
+        content = b"""<Callout>
+  Read [the docs](https://example.com).
+</Callout>
+"""
+        store = mdx_store(content, no_placeholders=True)
+        assert sources(store) == ["Read [the docs](https://example.com)."]
+        assert store.filesrc == content.decode()
+
+    def test_code_option_is_forwarded_to_child_markdown(self):
+        content = b"""<Callout>
+  ```text
+  literal code
+  ```
+</Callout>
+"""
+        assert sources(mdx_store(content, extract_code_blocks=False)) == []
+        assert sources(mdx_store(content)) == ["literal code"]
+
+    def test_component_children_can_contain_fenced_code(self):
+        content = b"""<Callout title="Example">
+  ```js
+  function example() { return <Card />; }
+  </Callout>
+  ```
+
+  After code.
+</Callout>
+"""
+        store = mdx_store(content)
+        assert sources(store) == [
+            "Example",
+            "function example() { return <Card />; }\n</Callout>",
+            "After code.",
+        ]
+        assert store.filesrc == content.decode()
+
+    def test_ellipsis_child_is_markdown(self):
+        content = b"""<Callout title="Note">
+  ...and then continue.
+</Callout>
+"""
+        store = mdx_store(content)
+        assert sources(store) == ["Note", "...and then continue."]
+        assert store.filesrc == content.decode()
+
+    def test_crlf_component_syntax_is_supported(self):
+        content = (
+            b'<Step title="Open" />\r\n\r\n'
+            b'<Callout title="Warning">\r\n  Copy.\r\n</Callout>\r\n'
+        )
+        translations = {
+            "Open": "Abrir",
+            "Warning": "Aviso",
+            "Copy.": "Copiar.",
+        }
+        store = mdx_store(content, callback=lambda text: translations.get(text, text))
+        assert sources(store) == ["Open", "Warning", "Copy."]
+        assert '<Step title="Abrir" />' in store.filesrc
+        assert '<Callout title="Aviso">' in store.filesrc
+        assert "  Copiar." in store.filesrc
+
+    def test_simple_component_preserves_trailing_spaces(self):
+        content = (
+            b'<Step title="Open" />  \n\n'
+            b'<Callout title="Warning">  \n'
+            b"  Copy.\n"
+            b"</Callout>  \n"
+        )
+        store = mdx_store(content)
+        assert sources(store) == ["Open", "Warning", "Copy."]
+        assert store.filesrc == content.decode()
+
+
+class TestOpaqueSyntax:
+    """Syntax outside the strict subset is never partially interpreted."""
+
+    @pytest.mark.parametrize(
+        "component",
+        [
+            '<Callout title="Open">Text</Callout>',
+            "<Callout kind={kind}>\n  Text\n</Callout>",
+            '<Callout\n  title="Open"\n>\n  Text\n</Callout>',
+            '<Outer>\n  <Inner title="Open">\n    Text\n  </Inner>\n</Outer>',
+            "<Outer>\n  <>\n    Text\n  </>\n</Outer>",
+            "<Callout>Intro\nMore text\n</Callout>",
+        ],
+    )
+    def test_unsupported_component_layout_is_opaque(self, component):
+        content = f"{component}\n\nAfter.\n".encode()
+        store = mdx_store(
+            content,
+            callback=lambda text: {
+                "Open": "Changed",
+                "Text": "Changed",
+                "More text": "Changed",
+                "After.": "After translated.",
+            }.get(text, text),
+        )
+        assert sources(store) == ["After."]
+        assert store.filesrc == f"{component}\n\nAfter translated.\n"
+
+    def test_raw_html_children_are_opaque(self):
+        component = """<Callout title="Open">
+<div>
+HTML child
+</div>
+</Callout>"""
+        content = f"{component}\n\nAfter.\n".encode()
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert component in store.filesrc
+
+    def test_nested_same_name_component_does_not_close_opaque_block_early(self):
+        component = """<Callout>Intro
+<Callout>Inner</Callout>
+More text
+</Callout>"""
+        content = f"{component}\n\nAfter.\n".encode()
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert component in store.filesrc
+
+    def test_opaque_component_stops_at_its_first_standalone_close(self):
+        first = """<Callout kind={kind}>
+Opaque text
+</Callout>"""
+        content = f"""{first}
+
+Between.
+
+<Callout title="Open">
+  Copy.
+</Callout>
+""".encode()
+        store = mdx_store(content)
+        assert sources(store) == ["Between.", "Open", "Copy."]
+        assert first in store.filesrc
+
+    def test_standalone_same_name_nesting_stays_opaque(self):
+        component = """<Callout kind={kind}>
+<Callout>
+Inner text
+</Callout>
+
+Outer text
+</Callout>"""
+        content = f"{component}\n\nAfter.\n".encode()
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert component in store.filesrc
+
+    def test_non_simple_same_name_nesting_stays_opaque(self):
+        component = """<Callout kind={outer}>
+<Callout kind={inner}>
+Inner text
+</Callout>
+
+Outer text
+</Callout>"""
+        content = f"{component}\n\nAfter.\n".encode()
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert component in store.filesrc
+
+    def test_closing_tag_in_html_comment_does_not_end_opaque_component(self):
+        component = """<Callout kind={kind}>
+<!--
+</Callout>
+-->
+
+Outer text
+</Callout>"""
+        content = f"{component}\n\nAfter.\n".encode()
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert component in store.filesrc
+
+    def test_opaque_component_close_allows_trailing_spaces(self):
+        component = """<Callout kind={kind}>
+First child.
+
+Second child.
+</Callout>  """
+        content = f"{component}\n\nAfter.\n".encode()
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert component in store.filesrc
+
+    @pytest.mark.parametrize("fragment", ["<>Text</>", "<>  \nText\n</>  "])
+    def test_fragment_layouts_are_opaque(self, fragment):
+        content = f"{fragment}\n\nAfter.\n".encode()
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert store.filesrc == content.decode()
+
+    def test_text_ending_in_self_close_syntax_does_not_end_open_block(self):
+        component = """<Callout>Text />
+More text
+</Callout>"""
+        content = f"{component}\n\nAfter.\n".encode()
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert component in store.filesrc
+
+    def test_closing_tag_literal_in_attribute_does_not_end_open_block(self):
+        component = """<Callout marker={"</Callout>"}>
+  More text
+</Callout>"""
+        content = f"{component}\n\nAfter.\n".encode()
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert component in store.filesrc
+
+    def test_spread_makes_the_whole_tag_opaque(self):
+        content = b'<Component {...props} title="Open" />\n'
+        store = mdx_store(
+            content, callback=lambda text: "Changed" if text == "Open" else text
+        )
+        assert sources(store) == []
+        assert store.filesrc == content.decode()
+
+    def test_expression_prop_with_arrow_does_not_hide_following_markdown(self):
+        content = b"""<Component render={() => null} />
+
+After.
+"""
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert store.filesrc == content.decode()
+
+    def test_four_space_child_is_ambiguous_and_opaque(self):
+        content = b"""<Callout>
+    const value = 1
+</Callout>
+"""
+        store = mdx_store(content, extract_code_blocks=False)
+        assert sources(store) == []
+        assert store.filesrc == content.decode()
+
+    def test_component_literal_in_child_makes_block_opaque(self):
+        content = b"""<Outer>
+  Use `<Button>` in this example.
+</Outer>
+"""
+        store = mdx_store(content)
+        assert sources(store) == []
+        assert store.filesrc == content.decode()
+
+    def test_closing_tag_in_link_title_does_not_end_block(self):
+        content = b"""<Outer>
+  [link](url "</Outer>")
+  Copy.
+</Outer>
+
+After.
+"""
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert store.filesrc == content.decode()
+
+    def test_expression_paragraph_is_opaque_without_js_balancing(self):
+        content = b"""Before {items.map(
+item => <Card title="No" />
+)}
+
+After.
+"""
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert store.filesrc == content.decode()
+
+    def test_soft_wrapped_expression_paragraph_stays_whole(self):
+        content = b"""This paragraph
+contains {an_expression}
+on several lines.
+
+After.
+"""
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert store.filesrc == content.decode()
+
+    def test_indented_expression_continuation_stays_opaque(self):
+        content = b"""Intro
+  {items.map(item => item.name)}
+
+After.
+"""
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert store.filesrc == content.decode()
+
+    def test_component_without_blank_boundary_is_wholly_opaque(self):
+        content = b"""Before.
+<Step title="Open" />
+After.
+"""
+        store = mdx_store(content)
+        assert sources(store) == []
+        assert store.filesrc == content.decode()
+
+
+class TestMarkdownOwnership:
+    """Contexts outside column-zero block JSX remain Markdown-owned."""
+
+    def test_inline_component_attribute_is_not_separately_extracted(self):
+        content = b'See <Badge label="New" /> now.\n'
+        store = mdx_store(content)
+        assert "New" not in sources(store)
+        assert sources(store) == ["See {1} now."]
+        assert store.filesrc == content.decode()
+
+    def test_component_literal_in_code_span_keeps_surrounding_prose(self):
+        content = b"Use `<Callout>` to show text.\n"
+        store = mdx_store(content)
+        assert sources(store) == ["Use `<Callout>` to show text."]
+        assert store.filesrc == content.decode()
+
+    def test_one_line_raw_html_keeps_markdown_extraction(self):
+        content = b"<span>Translatable</span>\n"
+        store = mdx_store(content)
+        assert sources(store) == ["Translatable"]
+        assert store.filesrc == content.decode()
+
+    def test_reference_metadata_is_not_scanned_as_jsx(self):
+        content = b'[ref]: /url "<Title>"\n'
+        store = mdx_store(content)
+        assert sources(store) == ["ref", "<Title>"]
+        assert store.filesrc == content.decode()
+
+    def test_fenced_code_is_not_scanned(self):
+        content = b"""````jsx
+<Card title="No" />
+```
 ````
 
-After.
+<Step title="Open" />
 """
-        sources = self._sources(content)
-        assert "Heading" in sources
-        assert "After." in sources
+        store = mdx_store(content, extract_code_blocks=False)
+        assert sources(store) == ["Open"]
+        assert '<Card title="No" />' in store.filesrc
 
-    def test_four_backtick_fence_not_closed_by_three(self):
-        """
-        A 4-backtick opener is NOT closed by a 3-backtick fence (CommonMark §4.5).
+    def test_indented_code_is_not_scanned(self):
+        content = b'    <Button label="Save" />\n'
+        store = mdx_store(content, extract_code_blocks=False)
+        assert sources(store) == []
+        assert store.filesrc == content.decode()
 
-        The triple-backtick line is inside the fence and the block continues
-        until the real 4-backtick closer.  Content after the real closer must
-        not disappear.
+    def test_large_indented_code_block_is_processed_linearly(self):
+        content = ("    const value = 1\n" * 10_000).encode()
+        store = mdx_store(content, extract_code_blocks=False)
+        assert sources(store) == []
+        assert store.filesrc == content.decode()
 
-        Note: mistune (the underlying Markdown parser) only recognises
-        triple-backtick fences, so the 4-backtick block is rendered as a
-        paragraph by mistune.  The important assertion here is that our
-        *protection* logic does not prematurely close the fence and thereby
-        expose "After." as lost content — i.e. "After." must still be present.
-        """
-        content = b"""# Heading
 
-````
-```
-still inside
-````
+class TestOpaqueRegions:
+    """Regions Markdown or MDX defines as opaque are not pre-scanned."""
 
-After.
-"""
-        sources = self._sources(content)
-        assert "Heading" in sources
-        # "After." follows the real closing fence and must be extracted.
-        assert "After." in sources
-
-    def test_backtick_fence_not_closed_by_tilde(self):
-        """A backtick fence cannot be closed by a tilde fence."""
-        content = b"""# Heading
-
-```
-code
-~~~
+    def test_multiline_html_comment(self):
+        content = b"""<!--
+<Card title="No" />
+-->
 
 After.
 """
-        # The ~~~ does not close the ``` fence; "After." is still inside the
-        # fence and will not be extracted as a translation unit (it is treated
-        # as literal code).  The important assertion is that "Heading" is still
-        # extracted and the parser does not crash.
-        sources = self._sources(content)
-        assert "Heading" in sources
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert store.filesrc == content.decode()
 
-    def test_tilde_fence_not_closed_by_backtick(self):
-        """A tilde fence cannot be closed by a backtick fence."""
-        content = b"""# Heading
+    def test_script_block_stays_opaque_across_blank_lines(self):
+        content = b"""<script>
 
-~~~
-code
-```
+<Card title="No" />
+</script>
+
+<Step title="Open" />
+"""
+        store = mdx_store(content)
+        assert sources(store) == ["Open"]
+        assert store.filesrc == content.decode()
+
+    def test_translate_off_control_is_exact_and_opaque(self):
+        content = b"""<!-- translate:off -->
+<Card title="No" />
+<!-- translate:on -->
 
 After.
 """
-        sources = self._sources(content)
-        assert "Heading" in sources
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert store.filesrc == content.decode()
 
-    def test_jsx_after_fence_is_protected(self):
-        """JSX block appearing after a properly closed fence is still protected."""
-        content = b"""# Title
+    def test_translate_off_words_are_normal_prose(self):
+        content = b"The literal text translate:off is documented here.\n"
+        assert sources(mdx_store(content)) == [
+            "The literal text translate:off is documented here."
+        ]
 
-```js
-<Fake />
-```
-
-<Real prop="x" />
-
-Text.
-"""
-        sources = self._sources(content)
-        assert "Title" in sources
-        assert "Text." in sources
-        # The real JSX block must not leak into sources as raw markup.
-        assert not any("<Real" in s for s in sources)
-
-    def test_nested_fence_depth_not_tracked(self):
-        """Fences do not nest; the first matching close ends the block."""
-        content = b"""# Title
-
-```
-outer
-```
+    def test_frontmatter_is_not_preprocessed(self):
+        content = b"""---
+body: |
+  <Card title="No">
+    Copy
+  </Card>
+---
 
 After.
 """
-        sources = self._sources(content)
-        assert "Title" in sources
-        assert "After." in sources
+        store = mdx_store(content, extract_frontmatter=False)
+        assert sources(store) == ["After."]
+        assert store.filesrc == content.decode()
 
-    def test_fence_with_info_string_closed_correctly(self):
-        """Fences with an info string (e.g. ```python) are closed by a plain fence."""
-        content = b"""# Title
 
-```python
-x = 1
-```
+class TestAttributeSerialization:
+    """Simple string attributes serialize without changing JSX syntax."""
+
+    def test_delimiter_quotes_use_entities(self):
+        content = b"<Comp title=\"Say\" note='It' />\n"
+        store = mdx_store(
+            content,
+            callback=lambda text: {
+                "Say": 'Say "hello"',
+                "It": "It's ready",
+            }.get(text, text),
+        )
+        assert store.filesrc == (
+            "<Comp title=\"Say &quot;hello&quot;\" note='It&apos;s ready' />\n"
+        )
+
+    def test_less_than_in_translation_uses_entity(self):
+        content = b'<Comp title="Small" />\n'
+        store = mdx_store(
+            content,
+            callback=lambda text: "Small < medium" if text == "Small" else text,
+        )
+        assert store.filesrc == '<Comp title="Small &lt; medium" />\n'
+
+    def test_backslashes_round_trip_and_terminal_one_is_doubled(self):
+        content = b'<Comp path="C:\\tmp" title="Ends" />\n'
+        store = mdx_store(
+            content,
+            callback=lambda text: "Ends\\" if text == "Ends" else text,
+        )
+        assert store.filesrc == '<Comp path="C:\\tmp" title="Ends\\\\" />\n'
+
+    def test_untranslated_terminal_backslash_is_preserved(self):
+        content = b'<Comp title="Ends\\" />\n'
+        store = mdx_store(content)
+        assert sources(store) == ["Ends\\"]
+        assert store.filesrc == content.decode()
+
+    def test_empty_attributes_keep_docpath_positions_stable(self):
+        content = b'<Comp first="" second="Value" />\n'
+        store = mdx_store(content)
+        assert sources(store) == ["Value"]
+        assert store.units[0].getdocpath() == "jsx-attr[2]/Comp.@second"
+
+    def test_source_escaped_quote_is_outside_supported_subset(self):
+        content = b'<Comp title="Say \\"hello\\"" />\n'
+        store = mdx_store(content)
+        assert sources(store) == []
+        assert store.filesrc == content.decode()
+
+
+class TestPlaceholders:
+    """Opaque placeholders do not leak or collide with source content."""
+
+    def test_placeholder_prefix_avoids_source_collision(self):
+        content = b"""<!-- MDX_BLOCK_1 -->
+
+<Step title="Open" />
+"""
+        store = mdx_store(content)
+        assert sources(store) == ["Open"]
+        assert store.filesrc == content.decode()
+
+    def test_no_placeholder_leaks_to_units(self):
+        content = b"""<Callout>Text</Callout>
 
 After.
 """
-        sources = self._sources(content)
-        assert "Title" in sources
-        assert "After." in sources
-
-    def test_five_tilde_fence_not_closed_by_three(self):
-        """A 5-tilde opener is not closed by a 3-tilde fence."""
-        content = b"""# Heading
-
-~~~~~
-~~~
-still inside
-~~~~~
-
-After.
-"""
-        sources = self._sources(content)
-        assert "Heading" in sources
-        assert "After." in sources
+        store = mdx_store(content)
+        assert sources(store) == ["After."]
+        assert not any("MDX_BLOCK" in source for source in sources(store))

--- a/translate/storage/mdxfile.py
+++ b/translate/storage/mdxfile.py
@@ -16,26 +16,48 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
-"""
-Module for parsing MDX files for translation.
-
-MDX is Markdown with JSX support. This module extends the Markdown parser to
-handle MDX-specific syntax:
-
-- import/export statements are preserved as-is (not translated)
-- JSX block-level components are preserved as-is (not translated)
-- Standalone JSX expression blocks on their own line ({expr}) are preserved
-- Regular Markdown content between JSX blocks is extracted for translation
-- Inline {expr} inside a paragraph is kept as-is (part of the translation unit)
-
-See: https://mdxjs.com/docs/what-is-mdx/
-"""
+"""Conservative MDX storage support built on the Markdown storage."""
 
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
 from translate.storage.markdown import MarkdownFile, MarkdownUnit
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_COMPONENT_NAME = r"[A-Z][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*"
+_ATTRIBUTE_NAME = r"[A-Za-z_:][A-Za-z0-9_.:-]*"
+_QUOTED_VALUE = r'(?:"[^"\r\n]*"|\'[^\'\r\n]*\')'
+_ATTRIBUTE = rf"\s+{_ATTRIBUTE_NAME}(?:\s*=\s*{_QUOTED_VALUE})?"
+
+_COMPONENT_START = re.compile(rf"^<(?P<name>{_COMPONENT_NAME})(?=[\s/>]|$)")
+_COMPONENT_CLOSE = re.compile(rf"^</(?P<name>{_COMPONENT_NAME})\s*>[ \t]*$")
+_FRAGMENT_START = re.compile(r"^(?:<>|</>)")
+_SIMPLE_TAG = re.compile(
+    rf"^<(?P<name>{_COMPONENT_NAME})(?P<attrs>(?:{_ATTRIBUTE})*)"
+    rf"\s*(?P<slash>/?)>[ \t]*$"
+)
+_ATTRIBUTE_TOKEN = re.compile(
+    rf"\s+(?P<name>{_ATTRIBUTE_NAME})"
+    rf"(?:\s*=\s*(?:\"(?P<double>[^\"\r\n]*)\"|'(?P<single>[^'\r\n]*)'))?"
+)
+_ESM_START = re.compile(
+    r"""^(?:
+        import \s+ (?:
+            \{|\*|type\s|\"|\'|`
+            |[A-Za-z_$][A-Za-z0-9_$]*\s*,\s*(?:\*|\{)
+            |[A-Za-z_$][A-Za-z0-9_$]*\s+from\b
+        )
+        |
+        export \s+ (?:default|const|function|class|type|let|var|\{|\*)
+    )""",
+    re.VERBOSE,
+)
+_FENCE = re.compile(r"^ {0,3}(?P<delimiter>`{3,}|~{3,})")
+_LOWER_HTML_START = re.compile(r"^ {0,3}<(?P<tag>[a-z][A-Za-z0-9-]*)(?:[\s>/]|$)")
 
 
 class MDXUnit(MarkdownUnit):
@@ -43,7 +65,7 @@ class MDXUnit(MarkdownUnit):
 
 
 class MDXFile(MarkdownFile):
-    """Parser for MDX files (Markdown with JSX)."""
+    """Parse a deliberately small, structurally isolated MDX subset."""
 
     UnitClass = MDXUnit
 
@@ -57,16 +79,12 @@ class MDXFile(MarkdownFile):
         frontmatter_translate_values=False,
         no_placeholders=False,
     ) -> None:
-        """
-        Construct a new MDXFile instance.
-
-        Parameters are the same as MarkdownFile. JSX components and
-        import/export statements are automatically preserved without
-        translation.
-        """
-        # Storage for MDX blocks that are replaced with placeholders
+        """Construct an MDX store with the same options as MarkdownFile."""
         self._mdx_blocks: dict[str, tuple[str, int]] = {}
         self._mdx_block_counter = 0
+        self._mdx_block_placeholder_prefix = "MDX_BLOCK"
+        self._jsx_attr_counter = 0
+        self._jsx_block_counter = 0
         super().__init__(
             inputfile=inputfile,
             callback=callback,
@@ -78,265 +96,552 @@ class MDXFile(MarkdownFile):
         )
 
     def parse(self, data) -> None:
-        """Pre-process MDX content, then delegate to the Markdown parser."""
-        # Reset placeholder state so repeated parse() calls don't accumulate
-        # stale entries from a previous pass.
+        """Protect MDX syntax, parse Markdown, and restore protected content."""
         self._mdx_blocks = {}
         self._mdx_block_counter = 0
+        self._jsx_attr_counter = 0
+        self._jsx_block_counter = 0
+
         text = data.decode() if isinstance(data, bytes) else data
-        text = self._protect_mdx_blocks(text)
-        super().parse(text.encode())
-        # Restore MDX blocks in the rendered output
+        self._mdx_block_placeholder_prefix = self._choose_placeholder_prefix(text)
+        frontmatter_offset = self._frontmatter_body_offset(text.split("\n"))
+        super().parse(self._protect_mdx(text).encode())
+        self.units.sort(
+            key=lambda unit: self._unit_document_line(unit, frontmatter_offset)
+        )
         self.filesrc = self._restore_mdx_blocks(self.filesrc)
 
-    def _make_placeholder(self, content: str) -> str:
-        """
-        Create an HTML comment placeholder for an MDX block.
-
-        HTML comments are used because they are preserved verbatim by the
-        Markdown parser and are not extracted as translation units.
-
-        The placeholder pads to the same number of lines as the original block
-        so that extracted PO ``#: file:line`` locations remain accurate.
-        Indentation is *not* embedded in the placeholder because the Markdown
-        renderer may alter leading whitespace; it is instead recovered from the
-        stored *content* when ``_restore_mdx_blocks`` runs.
-        """
-        self._mdx_block_counter += 1
-        key = f"<!-- MDX_BLOCK_{self._mdx_block_counter} -->"
-        n_lines = content.count("\n")
-        self._mdx_blocks[key] = (content, n_lines)
-        # Pad to the same number of lines as the original block so that
-        # downstream line-number references (PO locations) stay accurate.
-        return key + ("\n" * n_lines)
-
-    def _protect_mdx_blocks(self, text: str) -> str:
-        """
-        Replace MDX-specific blocks with HTML comment placeholders.
-
-        This allows the standard Markdown parser to handle the rest of the
-        content without being confused by JSX syntax.
-
-        Lines inside fenced code blocks (``` or ~~~) are never protected so
-        that JSX-like examples inside code samples are left intact.
-        """
+    def _protect_mdx(self, text: str) -> str:
+        """Replace recognized MDX blocks with line-count-preserving comments."""
         lines = text.split("\n")
-        result = []
-        i = 0
-        in_code_fence = False
-        code_fence_char = ""
-        code_fence_len = 0
+        frontmatter_lines = self._frontmatter_line_count(lines)
+        result = lines[:frontmatter_lines]
+        i = frontmatter_lines
+        fence: tuple[str, int] | None = None
+
         while i < len(lines):
             line = lines[i]
-            stripped = line.strip()
 
-            # Track fenced code blocks so we never protect content inside them.
-            if not in_code_fence:
-                fence_match = re.match(r"^(`{3,}|~{3,})", stripped)
-                if fence_match:
-                    in_code_fence = True
-                    code_fence_char = fence_match.group(1)[0]
-                    code_fence_len = len(fence_match.group(1))
-                    result.append(line)
-                    i += 1
-                    continue
-            else:
-                # Closing fence: same character, length >= opening length,
-                # nothing after except optional whitespace (CommonMark §4.5).
-                close_match = re.match(r"^(`{3,}|~{3,})\s*$", stripped)
-                if (
-                    close_match
-                    and close_match.group(1)[0] == code_fence_char
-                    and len(close_match.group(1)) >= code_fence_len
-                ):
-                    in_code_fence = False
-                    code_fence_char = ""
-                    code_fence_len = 0
+            if fence is not None:
+                result.append(line)
+                if self._is_fence_close(line, fence):
+                    fence = None
+                i += 1
+                continue
+
+            opening_fence = self._fence_open(line)
+            if opening_fence is not None:
+                fence = opening_fence
                 result.append(line)
                 i += 1
                 continue
 
-            # Import/export statements (may span multiple lines with parens/braces).
-            # Require a recognisable MDX import/export form to avoid treating
-            # normal paragraphs that begin with the word "import" or "export" as
-            # code blocks.
-            #
-            # Recognised import forms:
-            #   import { ... } from '...'
-            #   import * as x from '...'
-            #   import type ...
-            #   import DefaultExport from '...'  (identifier immediately followed
-            #     by "from" somewhere on the line)
-            #   import '...' (side-effect-only)
-            #
-            # Recognised export forms:
-            #   export default ...
-            #   export const/function/class/type/let/var ...
-            #   export { ... }
-            #   export * from '...'
-            if re.match(
-                r"""^(?:
-                    import \s+ (?:\{|\*|type\s|\"|\'|`|[A-Za-z_$][A-Za-z0-9_$]*\s+from\b)
-                    |
-                    export \s+ (?:default|const|function|class|type|let|var|\{|\*)
-                )""",
-                stripped,
-                re.VERBOSE,
-            ):
-                block_lines = [line]
-                # Collect continuation lines until the statement is complete.
-                # The cap guards against a malformed file with a never-closing
-                # brace consuming the entire rest of the file.  On hitting the
-                # cap we emit the collected lines as ordinary Markdown (fail
-                # open) rather than silently dropping all subsequent content.
-                MAX_IMPORT_LINES = 200
-                while (
-                    i + 1 < len(lines)
-                    and len(block_lines) < MAX_IMPORT_LINES
-                    and self._is_continuation("\n".join(block_lines))
-                ):
-                    i += 1
-                    block_lines.append(lines[i])
-                if self._is_continuation("\n".join(block_lines)):
-                    # Still open at cap — treat as regular Markdown.
-                    result.extend(block_lines)
-                    i += 1
-                    continue
-                result.append(self._make_placeholder("\n".join(block_lines)))
+            if self._is_indented_code(line):
+                result.append(line)
                 i += 1
                 continue
 
-            # JSX block-level component (starts with <UpperCase)
-            if re.match(r"^[ \t]*<[A-Z]", line) or re.match(r"^[ \t]*</[A-Z]", line):
-                block_lines = [line]
-                # Self-closing tag on one line
-                if re.search(r"/>\s*$", stripped):
-                    result.append(self._make_placeholder("\n".join(block_lines)))
-                    i += 1
-                    continue
-                # Opening tag - find corresponding closing tag
-                tag_match = re.match(r"^[ \t]*<([A-Z][A-Za-z0-9_.]*)", line)
-                if tag_match:
-                    tag_name = tag_match.group(1)
-                    # Check if opening tag closes on same line with >
-                    # then look for </TagName>
-                    depth = 1
-                    # Check if this line itself has content after the opening tag
-                    # that includes the closing tag
-                    close_pattern = re.compile(rf"</\s*{re.escape(tag_name)}\s*>")
-                    open_pattern = re.compile(rf"<{re.escape(tag_name)}(?:\s|>)")
-                    selfclose_pattern = re.compile(
-                        rf"<{re.escape(tag_name)}(?:\s[^>]*)?\s*/>"
-                    )
-                    # Count opens/closes on first line
-                    first_line_closes = len(close_pattern.findall(stripped))
-                    first_line_opens = len(open_pattern.findall(stripped)) - len(
-                        selfclose_pattern.findall(stripped)
-                    )
-                    depth = first_line_opens - first_line_closes
-                    if depth <= 0:
-                        # Entire component on one line
-                        result.append(self._make_placeholder("\n".join(block_lines)))
-                        i += 1
-                        continue
-                    # Multi-line component: collect lines until the matching
-                    # closing tag is found. If we reach EOF without closing
-                    # (malformed MDX), fall back to emitting the first line
-                    # as a placeholder and re-processing the rest, so that
-                    # content after the unclosed tag is not silently dropped.
-                    while i + 1 < len(lines) and depth > 0:
-                        i += 1
-                        block_lines.append(lines[i])
-                        current = lines[i]
-                        depth += len(open_pattern.findall(current)) - len(
-                            selfclose_pattern.findall(current)
-                        )
-                        depth -= len(close_pattern.findall(current))
-                    if depth > 0:
-                        # Unclosed tag: protect only the opening line and
-                        # re-process the remaining lines normally.
-                        result.append(self._make_placeholder(block_lines[0]))
-                        lines = block_lines[1:] + lines[i + 1 :]
-                        i = 0
-                        continue
-                    result.append(self._make_placeholder("\n".join(block_lines)))
-                    i += 1
-                    continue
-                # Closing tag alone - just protect it
-                result.append(self._make_placeholder("\n".join(block_lines)))
+            if not line.strip():
+                result.append(line)
                 i += 1
                 continue
 
-            # JSX expression blocks (lines that are just {expression})
-            if re.match(r"^[ \t]*\{", stripped) and not re.match(
-                r"^[ \t]*\{[{%]", stripped
-            ):
-                # Check if it's a standalone JSX expression block
-                brace_count = stripped.count("{") - stripped.count("}")
-                if brace_count == 0 and stripped.endswith("}"):
-                    result.append(self._make_placeholder(line))
-                    i += 1
-                    continue
-                if brace_count > 0:
-                    # Multi-line expression: collect lines until braces balance.
-                    # Cap guards against a never-closing brace in malformed MDX
-                    # consuming the entire file.  Fail open on hitting the cap.
-                    block_lines = [line]
-                    MAX_EXPR_LINES = 200
-                    while (
-                        i + 1 < len(lines)
-                        and brace_count > 0
-                        and len(block_lines) < MAX_EXPR_LINES
-                    ):
-                        i += 1
-                        block_lines.append(lines[i])
-                        brace_count += lines[i].count("{") - lines[i].count("}")
-                    if brace_count > 0:
-                        # Still unclosed at cap — treat as regular Markdown.
-                        result.extend(block_lines)
-                        i += 1
-                        continue
-                    result.append(self._make_placeholder("\n".join(block_lines)))
-                    i += 1
-                    continue
+            if line.strip() == "<!-- translate:off -->":
+                end = self._translate_off_end(lines, i)
+                result.append(self._opaque_lines(lines, i, end))
+                i = end
+                continue
 
-            result.append(line)
-            i += 1
+            raw_end = self._raw_html_end(lines, i)
+            if raw_end is not None:
+                result.append(self._opaque_lines(lines, i, raw_end))
+                i = raw_end
+                continue
+
+            if self._is_esm_start(line):
+                end = self._blank_delimited_end(lines, i)
+                result.append(self._opaque_lines(lines, i, end))
+                i = end
+                continue
+
+            component = _COMPONENT_START.match(line)
+            if component is not None:
+                end, rendered = self._component_block(lines, i, component.group("name"))
+                result.append(
+                    self._make_placeholder(rendered, source_line_count=end - i)
+                )
+                i = end
+                continue
+
+            if _COMPONENT_CLOSE.fullmatch(
+                self._logical_line(line)
+            ) or _FRAGMENT_START.match(self._logical_line(line)):
+                end = self._extend_to_blank(lines, i + 1)
+                result.append(self._opaque_lines(lines, i, end))
+                i = end
+                continue
+
+            end = self._blank_delimited_end(lines, i)
+            if self._chunk_requires_opaque(lines[i:end]):
+                result.append(self._opaque_lines(lines, i, end))
+            else:
+                result.extend(lines[i:end])
+            i = end
 
         return "\n".join(result)
 
-    def _restore_mdx_blocks(self, text: str) -> str:
-        r"""
-        Restore MDX blocks from their placeholders.
+    def _component_block(
+        self, lines: list[str], start: int, name: str
+    ) -> tuple[int, str]:
+        """Return the end and rendering of one column-zero component block."""
+        opening = lines[start]
+        simple = _SIMPLE_TAG.fullmatch(self._logical_line(opening))
+        if simple is not None and simple.group("slash"):
+            end = start + 1
+            if self._is_block_end(lines, end):
+                return end, self._translate_simple_tag(opening, start + 1)
+            end = self._extend_to_blank(lines, end)
+            return end, "\n".join(lines[start:end])
 
-        Each placeholder was emitted as ``key + "\n" * n_lines`` so that the
-        block occupied the same number of lines as the original content.  On
-        restoration, both the key and the padding newlines are replaced with
-        the original content to avoid doubling blank lines.
-        """
-        for key, (content, n_lines) in self._mdx_blocks.items():
-            text = text.replace(key + ("\n" * n_lines), content)
-            # Fallback: replace any remaining bare key (e.g. if the Markdown
-            # renderer stripped trailing whitespace/newlines).
+        first_close = self._first_standalone_close(lines, start + 1, name)
+        if (
+            simple is not None
+            and first_close is not None
+            and self._is_block_end(lines, first_close + 1)
+        ):
+            child_lines = lines[start + 1 : first_close]
+            if self._simple_markdown_children(child_lines):
+                return first_close + 1, self._render_simple_component(
+                    opening,
+                    child_lines,
+                    lines[first_close],
+                    start,
+                )
+
+        end = self._opaque_component_end(lines, start, name)
+        end = self._extend_to_blank(lines, end)
+        return end, "\n".join(lines[start:end])
+
+    def _render_simple_component(
+        self,
+        opening: str,
+        child_lines: list[str],
+        closing: str,
+        opening_index: int,
+    ) -> str:
+        """Translate one simple component as an isolated Markdown subdocument."""
+        translated_opening = self._translate_simple_tag(opening, opening_index + 1)
+        self._jsx_block_counter += 1
+        if not child_lines:
+            return f"{translated_opening}\n{closing}"
+
+        indent = self._common_child_indent(child_lines)
+        dedented_lines = [line[indent:] for line in child_lines]
+        child_store = MarkdownFile(
+            callback=self.callback,
+            max_line_length=self.max_line_length,
+            extract_code_blocks=self.extract_code_blocks,
+            extract_frontmatter=False,
+            no_placeholders=self.no_placeholders,
+        )
+        child_store.parse("\n".join(dedented_lines).encode())
+
+        self._copy_child_units(child_store, opening_index + 2)
+        rendered_children = self._reindent(child_store.filesrc, " " * indent)
+        if rendered_children and not rendered_children.endswith("\n"):
+            rendered_children += "\n"
+        return f"{translated_opening}\n{rendered_children}{closing}"
+
+    def _copy_child_units(self, child_store: MarkdownFile, first_line: int) -> None:
+        """Copy isolated Markdown units into this store with absolute locations."""
+        path_prefix = f"jsx-block[{self._jsx_block_counter}]"
+        for child_unit in child_store.units:
+            unit = self.addsourceunit(child_unit.source)
+            relative_line = self._unit_source_line(child_unit) or 1
+            unit.addlocation(f"{self.filename or ''}:{first_line + relative_line - 1}")
+            child_path = child_unit.getdocpath()
+            unit.setdocpath(
+                f"{path_prefix}/{child_path}" if child_path else path_prefix
+            )
+
+    def _translate_simple_tag(self, tag: str, line_number: int) -> str:
+        """Translate quoted values in a validated simple component tag."""
+        logical_tag = self._logical_line(tag)
+        match = _SIMPLE_TAG.fullmatch(logical_tag)
+        if match is None:
+            return tag
+
+        result: list[str] = []
+        pos = 0
+        attrs_start, attrs_end = match.span("attrs")
+        for attribute in _ATTRIBUTE_TOKEN.finditer(logical_tag, attrs_start, attrs_end):
+            value_group = (
+                "double" if attribute.group("double") is not None else "single"
+            )
+            if attribute.group(value_group) is None:
+                continue
+            value_start, value_end = attribute.span(value_group)
+            quote = '"' if value_group == "double" else "'"
+            result.append(tag[pos:value_start])
+            translated = self._translate_attribute(
+                tag[value_start:value_end],
+                match.group("name"),
+                attribute.group("name"),
+                line_number,
+            )
+            result.append(
+                self._escape_attribute(
+                    translated,
+                    quote,
+                    changed=translated != tag[value_start:value_end],
+                )
+            )
+            pos = value_end
+        result.append(tag[pos:])
+        return "".join(result)
+
+    def _translate_attribute(
+        self, value: str, component: str, attribute: str, line_number: int
+    ) -> str:
+        """Emit one quoted component attribute and return its translation."""
+        self._jsx_attr_counter += 1
+        if not value.strip():
+            return value
+        unit = self.addsourceunit(value)
+        unit.addlocation(f"{self.filename or ''}:{line_number}")
+        unit.setdocpath(f"jsx-attr[{self._jsx_attr_counter}]/{component}.@{attribute}")
+        return self.callback(value)
+
+    @staticmethod
+    def _escape_attribute(value: str, quote: str, *, changed: bool) -> str:
+        """Encode the active delimiter as a JSX-compatible character entity."""
+        entity = "&quot;" if quote == '"' else "&apos;"
+        value = value.replace(quote, entity)
+        if changed:
+            value = value.replace("<", "&lt;")
+            trailing_backslashes = len(value) - len(value.rstrip("\\"))
+            if trailing_backslashes % 2:
+                value += "\\"
+        return value
+
+    @classmethod
+    def _simple_markdown_children(cls, lines: list[str]) -> bool:
+        """Accept child Markdown only when it contains no MDX structure."""
+        nonblank = [line for line in lines if line.strip()]
+        if not nonblank:
+            return True
+        if any("\t" in line[: len(line) - len(line.lstrip())] for line in nonblank):
+            return False
+        if cls._common_child_indent(lines) >= 4:
+            return False
+        if nonblank[0].lstrip().startswith("---"):
+            return False
+        if any(
+            _LOWER_HTML_START.match(line) is not None
+            or cls._raw_html_end(lines, index) is not None
+            for index, line in enumerate(lines)
+        ):
+            return False
+
+        for _, line in cls._structural_lines(lines):
+            if (
+                re.search(
+                    r"</?[A-Z][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*",
+                    line,
+                )
+                or "<>" in line
+                or "</>" in line
+                or "{" in line
+                or "}" in line
+                or cls._is_esm_start(line.lstrip())
+            ):
+                return False
+        return True
+
+    @staticmethod
+    def _common_child_indent(lines: list[str]) -> int:
+        """Return the common leading-space indentation of nonblank children."""
+        indents = [len(line) - len(line.lstrip(" ")) for line in lines if line.strip()]
+        return min(indents, default=0)
+
+    @staticmethod
+    def _reindent(text: str, prefix: str) -> str:
+        """Restore a component child's structural indentation after rendering."""
+        if not prefix:
+            return text
+        return "".join(
+            f"{prefix}{line}" if line.strip() else line
+            for line in text.splitlines(keepends=True)
+        )
+
+    @classmethod
+    def _first_standalone_close(
+        cls, lines: list[str], start: int, name: str
+    ) -> int | None:
+        """Find the first exact, column-zero closing line for a component."""
+        for index, line in cls._structural_lines(lines, start):
+            closing = _COMPONENT_CLOSE.fullmatch(line)
+            if closing is not None and closing.group("name") == name:
+                return index
+        return None
+
+    @classmethod
+    def _opaque_component_end(cls, lines: list[str], start: int, name: str) -> int:
+        """Conservatively collect unsupported component syntax as one block."""
+        depth = 1
+        for index, line in cls._structural_lines(lines, start + 1):
+            if cls._is_opaque_same_name_open(line, name):
+                depth += 1
+                continue
+            closing = _COMPONENT_CLOSE.fullmatch(line)
+            if closing is not None and closing.group("name") == name:
+                depth -= 1
+                if depth == 0:
+                    return index + 1
+        return cls._blank_delimited_end(lines, start)
+
+    @classmethod
+    def _structural_lines(
+        cls, lines: list[str], start: int = 0
+    ) -> Iterator[tuple[int, str]]:
+        """Yield logical lines outside fenced code and raw HTML blocks."""
+        fence: tuple[str, int] | None = None
+        index = start
+        while index < len(lines):
+            line = lines[index]
+            if fence is not None:
+                if cls._is_fence_close(line, fence):
+                    fence = None
+                index += 1
+                continue
+            fence = cls._fence_open(line)
+            if fence is not None:
+                index += 1
+                continue
+            raw_html_end = cls._raw_html_end(lines, index)
+            if raw_html_end is not None:
+                index = raw_html_end
+                continue
+            yield index, cls._logical_line(line)
+            index += 1
+
+    @staticmethod
+    def _is_opaque_same_name_open(line: str, name: str) -> bool:
+        """Recognize a complete same-name opening line without parsing its attrs."""
+        opening = _COMPONENT_START.match(line)
+        if opening is None or opening.group("name") != name:
+            return False
+        stripped = line.rstrip()
+        if not stripped.endswith(">") or stripped.endswith("/>"):
+            return False
+        closing = re.compile(rf"</\s*{re.escape(name)}\s*>")
+        return closing.search(line, opening.end()) is None
+
+    @staticmethod
+    def _logical_line(line: str) -> str:
+        """Remove the CR from a CRLF line for syntax recognition."""
+        return line.removesuffix("\r")
+
+    def _opaque_lines(self, lines: list[str], start: int, end: int) -> str:
+        """Create a placeholder for a source line range."""
+        return self._make_placeholder(
+            "\n".join(lines[start:end]), source_line_count=end - start
+        )
+
+    def _make_placeholder(
+        self, content: str, source_line_count: int | None = None
+    ) -> str:
+        """Create a collision-resistant HTML comment placeholder."""
+        self._mdx_block_counter += 1
+        key = f"<!-- {self._mdx_block_placeholder_prefix}_{self._mdx_block_counter} -->"
+        padding_lines = (
+            content.count("\n")
+            if source_line_count is None
+            else max(source_line_count - 1, 0)
+        )
+        self._mdx_blocks[key] = (content, padding_lines)
+        return key + ("\n" * padding_lines)
+
+    def _restore_mdx_blocks(self, text: str) -> str:
+        """Restore all opaque and rendered MDX blocks."""
+        for key, (content, padding_lines) in self._mdx_blocks.items():
+            text = text.replace(key + ("\n" * padding_lines), content)
             text = text.replace(key, content)
         return text
 
     @staticmethod
-    def _is_continuation(text: str) -> bool:
-        """
-        Check if a multi-line import/export is incomplete.
+    def _choose_placeholder_prefix(text: str) -> str:
+        """Choose a placeholder prefix not present in user content."""
+        prefix = "MDX_BLOCK"
+        counter = 1
+        while f"<!-- {prefix}_" in text:
+            prefix = f"MDX_BLOCK_{counter}"
+            counter += 1
+        return prefix
 
-        Note: brace and parenthesis counts are naive — characters inside string
-        literals are not excluded. Import paths containing unbalanced brace or
-        paren characters (e.g. ``import x from './path/{section'``) may
-        incorrectly trigger continuation. This is an accepted limitation of
-        regex-based parsing.
-        """
-        # Unclosed braces
-        if text.count("{") > text.count("}"):
-            return True
-        # Unclosed parentheses
-        if text.count("(") > text.count(")"):
-            return True
-        # Line ends with a comma (continuation)
-        return text.rstrip().endswith(",")
+    @staticmethod
+    def _frontmatter_line_count(lines: list[str]) -> int:
+        """Return the number of leading YAML front matter lines."""
+        if not lines or not lines[0].startswith("---"):
+            return 0
+        for line_number, line in enumerate(lines[1:], start=1):
+            if line.startswith(("---", "...")):
+                return line_number + 1
+        return 0
+
+    @classmethod
+    def _frontmatter_body_offset(cls, lines: list[str]) -> int:
+        """Return the line offset used by Markdown body unit locations."""
+        offset = cls._frontmatter_line_count(lines)
+        if offset and offset < len(lines) and not lines[offset].strip():
+            offset += 1
+        return offset
+
+    @staticmethod
+    def _blank_delimited_end(lines: list[str], start: int) -> int:
+        """Return the first blank line after a conservative opaque block."""
+        end = start + 1
+        while end < len(lines) and lines[end].strip():
+            end += 1
+        return end
+
+    @classmethod
+    def _extend_to_blank(cls, lines: list[str], end: int) -> int:
+        """Extend a non-isolated construct through its Markdown block."""
+        if cls._is_block_end(lines, end):
+            return end
+        return cls._blank_delimited_end(lines, end)
+
+    @staticmethod
+    def _is_block_end(lines: list[str], end: int) -> bool:
+        """Return whether a construct ends at EOF or before a blank line."""
+        return end >= len(lines) or not lines[end].strip()
+
+    @classmethod
+    def _chunk_requires_opaque(cls, lines: list[str]) -> bool:
+        """Reject an ordinary Markdown block containing structural MDX."""
+        for line in lines:
+            logical_line = cls._logical_line(line)
+            if (
+                _COMPONENT_START.match(logical_line)
+                or _COMPONENT_CLOSE.fullmatch(logical_line)
+                or _FRAGMENT_START.match(logical_line)
+                or cls._is_esm_start(line)
+            ):
+                return True
+            if (
+                not cls._is_indented_code(line)
+                and not re.match(r"(?:>|[-+*]\s|\d+[.)]\s)", line.lstrip())
+                and ("{" in line or "}" in line)
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _is_indented_code(line: str) -> bool:
+        """Return whether a line has top-level Markdown code indentation."""
+        column = 0
+        for character in line:
+            if character == " ":
+                column += 1
+            elif character == "\t":
+                column += 4 - (column % 4)
+            else:
+                break
+        return column >= 4
+
+    @staticmethod
+    def _translate_off_end(lines: list[str], start: int) -> int:
+        """Collect an exact translation-control region through translate:on."""
+        for index in range(start + 1, len(lines)):
+            if lines[index].strip() == "<!-- translate:on -->":
+                return index + 1
+        return len(lines)
+
+    @staticmethod
+    def _is_esm_start(line: str) -> bool:
+        """Recognize a top-level MDX ESM statement without parsing JavaScript."""
+        return line == line.lstrip() and _ESM_START.match(line) is not None
+
+    @staticmethod
+    def _fence_open(line: str) -> tuple[str, int] | None:
+        """Return the character and length of a top-level Markdown fence."""
+        match = _FENCE.match(line)
+        if match is None:
+            return None
+        delimiter = match.group("delimiter")
+        return delimiter[0], len(delimiter)
+
+    @staticmethod
+    def _is_fence_close(line: str, fence: tuple[str, int]) -> bool:
+        """Return whether a line closes the active Markdown fence."""
+        character, length = fence
+        match = re.fullmatch(r" {0,3}(`{3,}|~{3,})\s*", line)
+        return bool(
+            match and match.group(1)[0] == character and len(match.group(1)) >= length
+        )
+
+    @classmethod
+    def _raw_html_end(cls, lines: list[str], start: int) -> int | None:
+        """Return the end of raw HTML that must remain opaque to JSX scanning."""
+        line = lines[start]
+        stripped = line.lstrip(" ")
+        if len(line) - len(stripped) > 3:
+            return None
+
+        if stripped.startswith("<!--"):
+            return cls._marker_end(lines, start, "-->")
+        if stripped.startswith("<?"):
+            return cls._marker_end(lines, start, "?>")
+        if stripped.startswith("<![CDATA["):
+            return cls._marker_end(lines, start, "]]>")
+        if re.match(r"<![A-Za-z]", stripped):
+            return cls._marker_end(lines, start, ">")
+
+        match = _LOWER_HTML_START.match(line)
+        if match is None:
+            return None
+        tag = match.group("tag")
+        if re.search(rf"</\s*{re.escape(tag)}\s*>", line, re.IGNORECASE):
+            return None
+        if line.rstrip().endswith("/>"):
+            return None
+        if tag.lower() in {"pre", "script", "style", "textarea"}:
+            return cls._marker_end(lines, start, f"</{tag}>", ignore_case=True)
+        return cls._blank_delimited_end(lines, start)
+
+    @staticmethod
+    def _marker_end(
+        lines: list[str],
+        start: int,
+        marker: str,
+        *,
+        ignore_case: bool = False,
+    ) -> int:
+        """Collect through a literal raw-HTML terminator or end of file."""
+        needle = marker.lower() if ignore_case else marker
+        for index in range(start, len(lines)):
+            haystack = lines[index].lower() if ignore_case else lines[index]
+            if needle in haystack:
+                return index + 1
+        return len(lines)
+
+    @staticmethod
+    def _unit_source_line(unit: MarkdownUnit) -> int:
+        """Return the numeric source line used for stable unit ordering."""
+        for location in unit.getlocations():
+            match = re.search(r":(\d+)$", location)
+            if match:
+                return int(match.group(1))
+        return 0
+
+    @classmethod
+    def _unit_document_line(cls, unit: MarkdownUnit, frontmatter_offset: int) -> int:
+        """Return an absolute source line for document-order sorting."""
+        line = cls._unit_source_line(unit)
+        docpath = unit.getdocpath() or ""
+        if docpath.startswith("frontmatter"):
+            return 0
+        if docpath.startswith("jsx-"):
+            return line
+        return line + frontmatter_offset


### PR DESCRIPTION
Limit extraction to structurally isolated JSX so ambiguous MDX remains opaque instead of requiring a partial JSX or JavaScript parser.

Extract simple quoted attributes and Markdown children while preserving unsupported layouts verbatim.

Fixes WeblateOrg/weblate#20374