### PR TITLE
chore: correct language model copyright attribution

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -12,7 +12,10 @@ path = [
   "translate/share/langmodels/fpdb.conf"
 ]
 precedence = "override"
-SPDX-FileCopyrightText = "2003 WiseGuys Internet B.V."
+SPDX-FileCopyrightText = [
+  "Gertjan van Noord",
+  "Jocelyn Merand <joc.mer@gmail.com>"
+]
 SPDX-License-Identifier = "BSD-3-Clause"
 
 [[annotations]]


### PR DESCRIPTION
Attribute the bundled TextCat models to their original author and OpenOffice adapter so REUSE and SBOM output names the actual rights holders.