### PR TITLE
perf(storage): cache plural tag lookups

### DIFF
--- a/tests/translate/storage/test_base.py
+++ b/tests/translate/storage/test_base.py
@@ -92,6 +92,37 @@ def test_known_language_single_plural_tags_keep_language_mapping() -> None:
     assert store.get_plural_tags(multistring(["one form"])) == ["one", "other"]
 
 
+def test_plural_tags_are_cached_by_language_and_count(monkeypatch) -> None:
+    get_cldr_plural_tags = base.get_cldr_plural_tags
+    get_cldr_plural_tags_calls = 0
+
+    def counting_get_cldr_plural_tags(locale, plural_count=None):
+        nonlocal get_cldr_plural_tags_calls
+        get_cldr_plural_tags_calls += 1
+        return get_cldr_plural_tags(locale, plural_count)
+
+    monkeypatch.setattr(base, "get_cldr_plural_tags", counting_get_cldr_plural_tags)
+    store = base.TranslationStore()
+    store.settargetlanguage("en")
+
+    assert store.get_plural_tags(multistring(["one", "other"])) == ["one", "other"]
+    assert store.get_plural_tags(multistring(["first", "second"])) == [
+        "one",
+        "other",
+    ]
+
+    store.settargetlanguage("ar")
+    assert store.get_plural_tags(multistring(["one", "other"])) == [
+        "zero",
+        "one",
+        "two",
+        "few",
+        "many",
+        "other",
+    ]
+    assert get_cldr_plural_tags_calls == 2
+
+
 class TestTranslationUnit:
     """
     Tests a TranslationUnit.

--- a/tests/translate/storage/test_jsonl10n.py
+++ b/tests/translate/storage/test_jsonl10n.py
@@ -1,3 +1,4 @@
+import json
 from io import BytesIO
 
 from pytest import mark, raises
@@ -1208,6 +1209,41 @@ class TestI18NextV4Store(test_monolingual.TestMonolingualStore):
         store.targetlanguage = "ar"
         store.parse(self.PartiallyPluralizedJson)
         assert len(store.units) == 4
+
+    def test_plural_tags_resolved_once(self, monkeypatch) -> None:
+        """Resolve invariant locale plural tags once for the whole catalog."""
+        store = self.StoreClass()
+        store.targetlanguage = "en"
+        get_plural_tags = store.get_plural_tags
+        get_plural_tags_calls = 0
+
+        def counting_get_plural_tags():
+            nonlocal get_plural_tags_calls
+            get_plural_tags_calls += 1
+            return get_plural_tags()
+
+        monkeypatch.setattr(store, "get_plural_tags", counting_get_plural_tags)
+        messages = {
+            f"message_{index}_{suffix}": suffix
+            for index in range(100)
+            for suffix in ("one", "other")
+        }
+
+        store.parse(json.dumps(messages))
+
+        assert len(store.units) == 100
+        assert get_plural_tags_calls == 1
+
+    def test_plural_base_processed_once(self) -> None:
+        """Do not duplicate a group containing an extra CLDR plural form."""
+        store = self.StoreClass()
+        store.targetlanguage = "en"
+
+        store.parse(
+            '{"message_one": "one", "message_other": "other", "message_few": "few"}'
+        )
+
+        assert len(store.units) == 1
 
     def test_plurals(self) -> None:
         store = self.StoreClass()

--- a/tests/translate/storage/test_yaml.py
+++ b/tests/translate/storage/test_yaml.py
@@ -650,6 +650,26 @@ class TestRubyYAMLResourceStore(test_monolingual.TestMonolingualStore):
         store.parse(data)
         assert bytes(store) == data.encode("ascii")
 
+    def test_plural_tags_only_resolved_for_plural_mappings(self, monkeypatch) -> None:
+        store = self.StoreClass()
+        get_plural_tags = store.get_plural_tags
+        get_plural_tags_calls = 0
+
+        def counting_get_plural_tags(target=None):
+            nonlocal get_plural_tags_calls
+            get_plural_tags_calls += 1
+            return get_plural_tags(target)
+
+        monkeypatch.setattr(store, "get_plural_tags", counting_get_plural_tags)
+        data = "en:\n" + "".join(
+            f"  group_{index}:\n    message: Value {index}\n" for index in range(100)
+        )
+
+        store.parse(data)
+
+        assert len(store.units) == 100
+        assert get_plural_tags_calls == 0
+
     def test_ruby_wrong(self) -> None:
         data = """no_data: No data
 """

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -881,6 +881,7 @@ class TranslationStore(Generic[U]):
         self.locationindex = {}
         self.sourceindex = {}
         self.id_index = {}
+        self._plural_tags_cache: dict[tuple[str | None, int | None], list[str]] = {}
 
     @property
     def encoding(self):
@@ -1277,11 +1278,20 @@ class TranslationStore(Generic[U]):
     def get_plural_tags(
         self, target: list[str] | str | multistring | None = None
     ) -> list[str]:
-        locale = self.get_base_locale_code()
         plural_count = None
         if target is not None:
-            plural_count = len(self.UnitClass.get_plural_strings(target))
-        return get_cldr_plural_tags(locale, plural_count)
+            if isinstance(target, multistring):
+                plural_count = len(target.strings)
+            elif isinstance(target, list):
+                plural_count = len(target)
+            else:
+                plural_count = 1
+        cache_key = (self.gettargetlanguage(), plural_count)
+        if cache_key not in self._plural_tags_cache:
+            self._plural_tags_cache[cache_key] = get_cldr_plural_tags(
+                self.get_base_locale_code(), plural_count
+            )
+        return self._plural_tags_cache[cache_key]
 
 
 class UnitId:

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -532,18 +532,16 @@ class I18NextV4File(JsonNestedFile):
         name_node=None,
         name_last_node=None,
         last_node=None,
+        plural_tags=None,
     ):
         if prev is None:
             prev = self.UnitClass.IdClass([])
+        if plural_tags is None:
+            plural_tags = self.get_plural_tags()
         if isinstance(data, dict):
-            processed = set()
+            processed_plural_bases = set()
 
             for k, v in data.items():
-                # Check already processed items
-                if k in processed:
-                    continue
-
-                plurals = []
                 suffix = ""
                 plural_base = ""
 
@@ -551,17 +549,11 @@ class I18NextV4File(JsonNestedFile):
                     plural_base, suffix = k.rsplit("_", 1)
 
                 if suffix in cldr_plural_categories:
-                    plurals = [
-                        f"{plural_base}_{suffix}" for suffix in self.get_plural_tags()
-                    ]
-
-                if plurals:
-                    sources = []
-                    items = []
-                    for key in plurals:
-                        processed.add(key)
-                        sources.append(data.get(key, ""))
-                        items.append(key)
+                    if plural_base in processed_plural_bases:
+                        continue
+                    processed_plural_bases.add(plural_base)
+                    items = [f"{plural_base}_{suffix}" for suffix in plural_tags]
+                    sources = [data.get(key, "") for key in items]
 
                     unit = self.UnitClass(multistring(sources), items)
                     newid = prev.extend("key", plural_base)
@@ -570,7 +562,13 @@ class I18NextV4File(JsonNestedFile):
                     continue
 
                 yield from self._extract_units(
-                    v, stop, prev.extend("key", k), k, None, data
+                    v,
+                    stop,
+                    prev.extend("key", k),
+                    k,
+                    None,
+                    data,
+                    plural_tags,
                 )
         else:
             yield from super()._extract_units(

--- a/translate/storage/yaml.py
+++ b/translate/storage/yaml.py
@@ -356,8 +356,8 @@ class RubyYAMLFile(YAMLFile):
 
     def _parse_dict(self, data, prev):
         # Does this look like a plural?
-        tags = self.get_plural_tags()
         if data and all(x in cldr_plural_categories for x in data):
+            tags = self.get_plural_tags()
             # Ensure we have correct plurals ordering.
             values = [data[item] for item in tags if item in data]
 


### PR DESCRIPTION
Reduce repeated CLDR work and memory use when processing large plural catalogs.