### PR TITLE
perf(yaml): avoid quadratic comment lookup

### DIFF
--- a/tests/translate/storage/test_yaml.py
+++ b/tests/translate/storage/test_yaml.py
@@ -1,4 +1,5 @@
 import pytest
+from ruamel.yaml.comments import CommentedMap
 
 from translate.misc.multistring import multistring
 from translate.storage import base, yaml
@@ -564,6 +565,26 @@ key2: value2
         assert len(store.units) == 2
         assert store.units[0].getnotes() == ""
         assert store.units[1].getnotes() == ""
+
+    def test_sibling_keys_are_indexed_once(self) -> None:
+        """Comment extraction should not scan all sibling keys per value."""
+
+        class CountingCommentedMap(CommentedMap):
+            def __init__(self, *args, **kwargs) -> None:
+                self.keys_calls = 0
+                super().__init__(*args, **kwargs)
+
+            def keys(self):
+                self.keys_calls += 1
+                return super().keys()
+
+        data = CountingCommentedMap(
+            (f"key_{index}", f"value_{index}") for index in range(10)
+        )
+
+        list(self.StoreClass()._flatten(data))
+
+        assert data.keys_calls == 1
 
     def test_multiline_literal_format(self) -> None:
         """Test that multiline strings use literal format (|) for better readability."""

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -190,7 +190,7 @@ class YAMLFile(base.DictStore[YAMLUnit]):
                         comment_lines.append(line[1:].strip())
         return comment_lines
 
-    def _get_key_comment(self, commented_map, key):
+    def _get_key_comment(self, commented_map, key, previous_key, is_first_key):
         """
         Extract the comment that appears before a key in a CommentedMap.
 
@@ -205,28 +205,22 @@ class YAMLFile(base.DictStore[YAMLUnit]):
             return None
 
         comment_lines = []
-        keys = list(commented_map.keys())
 
         # Check for top-level comment if this is the first key
-        if keys and keys[0] == key:
+        if is_first_key:
             ca_comment = getattr(commented_map.ca, "comment", None)
             if ca_comment and len(ca_comment) > 1 and ca_comment[1]:
                 comment_lines.extend(self._extract_comment_lines(ca_comment[1]))
 
         # For non-first keys, check the previous key's end comment
-        elif key in keys:
-            key_index = keys.index(key)
-            if key_index > 0 and hasattr(commented_map.ca, "items"):
-                prev_key = keys[key_index - 1]
-                prev_comment_info = commented_map.ca.items.get(prev_key)
-                if (
-                    prev_comment_info
-                    and len(prev_comment_info) > 2
-                    and prev_comment_info[2]
-                ):
-                    comment_lines.extend(
-                        self._extract_comment_lines(prev_comment_info[2])
-                    )
+        elif hasattr(commented_map.ca, "items"):
+            prev_comment_info = commented_map.ca.items.get(previous_key)
+            if (
+                prev_comment_info
+                and len(prev_comment_info) > 2
+                and prev_comment_info[2]
+            ):
+                comment_lines.extend(self._extract_comment_lines(prev_comment_info[2]))
 
         # Check for comments on separate lines before this key
         if hasattr(commented_map.ca, "items"):
@@ -238,11 +232,27 @@ class YAMLFile(base.DictStore[YAMLUnit]):
 
     def _parse_dict(self, data, prev):
         # Avoid using merged items, it is enough to have them once
+        keys = list(data.keys())
+        key_positions = {key: position for position, key in enumerate(keys)}
         for k, v in data.non_merged_items():
-            yield from self._flatten(v, prev.extend("key", k), parent_map=data, key=k)
+            position = key_positions[k]
+            yield from self._flatten(
+                v,
+                prev.extend("key", k),
+                parent_map=data,
+                key=k,
+                previous_key=keys[position - 1] if position else None,
+                is_first_key=position == 0,
+            )
 
     def _flatten(
-        self, data, prev=None, parent_map=None, key=None
+        self,
+        data,
+        prev=None,
+        parent_map=None,
+        key=None,
+        previous_key=None,
+        is_first_key=False,
     ) -> Generator[tuple[base.UnitId, str, str | None]]:
         """
         Flatten YAML dictionary.
@@ -254,16 +264,28 @@ class YAMLFile(base.DictStore[YAMLUnit]):
         if isinstance(data, dict):
             yield from self._parse_dict(data, prev)
         elif isinstance(data, str):
-            yield (prev, data, self._get_key_comment(parent_map, key))
+            yield (
+                prev,
+                data,
+                self._get_key_comment(parent_map, key, previous_key, is_first_key),
+            )
         elif isinstance(data, (bool, int)):
-            yield (prev, str(data), self._get_key_comment(parent_map, key))
+            yield (
+                prev,
+                str(data),
+                self._get_key_comment(parent_map, key, previous_key, is_first_key),
+            )
         elif isinstance(data, list):
             for k, v in enumerate(data):
                 yield from self._flatten(
                     v, prev.extend("index", k), parent_map=data, key=k
                 )
         elif isinstance(data, TaggedScalar):
-            yield (prev, data.value, self._get_key_comment(parent_map, key))
+            yield (
+                prev,
+                data.value,
+                self._get_key_comment(parent_map, key, previous_key, is_first_key),
+            )
         elif data is None:
             pass
         else:


### PR DESCRIPTION
Index sibling keys once to speed up loading large YAML catalogs.