### PR TITLE
fix(applestrings): preserve Apple XLIFF workflow state

### DIFF
--- a/tests/translate/storage/test_applestrings_xliff.py
+++ b/tests/translate/storage/test_applestrings_xliff.py
@@ -23,6 +23,32 @@ _SINGULAR_XLIFF = b"""<?xml version="1.0" encoding="UTF-8"?>
   </file>
 </xliff>"""
 
+# Based on Apple's documented XLIFF editing example:
+# https://developer.apple.com/documentation/xcode/editing-xliff-and-string-catalog-files
+_APPLE_WORKFLOW_XLIFF = b"""<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="Localizable.strings" source-language="en" target-language="de" datatype="plaintext">
+    <body>
+      <trans-unit id="greeting" xml:space="preserve">
+        <source>Hello, world!</source>
+        <target>Hallo, Welt!</target>
+        <note>A friendly greeting.</note>
+      </trans-unit>
+      <trans-unit id="missing-target" xml:space="preserve">
+        <source>Missing target</source>
+      </trans-unit>
+      <trans-unit id="empty-target" xml:space="preserve">
+        <source>Empty target</source>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="explicit-state" xml:space="preserve">
+        <source>Explicit state</source>
+        <target state="needs-review-translation" state-qualifier="leveraged-mt">Expliziter Status</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>"""
+
 _BASIC_PLURAL_XLIFF = b"""<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="Localizable.strings" source-language="en" target-language="en" datatype="plaintext">
@@ -87,6 +113,7 @@ class TestAppleStringsXliffUnit(test_xliff.TestXLIFFUnit):
     """Tests for AppleStringsXliffUnit."""
 
     UnitClass = applestrings_xliff.AppleStringsXliffUnit
+    StoreClass = applestrings_xliff.AppleStringsXliffFile
 
 
 # ---------------------------------------------------------------------------
@@ -98,6 +125,9 @@ class TestAppleStringsXliffFile(test_xliff.TestXLIFFfile):
     """Tests for AppleStringsXliffFile."""
 
     StoreClass = applestrings_xliff.AppleStringsXliffFile
+    translated_unit_attributes = ""
+    translated_target_attributes = ""
+    fuzzy_without_target_attribute = ""
 
     # ------------------------------------------------------------------
     # Basic parsing
@@ -113,6 +143,170 @@ class TestAppleStringsXliffFile(test_xliff.TestXLIFFfile):
         assert unit.source == "Hello"
         assert unit.target == "Hello"
         assert not unit.hasplural()
+
+    def test_parse_apple_workflow(self):
+        """Apple targets and bare developer notes have implicit semantics."""
+        store = self.StoreClass.parsestring(_APPLE_WORKFLOW_XLIFF)
+        greeting, missing_target, empty_target, explicit_state = store.units
+
+        assert greeting.get_state_n() == greeting.S_TRANSLATED
+        assert greeting.isapproved()
+        assert not greeting.isfuzzy()
+        assert greeting.getnotes() == "A friendly greeting."
+        assert greeting.getnotes(origin="developer") == "A friendly greeting."
+
+        assert missing_target.get_state_n() == missing_target.S_UNTRANSLATED
+        assert not missing_target.isapproved()
+        assert not missing_target.isfuzzy()
+
+        assert empty_target.get_state_n() == empty_target.S_UNTRANSLATED
+        assert not empty_target.isapproved()
+        assert not empty_target.isfuzzy()
+
+        assert explicit_state.get_state_n() == explicit_state.S_NEEDS_REVIEW
+        assert not explicit_state.isapproved()
+        assert explicit_state.isfuzzy()
+
+    def test_whitespace_target_inherits_unit_xml_space(self):
+        """Whitespace-only targets respect xml:space on the trans-unit."""
+        content = _APPLE_WORKFLOW_XLIFF.replace(
+            b"<target>Hallo, Welt!</target>",
+            b"<target>   </target>",
+        )
+        greeting = self.StoreClass.parsestring(content).units[0]
+
+        assert greeting.target == "   "
+        assert greeting.get_state_n() == greeting.S_TRANSLATED
+        assert greeting.isapproved()
+        assert greeting.istranslated()
+        assert not greeting.isfuzzy()
+
+    def test_apple_workflow_serialization(self):
+        """Apple metadata round-trips without synthesized XLIFF attributes."""
+        store = self.StoreClass.parsestring(_APPLE_WORKFLOW_XLIFF)
+        greeting = store.units[0]
+
+        greeting.target = "Guten Tag!"
+        greeting.addnote("Shown to translators.", origin="developer")
+        greeting.addnote("Internal note.", origin="translator")
+
+        serialized = bytes(store)
+        reparsed = self.StoreClass.parsestring(serialized)
+        greeting = reparsed.units[0]
+        explicit_state = reparsed.units[3]
+
+        assert "approved" not in greeting.xmlelement.attrib
+        assert "state" not in greeting.get_target_dom().attrib
+        assert greeting.getnotes(origin="developer") == (
+            "A friendly greeting.\nShown to translators."
+        )
+        assert greeting.getnotes(origin="translator") == "Internal note."
+
+        note_nodes = list(
+            greeting.xmlelement.iterdescendants(greeting.namespaced("note"))
+        )
+        assert [note.get("from") for note in note_nodes] == [
+            None,
+            None,
+            "translator",
+        ]
+
+        explicit_target = explicit_state.get_target_dom()
+        assert explicit_target.get("state") == "needs-review-translation"
+        assert explicit_target.get("state-qualifier") == "leveraged-mt"
+
+    def test_apple_state_transitions(self):
+        """Explicit workflow transitions remain observable without approval tags."""
+        store = self.StoreClass.parsestring(_APPLE_WORKFLOW_XLIFF)
+        greeting = store.units[0]
+        target = greeting.get_target_dom()
+
+        greeting.set_state_n(greeting.S_UNTRANSLATED)
+        assert target.get("state") == "new"
+        assert greeting.get_state_n() == greeting.S_UNTRANSLATED
+        assert not greeting.isapproved()
+
+        greeting.markapproved()
+        assert target.get("state") == "translated"
+        assert greeting.isapproved()
+
+        greeting.markapproved(False)
+        assert target.get("state") == "needs-review-translation"
+        assert not greeting.isapproved()
+        assert greeting.isfuzzy()
+        assert "approved" not in greeting.xmlelement.attrib
+
+    def test_state_transition_creates_missing_singular_target(self):
+        """A singular state transition persists without an existing target."""
+        store = self.StoreClass.parsestring(_APPLE_WORKFLOW_XLIFF)
+        missing_target = store.units[1]
+        assert missing_target.get_target_dom() is None
+
+        missing_target.markapproved()
+
+        target = missing_target.get_target_dom()
+        assert target is not None
+        assert target.get("state") == "translated"
+        assert missing_target.get_state_n() == missing_target.S_TRANSLATED
+        assert missing_target.isapproved()
+
+        reparsed = self.StoreClass.parsestring(bytes(store)).units[1]
+        assert reparsed.get_target_dom() is not None
+        assert reparsed.get_state_n() == reparsed.S_TRANSLATED
+        assert reparsed.isapproved()
+
+    def test_state_transition_removes_generic_approval(self):
+        """Apple target state does not conflict with generic approval metadata."""
+        content = _APPLE_WORKFLOW_XLIFF.replace(
+            b'<trans-unit id="greeting"',
+            b'<trans-unit id="greeting" approved="yes"',
+        )
+        store = self.StoreClass.parsestring(content)
+        greeting = store.units[0]
+        assert greeting.xmlelement.get("approved") == "yes"
+
+        greeting.markapproved(False)
+
+        assert "approved" not in greeting.xmlelement.attrib
+        assert greeting.get_target_dom().get("state") == "needs-review-translation"
+        serialized = bytes(store)
+        assert b"approved=" not in serialized
+
+        reparsed = self.StoreClass.parsestring(serialized).units[0]
+        assert reparsed.get_state_n() == reparsed.S_NEEDS_REVIEW
+        assert not reparsed.isapproved()
+
+    def test_exact_xliff_states_are_preserved(self):
+        """Setting an exact numeric state does not collapse XLIFF variants."""
+        greeting = self.StoreClass.parsestring(_APPLE_WORKFLOW_XLIFF).units[0]
+        target = greeting.get_target_dom()
+
+        for xml_state, state_n in greeting.statemap.items():
+            if xml_state == "new":
+                continue
+            target.set("state", xml_state)
+            assert greeting.get_state_n() == state_n
+
+            greeting.set_state_n(greeting.get_state_n())
+
+            assert target.get("state") == xml_state
+
+    def test_remove_bare_developer_notes(self):
+        store = self.StoreClass.parsestring(_APPLE_WORKFLOW_XLIFF)
+        greeting = store.units[0]
+        greeting.addnote("Internal note.", origin="translator")
+        greeting.addnote(
+            "Replacement developer note.",
+            origin="developer",
+            position="replace",
+        )
+
+        assert greeting.getnotes(origin="developer") == "Replacement developer note."
+        assert greeting.getnotes(origin="translator") == "Internal note."
+
+        greeting.removenotes(origin="developer")
+
+        assert greeting.getnotes() == "Internal note."
 
     def test_parse_apple_plural_basic(self):
         """Plurals are folded into one unit with a multistring source/target."""
@@ -134,6 +328,214 @@ class TestAppleStringsXliffFile(test_xliff.TestXLIFFfile):
         assert unit.source.strings[2] == "%d items"  # 'other' form
         assert unit.target.strings[1] == "One item"
         assert unit.target.strings[2] == "%d items"
+
+    def test_plural_state_aggregation_and_propagation(self):
+        """Folded plurals expose and update their least-complete form state."""
+        content = _BASIC_PLURAL_XLIFF.replace(
+            b"<target>One item</target>",
+            b'<target state="needs-review-translation">One item</target>',
+        )
+        store = self.StoreClass.parsestring(content)
+        unit = store.units[0]
+
+        assert unit.get_state_n() == unit.S_NEEDS_REVIEW
+        assert not unit.isapproved()
+        assert unit.isfuzzy()
+
+        unit.markapproved()
+        assert unit.get_state_n() == unit.S_TRANSLATED
+        assert unit.isapproved()
+        assert bytes(store).count(b'state="translated"') == 2
+
+        unit.markapproved(False)
+        assert unit.get_state_n() == unit.S_NEEDS_REVIEW
+        assert not unit.isapproved()
+        assert bytes(store).count(b'state="needs-review-translation"') == 2
+
+        unit.set_state_n(unit.S_UNTRANSLATED)
+        assert unit.get_state_n() == unit.S_UNTRANSLATED
+        assert bytes(store).count(b'state="new"') == 2
+
+        unit.markapproved(False)
+        unit.target = multistring(["", "One translated item", "%d translated items"])
+        serialized = bytes(store)
+        assert serialized.count(b'state="needs-review-translation"') == 2
+
+        reparsed = self.StoreClass.parsestring(serialized)
+        assert reparsed.units[0].get_state_n() == unit.S_NEEDS_REVIEW
+
+    def test_dirty_plural_state_uses_in_memory_targets(self):
+        """Plural state changes immediately when implicit target forms are edited."""
+        store = self.StoreClass.parsestring(_BASIC_PLURAL_XLIFF)
+        unit = store.units[0]
+
+        unit.target = multistring(["", "", "%d items"])
+
+        assert unit.get_state_n() == unit.S_UNTRANSLATED
+        assert not unit.isapproved()
+        assert not unit.istranslated()
+        assert unit.isfuzzy()
+
+        unit.target = multistring(["", "One translated item", "%d items"])
+
+        assert unit.get_state_n() == unit.S_TRANSLATED
+        assert unit.isapproved()
+        assert unit.istranslated()
+        assert not unit.isfuzzy()
+
+    def test_dirty_empty_plural_ignores_stale_translated_state(self):
+        """Clearing a form supersedes its old explicit translated state."""
+        content = _BASIC_PLURAL_XLIFF.replace(
+            b"<target>One item</target>",
+            b'<target state="translated">One item</target>',
+        ).replace(
+            b"<target>%d items</target>",
+            b'<target state="translated">%d items</target>',
+        )
+        store = self.StoreClass.parsestring(content)
+        unit = store.units[0]
+        assert unit.get_state_n() == unit.S_TRANSLATED
+
+        unit.target = multistring(["", "", "%d items"])
+
+        assert unit.get_state_n() == unit.S_UNTRANSLATED
+        assert not unit.isapproved()
+        assert not unit.istranslated()
+        assert unit.isfuzzy()
+
+        serialized = bytes(store)
+        assert serialized.count(b'state="translated"') == 1
+        reparsed = self.StoreClass.parsestring(serialized).units[0]
+        assert reparsed.get_state_n() == reparsed.S_UNTRANSLATED
+        assert not reparsed.isapproved()
+
+    def test_plural_target_edit_clears_state_override(self):
+        """Editing targets invalidates an earlier plural-wide transition."""
+        store = self.StoreClass.parsestring(_BASIC_PLURAL_XLIFF)
+        unit = store.units[0]
+        unit.markapproved()
+        assert unit._plural_state_override == unit.S_TRANSLATED
+
+        unit.target = multistring(["", "", "%d items"])
+
+        assert unit._plural_state_override is None
+        assert unit.get_state_n() == unit.S_UNTRANSLATED
+        assert not unit.isapproved()
+        assert not unit.istranslated()
+
+        serialized = bytes(store)
+        assert serialized.count(b'state="translated"') == 1
+        reparsed = self.StoreClass.parsestring(serialized).units[0]
+        assert reparsed.get_state_n() == reparsed.S_UNTRANSLATED
+
+    def test_dirty_plural_preserves_unchanged_empty_form_state(self):
+        """Editing another form retains state metadata on an empty target."""
+        content = _BASIC_PLURAL_XLIFF.replace(
+            b"<target>One item</target>",
+            b'<target state="needs-review-translation"></target>',
+        )
+        store = self.StoreClass.parsestring(content)
+        unit = store.units[0]
+        assert unit.get_state_n() == unit.S_NEEDS_REVIEW
+
+        unit.target = multistring(["", "", "%d translated items"])
+
+        assert unit._plural_dirty_targets == {"other"}
+        assert unit.get_state_n() == unit.S_NEEDS_REVIEW
+        serialized = bytes(store)
+        assert serialized.count(b'state="needs-review-translation"') == 1
+
+        reparsed = self.StoreClass.parsestring(serialized).units[0]
+        assert reparsed.get_state_n() == reparsed.S_NEEDS_REVIEW
+
+    def test_new_plural_state_derives_target_tags(self):
+        """New plural state evaluates each required in-memory target form."""
+        store = self.StoreClass()
+        store.settargetlanguage("en")
+        unit = _add_plural(
+            store,
+            "items:count",
+            ["", "", "%d items"],
+            source_strings=["", "One item", "%d items"],
+        )
+        assert unit._plural_tags == []
+
+        assert unit.get_state_n() == unit.S_UNTRANSLATED
+        assert not unit.isapproved()
+        assert not unit.istranslated()
+        assert unit.isfuzzy()
+
+    def test_plural_state_transition_creates_missing_targets(self):
+        """A plural state transition persists when form targets are absent."""
+        content = _BASIC_PLURAL_XLIFF.replace(
+            b"        <target>One item</target>\n",
+            b"",
+        ).replace(
+            b"        <target>%d items</target>\n",
+            b"",
+        )
+        store = self.StoreClass.parsestring(content)
+        unit = store.units[0]
+        assert all(
+            next(form.iterchildren(unit.namespaced("target")), None) is None
+            for form in unit._plural_forms.values()
+        )
+
+        unit.markapproved()
+
+        assert unit._plural_dirty
+        serialized = bytes(store)
+        assert serialized.count(b'state="translated"') == 2
+
+        reparsed = self.StoreClass.parsestring(serialized).units[0]
+        assert reparsed.get_state_n() == reparsed.S_TRANSLATED
+        assert reparsed.isapproved()
+
+    def test_dirty_plural_preserves_per_form_state(self):
+        """Rebuilding edited forms retains each form's exact explicit state."""
+        content = _BASIC_PLURAL_XLIFF.replace(
+            b"<target>One item</target>",
+            b'<target state="needs-review-adaptation" '
+            b'state-qualifier="leveraged-mt">One item</target>',
+        )
+        store = self.StoreClass.parsestring(content)
+        unit = store.units[0]
+
+        unit.target = multistring(["", "One translated item", "%d translated items"])
+        serialized = bytes(store)
+
+        assert serialized.count(b'state="needs-review-adaptation"') == 1
+        assert serialized.count(b'state-qualifier="leveraged-mt"') == 1
+        assert serialized.count(b" state=") == 1
+        reparsed = self.StoreClass.parsestring(serialized)
+        assert (
+            reparsed.units[0].get_state_n() == unit.statemap["needs-review-adaptation"]
+        )
+        one_target = next(
+            reparsed.units[0]
+            ._plural_forms["one"]
+            .iterchildren(reparsed.units[0].namespaced("target"))
+        )
+        assert one_target.get("state-qualifier") == "leveraged-mt"
+
+    def test_plural_state_uses_folded_form_index(self, monkeypatch):
+        """State reads and writes do not rescan the containing XML body."""
+        store = self.StoreClass.parsestring(_BASIC_PLURAL_XLIFF)
+        unit = store.units[0]
+        assert set(unit._plural_forms) == {"one", "other"}
+
+        def fail_on_scan(*args):
+            raise AssertionError("plural state rescanned the XML body")
+
+        monkeypatch.setattr(
+            self.StoreClass,
+            "_is_plural_form_sibling",
+            fail_on_scan,
+        )
+
+        assert unit.get_state_n() == unit.S_TRANSLATED
+        unit.markapproved(False)
+        assert unit.get_state_n() == unit.S_NEEDS_REVIEW
 
     def test_parse_apple_plural_complex(self):
         """Each plural group becomes one unit; regular units are preserved."""

--- a/tests/translate/storage/test_poxliff.py
+++ b/tests/translate/storage/test_poxliff.py
@@ -8,6 +8,7 @@ from . import test_xliff
 
 class TestPOXLIFFUnit(test_xliff.TestXLIFFUnit):
     UnitClass = poxliff.PoXliffUnit
+    StoreClass = poxliff.PoXliffFile
 
     def test_plurals(self) -> None:
         """Tests that plurals are handled correctly."""
@@ -235,6 +236,9 @@ class TestPOXLIFFUnit(test_xliff.TestXLIFFUnit):
 
 class TestPOXLIFFfile(test_xliff.TestXLIFFfile):
     StoreClass = poxliff.PoXliffFile
+    supports_inline_placeables = False
+    supports_plain_rich_target = False
+    supports_xliff_locations = False
     xliffskeleton = """<?xml version="1.0" ?>
 <xliff version="1.1" xmlns="urn:oasis:names:tc:xliff:document:1.1">
   <file original="filename.po" source-language="en-US" datatype="po">

--- a/tests/translate/storage/test_xliff.py
+++ b/tests/translate/storage/test_xliff.py
@@ -11,6 +11,7 @@ from . import test_base
 
 class TestXLIFFUnit(test_base.TestTranslationUnit):
     UnitClass = xliff.xliffunit
+    StoreClass = xliff.xlifffile
 
     def test_markreview(self) -> None:
         """Tests if we can mark the unit to need review."""
@@ -76,7 +77,7 @@ class TestXLIFFUnit(test_base.TestTranslationUnit):
         assert self.unit.target == "Een"
 
     def test_copy_uses_independent_xml_subtree(self) -> None:
-        xlifffile = xliff.xlifffile()
+        xlifffile = self.StoreClass()
         unit = xlifffile.addsourceunit("Source")
         unit.target = "Target"
         unit.xmlelement.set("id", "unit-1")
@@ -103,6 +104,12 @@ class TestXLIFFUnit(test_base.TestTranslationUnit):
 
 class TestXLIFFfile(test_base.TestTranslationStore):
     StoreClass = xliff.xlifffile
+    supports_inline_placeables = True
+    supports_plain_rich_target = True
+    supports_xliff_locations = True
+    translated_unit_attributes = ' approved="yes"'
+    translated_target_attributes = ' state="translated"'
+    fuzzy_without_target_attribute = 'approved="no"'
     skeleton = """<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.1" xmlns="urn:oasis:names:tc:xliff:document:1.1">
         <file original="doc.txt" source-language="en-US">
@@ -113,11 +120,11 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 </xliff>"""
 
     def test_basic(self) -> None:
-        xlifffile = xliff.xlifffile()
+        xlifffile = self.StoreClass()
         assert xlifffile.units == []
         xlifffile.addsourceunit("Bla")
         assert len(xlifffile.units) == 1
-        newfile = xliff.xlifffile.parsestring(bytes(xlifffile))
+        newfile = self.StoreClass.parsestring(bytes(xlifffile))
         print(bytes(xlifffile))
         assert len(newfile.units) == 1
         assert newfile.units[0].source == "Bla"
@@ -136,12 +143,14 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         </xliff:body>
     </xliff:file>
 </xliff:xliff>"""
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         print(bytes(xlifffile))
         assert xlifffile.units[0].source == "File 1"
 
     def test_rich_source(self) -> None:
-        xlifffile = xliff.xlifffile()
+        if not self.supports_inline_placeables:
+            pytest.skip("store does not expose XLIFF inline source placeables")
+        xlifffile = self.StoreClass()
         xliffunit = xlifffile.addsourceunit("")
 
         # Test 1
@@ -190,7 +199,9 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         ]
 
     def test_rich_target(self) -> None:
-        xlifffile = xliff.xlifffile()
+        if not self.supports_inline_placeables:
+            pytest.skip("store does not expose XLIFF inline target placeables")
+        xlifffile = self.StoreClass()
         xliffunit = xlifffile.addsourceunit("")
 
         # Test 1
@@ -241,13 +252,13 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         print(bytes(xlifffile).decode())
         assert (
             bytes(xlifffile).decode()
-            == """<?xml version="1.0" encoding="UTF-8"?>
+            == f"""<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.1" version="1.1">
   <file original="NoName" source-language="en" datatype="plaintext">
     <body>
-      <trans-unit xml:space="preserve" id="2" approved="yes">
+      <trans-unit xml:space="preserve" id="2"{self.translated_unit_attributes}>
         <source></source>
-        <target state="translated">foobaz<g id="oof"><g id="zab">barrab</g></g></target>
+        <target{self.translated_target_attributes}>foobaz<g id="oof"><g id="zab">barrab</g></g></target>
       </trans-unit>
     </body>
   </file>
@@ -267,7 +278,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         </body>
     </file>
 </xliff>"""
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         xliffunit = xlifffile.units[0]
 
         assert xliffunit.source == "Label A: %1 | Label B: %2 |  Label C: %3"
@@ -295,31 +306,31 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         )
 
     def test_source(self) -> None:
-        xlifffile = xliff.xlifffile()
+        xlifffile = self.StoreClass()
         xliffunit = xlifffile.addsourceunit("Concept")
         xliffunit.source = "Term"
-        newfile = xliff.xlifffile.parsestring(bytes(xlifffile))
+        newfile = self.StoreClass.parsestring(bytes(xlifffile))
         print(bytes(xlifffile))
         assert newfile.findunit("Concept") is None
         assert newfile.findunit("Term") is not None
 
     def test_target(self) -> None:
-        xlifffile = xliff.xlifffile()
+        xlifffile = self.StoreClass()
         xliffunit = xlifffile.addsourceunit("Concept")
         xliffunit.target = "Konsep"
-        newfile = xliff.xlifffile.parsestring(bytes(xlifffile))
+        newfile = self.StoreClass.parsestring(bytes(xlifffile))
         print(bytes(xlifffile))
         assert newfile.findunit("Concept").target == "Konsep"
 
     def test_sourcelanguage(self) -> None:
-        xlifffile = xliff.xlifffile(sourcelanguage="xh")
+        xlifffile = self.StoreClass(sourcelanguage="xh")
         xmltext = bytes(xlifffile).decode("utf-8")
         print(xmltext)
         assert xmltext.find('source-language="xh"') > 0
         # TODO: test that it also works for new files.
 
     def test_targetlanguage(self) -> None:
-        xlifffile = xliff.xlifffile(sourcelanguage="zu", targetlanguage="af")
+        xlifffile = self.StoreClass(sourcelanguage="zu", targetlanguage="af")
         xmltext = bytes(xlifffile).decode("utf-8")
         print(xmltext)
         assert xmltext.find('source-language="zu"') > 0
@@ -334,7 +345,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         <file original="doc.txt" source-language="en-US">
         </file>
 </xliff>"""
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         xlifffile.settargetlanguage("cs")
         xlifffile.setsourcelanguage("de")
         xmltext = bytes(xlifffile).decode()
@@ -343,7 +354,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert xmltext.count('target-language="cs"') == 2
 
     def test_notes(self) -> None:
-        xlifffile = xliff.xlifffile()
+        xlifffile = self.StoreClass()
         unit = xlifffile.addsourceunit("Concept")
         # We don't want to add unnecessary notes
         assert "note" not in bytes(xlifffile).decode("utf-8")
@@ -386,7 +397,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 
     def test_alttrans(self) -> None:
         """Test xliff <alt-trans> accessors."""
-        xlifffile = xliff.xlifffile()
+        xlifffile = self.StoreClass()
         unit = xlifffile.addsourceunit("Testing")
 
         unit.addalttrans("ginmi")
@@ -434,7 +445,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         )
 
     def test_fuzzy(self) -> None:
-        xlifffile = xliff.xlifffile()
+        xlifffile = self.StoreClass()
         unit = xlifffile.addsourceunit("Concept")
         unit.markfuzzy()
         assert not unit.isfuzzy()  # untranslated
@@ -454,7 +465,10 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert unit.target is None
         print(unit)
         unit.markfuzzy(True)
-        assert 'approved="no"' in str(unit)
+        if self.fuzzy_without_target_attribute:
+            assert self.fuzzy_without_target_attribute in str(unit)
+        else:
+            assert "approved=" not in str(unit)
         # assert unit.isfuzzy()
 
     def test_xml_space(self) -> None:
@@ -464,7 +478,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
                    <source> File  1 </source>
                </trans-unit>"""
         )
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         assert xlifffile.units[0].source == " File  1 "
         root_node = xlifffile.document.getroot()
         setXMLspace(root_node, "preserve")
@@ -477,7 +491,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
                    <source> File  1 </source>
                </trans-unit>"""
         )
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         assert xlifffile.units[0].source == "File 1"
         root_node = xlifffile.document.getroot()
         setXMLspace(root_node, "preserve")
@@ -491,7 +505,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
                </trans-unit>"""
         )
         # we currently always normalize as default behaviour for xliff
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         assert xlifffile.units[0].source == "File 1"
         root_node = xlifffile.document.getroot()
         setXMLspace(root_node, "preserve")
@@ -506,7 +520,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
                </trans-unit>"""
         )
         # we currently always normalize as default behaviour for xliff
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         assert xlifffile.units[0].source == "File 1"
         root_node = xlifffile.document.getroot()
         setXMLspace(root_node, "preserve")
@@ -522,7 +536,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
                      <target/>
                  </trans-unit>"""
         )
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         assert xlifffile.units[0].istranslatable()
 
         xlfsource = (
@@ -532,7 +546,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
                      <target/>
                  </trans-unit>"""
         )
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         assert not xlifffile.units[0].istranslatable()
 
         xlfsource = (
@@ -542,7 +556,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
                      <target/>
                  </trans-unit>"""
         )
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         assert xlifffile.units[0].istranslatable()
 
     def test_marktranslatable(self) -> None:
@@ -554,7 +568,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
                      <target/>
                  </trans-unit>"""
         )
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         unit = xlifffile.units[0]
 
         # Test marking as untranslatable
@@ -596,7 +610,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
                 </body>
         </file>
 </xliff>"""
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         assert xlifffile.units[0].istranslatable()
         assert xlifffile.units[0].source == ""
         assert xlifffile.units[1].istranslatable()
@@ -620,20 +634,20 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </body>
   </file>
 </xliff>"""
-        xfile = xliff.xlifffile.parsestring(xlfsource)
+        xfile = self.StoreClass.parsestring(xlfsource)
         assert len(xfile.units) == 2
         assert xfile.units[0].getid() == "file0\x04hello"
         assert xfile.units[1].getid() == "file1\x04world"
-        xunit = xliff.xlifffile.UnitClass(source="goodbye")
+        xunit = self.StoreClass.UnitClass(source="goodbye")
         xunit.setid("file2\x04goodbye")
         xfile.addunit(xunit)
         assert xfile.units[2].getid() == "file2\x04goodbye"
         # if there is no file set it will use the active context
-        xunit = xliff.xlifffile.UnitClass(source="lastfile")
+        xunit = self.StoreClass.UnitClass(source="lastfile")
         xunit.setid("lastfile")
         xfile.addunit(xunit)
         assert xfile.units[3].getid() == "file2\x04lastfile"
-        newxfile = xliff.xlifffile()
+        newxfile = self.StoreClass()
         newxfile.addunit(xfile.units[0])
         newxfile.addunit(xfile.units[1])
         assert newxfile.units[0].getid() == "file0\x04hello"
@@ -681,11 +695,11 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 </xliff>
 """
 
-        source = xliff.xlifffile.parsestring(source_xliff)
+        source = self.StoreClass.parsestring(source_xliff)
         assert len(source.units) == 2
 
         # Add units to a new translation store
-        translation = xliff.xlifffile()
+        translation = self.StoreClass()
         translation.sourcelanguage = "en"
         translation.targetlanguage = "fr"
 
@@ -697,7 +711,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert serialized == expected_output
 
         # Also verify by parsing and checking structure
-        translation_reloaded = xliff.xlifffile.parsestring(serialized)
+        translation_reloaded = self.StoreClass.parsestring(serialized)
         assert len(translation_reloaded.units) == 2
         for unit in translation_reloaded.units:
             parent = unit.xmlelement.getparent()
@@ -727,11 +741,11 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
 
-        source = xliff.xlifffile.parsestring(source_xliff)
+        source = self.StoreClass.parsestring(source_xliff)
         assert len(source.units) == 2
 
         # Add units to a new translation store
-        translation = xliff.xlifffile()
+        translation = self.StoreClass()
         translation.sourcelanguage = "en"
         translation.targetlanguage = "fr"
 
@@ -741,7 +755,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         # Verify both files and groups are preserved
         assert translation.getfilenames() == ["file1.txt", "file2.txt"]
         serialized = bytes(translation)
-        translation_reloaded = xliff.xlifffile.parsestring(serialized)
+        translation_reloaded = self.StoreClass.parsestring(serialized)
 
         # Verify structure matches original
         assert translation_reloaded.getfilenames() == ["file1.txt", "file2.txt"]
@@ -780,7 +794,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
 
-        translation = xliff.xlifffile.parsestring(translation_xliff)
+        translation = self.StoreClass.parsestring(translation_xliff)
 
         # Add a new unit from a source that has the same group
         source_xliff = b"""<?xml version="1.0" encoding="utf-8"?>
@@ -796,7 +810,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
 
-        source = xliff.xlifffile.parsestring(source_xliff)
+        source = self.StoreClass.parsestring(source_xliff)
         new_unit = source.units[0]
 
         # Add the new unit
@@ -805,7 +819,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         # Verify the new unit is in the same group
         assert len(translation.units) == 2
         serialized = bytes(translation)
-        translation_reloaded = xliff.xlifffile.parsestring(serialized)
+        translation_reloaded = self.StoreClass.parsestring(serialized)
 
         # Both units should be in group1
         for unit in translation_reloaded.units:
@@ -828,7 +842,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
 
-        translation = xliff.xlifffile.parsestring(translation_xliff)
+        translation = self.StoreClass.parsestring(translation_xliff)
         assert translation.getfilenames() == ["file1.txt"]
 
         # Add a new unit from a different file
@@ -843,7 +857,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
 
-        source = xliff.xlifffile.parsestring(source_xliff)
+        source = self.StoreClass.parsestring(source_xliff)
         new_unit = source.units[0]
 
         # Add the new unit
@@ -855,7 +869,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 
         # Verify structure is correct
         serialized = bytes(translation)
-        translation_reloaded = xliff.xlifffile.parsestring(serialized)
+        translation_reloaded = self.StoreClass.parsestring(serialized)
         assert set(translation_reloaded.getfilenames()) == {"file1.txt", "file2.txt"}
 
         # Verify each unit is in the correct file
@@ -884,8 +898,8 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
 
-        source = xliff.xlifffile.parsestring(source_xliff)
-        translation = xliff.xlifffile()
+        source = self.StoreClass.parsestring(source_xliff)
+        translation = self.StoreClass()
         translation.sourcelanguage = "en"
         translation.targetlanguage = "fr"
 
@@ -894,7 +908,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 
         # Verify structure is preserved
         serialized = bytes(translation)
-        translation_reloaded = xliff.xlifffile.parsestring(serialized)
+        translation_reloaded = self.StoreClass.parsestring(serialized)
         assert len(translation_reloaded.units) == 2
 
         # First unit should be in group
@@ -920,8 +934,8 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
 
-        source = xliff.xlifffile.parsestring(source_xliff)
-        translation = xliff.xlifffile()
+        source = self.StoreClass.parsestring(source_xliff)
+        translation = self.StoreClass()
         translation.sourcelanguage = "en"
         translation.targetlanguage = "fr"
 
@@ -937,7 +951,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         # But xmlelement should not be in the body or any group
         serialized = bytes(translation)
         # Should not contain the trans-unit since new=False
-        translation_reloaded = xliff.xlifffile.parsestring(serialized)
+        translation_reloaded = self.StoreClass.parsestring(serialized)
         assert len(translation_reloaded.units) == 0
 
     def test_namespace_preservation_across_versions(self) -> None:
@@ -956,8 +970,8 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
 
-        source = xliff.xlifffile.parsestring(source_xliff)
-        translation = xliff.xlifffile()
+        source = self.StoreClass.parsestring(source_xliff)
+        translation = self.StoreClass()
         translation.sourcelanguage = "en"
         translation.targetlanguage = "fr"
 
@@ -1006,8 +1020,8 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
 
-        source = xliff.xlifffile.parsestring(source_xliff)
-        target = xliff.xlifffile.parsestring(target_xliff)
+        source = self.StoreClass.parsestring(source_xliff)
+        target = self.StoreClass.parsestring(target_xliff)
 
         # Add units from source to target
         for unit in source.units:
@@ -1015,7 +1029,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 
         # Verify all three files are present
         serialized = bytes(target)
-        target_reloaded = xliff.xlifffile.parsestring(serialized)
+        target_reloaded = self.StoreClass.parsestring(serialized)
 
         filenames = target_reloaded.getfilenames()
         assert len(filenames) == 3
@@ -1063,8 +1077,8 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
 
-        source = xliff.xlifffile.parsestring(source_xliff)
-        target = xliff.xlifffile.parsestring(target_xliff)
+        source = self.StoreClass.parsestring(source_xliff)
+        target = self.StoreClass.parsestring(target_xliff)
 
         # Verify initial state
         assert len(source.units) == 1
@@ -1078,7 +1092,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 
         # Serialize and reload to verify structure
         serialized = bytes(target)
-        target_reloaded = xliff.xlifffile.parsestring(serialized)
+        target_reloaded = self.StoreClass.parsestring(serialized)
 
         # Should still have 2 units after round-trip
         assert len(target_reloaded.units) == 2
@@ -1148,8 +1162,8 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
 
-        source = xliff.xlifffile.parsestring(source_xliff)
-        target = xliff.xlifffile.parsestring(target_xliff)
+        source = self.StoreClass.parsestring(source_xliff)
+        target = self.StoreClass.parsestring(target_xliff)
 
         # Verify different namespaces
         assert source.namespace == "urn:oasis:names:tc:xliff:document:1.2"
@@ -1233,12 +1247,14 @@ class TestXLIFFfile(test_base.TestTranslationStore):
   </file>
 </xliff>
 """
-        xfile = xliff.xlifffile.parsestring(xlfsource)
+        xfile = self.StoreClass.parsestring(xlfsource)
         assert bytes(xfile) == xlfsource
         xfile.units[0].addnote("Test note")
         assert bytes(xfile) == xlfsourcenote
 
     def test_add_target(self) -> None:
+        if not self.supports_plain_rich_target:
+            pytest.skip("store requires rich target elements")
         xlfsource = """<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.1" version="1.1">
   <file original="doc.txt" source-language="en-US">
@@ -1260,7 +1276,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
   </file>
 </xliff>
 """
-        xfile = xliff.xlifffile.parsestring(xlfsource)
+        xfile = self.StoreClass.parsestring(xlfsource)
         assert bytes(xfile).decode() == xlfsource
         xfile.units[0].rich_target = ["Soubor"]
         assert bytes(xfile).decode("ascii") == xlftarget
@@ -1278,10 +1294,10 @@ class TestXLIFFfile(test_base.TestTranslationStore):
   </file>
 </xliff>
 """
-        xfile = xliff.xlifffile.parsestring(xlfsource)
+        xfile = self.StoreClass.parsestring(xlfsource)
         assert bytes(xfile).decode() == xlfsource
         xfile.units[0].target = "H  E"
-        newfile = xliff.xlifffile.parsestring(bytes(xfile))
+        newfile = self.StoreClass.parsestring(bytes(xfile))
         assert newfile.units[0].target == "H  E"
 
     def test_closing_tags(self) -> None:
@@ -1301,7 +1317,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
   </file>
 </xliff>
 """
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         xlifffile.XMLSelfClosingTags = False
         xlifffile.XMLuppercaseEncoding = False
 
@@ -1326,7 +1342,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
   </file>
 </xliff>
 """
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         contextGroups = xlifffile.units[0].getcontextgroupsbyattribute(
             "purpose", "location"
         )
@@ -1338,6 +1354,8 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert contextGroups[0][1][1] == "222"
 
     def test_getlocations(self) -> None:
+        if not self.supports_xliff_locations:
+            pytest.skip("store uses format-specific location metadata")
         xlfsource = """<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="en-US" original="Email - SMTP API">
@@ -1356,12 +1374,14 @@ class TestXLIFFfile(test_base.TestTranslationStore):
   </file>
 </xliff>
 """
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         locations = xlifffile.units[0].getlocations()
 
         assert locations == ["some-directory/on-some-test/test.file:222"]
 
     def test_addlocation(self) -> None:
+        if not self.supports_xliff_locations:
+            pytest.skip("store uses format-specific location metadata")
         xlfsource = """<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="en-US" original="Email - SMTP API">
@@ -1380,7 +1400,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
   </file>
 </xliff>
 """
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         xlifffile.units[0].addlocation("some-directory/on-some-test/test.file2:333")
         xlifffile.units[0].addlocation("docs/config.md:block 1 (header)")
         xlifffile.units[0].addlocation("file.rst")
@@ -1401,7 +1421,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
                  </trans-unit>"""
             * 100_000
         )
-        xlifffile = xliff.xlifffile.parsestring(xlfsource)
+        xlifffile = self.StoreClass.parsestring(xlfsource)
         assert len(xlifffile.units) == 100_000
 
     def test_preserve_add(self) -> None:
@@ -1431,13 +1451,13 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 </xliff>
 """
         target_element = f"""
-          <target state="translated">{target}</target>"""
+          <target{self.translated_target_attributes}>{target}</target>"""
         xlfsource_blank = xlfsource_template.format(target="", extra="")
         xlfsource_plain = xlfsource_template.format(target=target_element, extra="")
         xlfsource_preserve = xlfsource_template.format(
             target=target_element, extra=' xml:space="preserve"'
         )
-        xlifffile = xliff.xlifffile.parsestring(xlfsource_plain)
+        xlifffile = self.StoreClass.parsestring(xlfsource_plain)
 
         assert len(xlifffile.units) == 1
         unit = xlifffile.units[0]
@@ -1447,7 +1467,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 
         assert bytes(xlifffile).decode() == xlfsource_preserve
 
-        xlifffile = xliff.xlifffile.parsestring(xlfsource_blank)
+        xlifffile = self.StoreClass.parsestring(xlfsource_blank)
 
         assert len(xlifffile.units) == 1
         unit = xlifffile.units[0]
@@ -1456,10 +1476,11 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         unit.target = target
 
         assert bytes(xlifffile).decode() == xlfsource_template.format(
-            target=target_element, extra=' xml:space="preserve" approved="yes"'
+            target=target_element,
+            extra=f' xml:space="preserve"{self.translated_unit_attributes}',
         )
 
-        xlifffile = xliff.xlifffile.parsestring(xlfsource_preserve)
+        xlifffile = self.StoreClass.parsestring(xlfsource_preserve)
 
         assert len(xlifffile.units) == 1
         unit = xlifffile.units[0]
@@ -1468,12 +1489,14 @@ class TestXLIFFfile(test_base.TestTranslationStore):
 
         assert bytes(xlifffile).decode() == xlfsource_preserve
 
-        xlifffile = xliff.xlifffile.parsestring(xlfsource_plain)
+        xlifffile = self.StoreClass.parsestring(xlfsource_plain)
 
         assert len(xlifffile.units) == 1
         unit = xlifffile.units[0]
 
         assert unit.target == target.replace("\n", " ")
+        if not self.supports_plain_rich_target:
+            return
         unit.rich_target = [target]
 
         assert bytes(xlifffile).decode() == xlfsource_preserve
@@ -1492,7 +1515,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
         with pytest.raises(ValueError) as exc_info:
-            xliff.xlifffile.parsestring(xliff2_content)
+            self.StoreClass.parsestring(xliff2_content)
         assert "XLIFF 2" in str(exc_info.value)
         assert "version='2.0'" in str(exc_info.value)
         assert "xliff2.Xliff2File" in str(exc_info.value)
@@ -1511,7 +1534,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
     </file>
 </xliff>"""
         with pytest.raises(ValueError) as exc_info:
-            xliff.xlifffile.parsestring(xliff2_no_version)
+            self.StoreClass.parsestring(xliff2_no_version)
         assert "XLIFF 2" in str(exc_info.value)
         assert "namespace" in str(exc_info.value)
         assert "xliff2.Xliff2File" in str(exc_info.value)

--- a/translate/storage/applestrings_xliff.py
+++ b/translate/storage/applestrings_xliff.py
@@ -44,7 +44,7 @@ from lxml import etree
 
 from translate.lang import data
 from translate.misc.multistring import multistring
-from translate.misc.xml_helpers import getText, setXMLspace
+from translate.misc.xml_helpers import getText, getXMLspace, setXMLspace
 from translate.storage import base, xliff
 
 
@@ -67,8 +67,172 @@ class AppleStringsXliffUnit(xliff.Xliff1Unit):
         self._plural_source: multistring | None = None
         self._plural_target: multistring | None = None
         self._plural_base_key: str | None = None
+        self._plural_forms: dict[str, etree._Element] = {}
+        self._plural_tags: list[str] = []
         self._plural_dirty: bool = False
+        self._plural_dirty_targets: set[str] = set()
+        self._plural_state_override: int | None = None
         super().__init__(source, **kwargs)
+
+    @staticmethod
+    def correctorigin(node, origin):
+        """Treat Apple's bare notes as developer notes."""
+        if (
+            origin == "developer"
+            and etree.QName(node).localname == "note"
+            and not node.get("from")
+        ):
+            return True
+        return xliff.Xliff1Unit.correctorigin(node, origin)
+
+    def addnote(self, text, origin=None, position="append") -> None:
+        """Add developer notes using Apple's bare ``note`` representation."""
+        if origin == "developer":
+            if position != "append":
+                self.removenotes(origin=origin)
+                position = "append"
+            origin = None
+        super().addnote(text, origin=origin, position=position)
+
+    def _plural_form_elements(self) -> list[etree._Element]:
+        """Return the XML trans-units represented by this folded plural."""
+        return list(self._plural_forms.values())
+
+    def _target_state(
+        self,
+        target_node: etree._Element | None,
+        target_text: str | None = None,
+    ) -> tuple[int, bool]:
+        """Return a target's effective state and whether it was explicit."""
+        if target_text is not None and not target_text:
+            return self.S_UNTRANSLATED, False
+
+        if target_node is not None:
+            xml_state = target_node.get("state")
+            if xml_state is not None:
+                if xml_state == "new":
+                    return self.S_UNTRANSLATED, True
+                return self.statemap.get(xml_state, self.S_UNTRANSLATED), True
+
+            if target_text is None:
+                parent = target_node.getparent()
+                xml_space = getXMLspace(
+                    parent, getattr(self, "_default_xml_space", "preserve")
+                )
+                target_text = getText(target_node, xml_space)
+
+        if target_text:
+            return self.S_TRANSLATED, False
+        return self.S_UNTRANSLATED, False
+
+    def _plural_explicit_states(self) -> dict[str, tuple[int, str | None]]:
+        """Return explicit states indexed by plural tag."""
+        states = {}
+        for tag, form in self._plural_forms.items():
+            target_node = next(
+                form.iterchildren(self.namespaced("target")),
+                None,
+            )
+            state_n, is_explicit = self._target_state(target_node)
+            if is_explicit and target_node is not None:
+                states[tag] = (state_n, target_node.get("state-qualifier"))
+        return states
+
+    def _plural_tags_for_target(self, target: multistring | None) -> list[str]:
+        """Return stored or inferred plural tags for an in-memory target."""
+        if self._plural_tags:
+            return self._plural_tags
+        if isinstance(self._store, AppleStringsXliffFile):
+            return self._store._get_target_plural_tags(target)
+        return []
+
+    def _plural_state(self) -> tuple[int, bool]:
+        """Aggregate the least-complete state across folded plural forms."""
+        states = []
+        has_explicit_state = False
+        source_strings = self._plural_source.strings if self._plural_source else []
+        target_strings = self._plural_target.strings if self._plural_target else []
+        plural_tags = self._plural_tags_for_target(self._plural_target)
+        for index, tag in enumerate(plural_tags):
+            form = self._plural_forms.get(tag)
+            source = str(source_strings[index]) if index < len(source_strings) else ""
+            target = str(target_strings[index]) if index < len(target_strings) else ""
+            if self._plural_dirty and not source and not target:
+                continue
+            if not self._plural_dirty and form is None:
+                continue
+
+            target_node = (
+                next(form.iterchildren(self.namespaced("target")), None)
+                if form is not None
+                else None
+            )
+            if self._plural_state_override is not None:
+                state_n, is_explicit = self._plural_state_override, True
+            else:
+                state_n, is_explicit = self._target_state(
+                    target_node,
+                    target if tag in self._plural_dirty_targets else None,
+                )
+            states.append(state_n)
+            has_explicit_state |= is_explicit
+
+        if states:
+            return min(states), has_explicit_state
+        if self._plural_state_override is not None:
+            return self._plural_state_override, True
+        return (
+            self.S_TRANSLATED if self.target else self.S_UNTRANSLATED,
+            False,
+        )
+
+    def get_state_n(self):
+        """Infer state, aggregating the least-complete folded plural form."""
+        if self.hasplural():
+            return self._plural_state()[0]
+        return self._target_state(self.get_target_dom())[0]
+
+    def _set_target_state(self, target_node: etree._Element, value: int) -> None:
+        """Write an Apple-compatible explicit state to a target node."""
+        xml_state = "new" if value == self.S_UNTRANSLATED else self.statemap_r[value]
+        target_node.set("state", xml_state)
+
+    def set_state_n(self, value) -> None:
+        """Set an explicit XLIFF state without synthesizing ``approved``."""
+        if value not in self.statemap_r:
+            value = self.get_state_id(value)
+        self.xmlelement.attrib.pop("approved", None)
+
+        if self.hasplural():
+            self._plural_state_override = value
+            missing_target = not self._plural_forms
+            for form in self._plural_form_elements():
+                form.attrib.pop("approved", None)
+                target_node = next(
+                    form.iterchildren(self.namespaced("target")),
+                    None,
+                )
+                if target_node is None:
+                    missing_target = True
+                    continue
+                self._set_target_state(target_node, value)
+            if missing_target:
+                self._plural_dirty = True
+            return
+
+        target_node = self.get_target_dom()
+        if target_node is None:
+            target_node = self.createlanguageNode("xx", "", "target")
+            self.set_target_dom(target_node)
+        self._set_target_state(target_node, value)
+
+    def isapproved(self):
+        """Return approval inferred from Apple's target state."""
+        return self.get_state_n() >= self.S_TRANSLATED
+
+    def markapproved(self, value=True) -> None:
+        """Map approval to target state without emitting ``approved``."""
+        self.set_state_n(self.S_TRANSLATED if value else self.S_NEEDS_REVIEW)
 
     # ------------------------------------------------------------------
     # source / target properties – delegate to XML for regular units,
@@ -99,6 +263,18 @@ class AppleStringsXliffUnit(xliff.Xliff1Unit):
     @target.setter
     def target(self, value) -> None:
         if isinstance(value, multistring):
+            old_target = self._plural_target
+            old_strings = old_target.strings if old_target else []
+            new_strings = value.strings
+            plural_tags = self._plural_tags_for_target(value)
+            self._plural_dirty_targets.update(
+                tag
+                for index, tag in enumerate(plural_tags)
+                if str(old_strings[index] if index < len(old_strings) else "")
+                != str(new_strings[index] if index < len(new_strings) else "")
+            )
+            if old_target is None or old_target != value:
+                self._plural_state_override = None
             self._plural_target = value
             self._plural_dirty = True
         else:
@@ -132,8 +308,7 @@ class AppleStringsXliffUnit(xliff.Xliff1Unit):
     @rich_target.setter
     def rich_target(self, value) -> None:
         if self.hasplural():
-            self._plural_target = self.rich_to_multistring(value)
-            self._plural_dirty = True
+            self.target = self.rich_to_multistring(value)
         else:
             self.set_rich_target(value)
 
@@ -306,7 +481,15 @@ class AppleStringsXliffFile(xliff.Xliff1File):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _is_plural_sibling(child_id: str, base_key: str) -> bool:
+    def _is_plural_form_sibling(child_id: str, base_key: str) -> bool:
+        """Return whether *child_id* is a plural form for *base_key*."""
+        return any(
+            child_id == f"{base_key}:dict/{tag}:dict/:string"
+            for tag in data.cldr_plural_categories
+        )
+
+    @classmethod
+    def _is_plural_sibling(cls, child_id: str, base_key: str) -> bool:
         """
         Return ``True`` if *child_id* belongs to the plural group *base_key*.
 
@@ -315,10 +498,7 @@ class AppleStringsXliffFile(xliff.Xliff1File):
         """
         if child_id == f"{base_key}:dict/:string":
             return True
-        return any(
-            child_id == f"{base_key}:dict/{tag}:dict/:string"
-            for tag in data.cldr_plural_categories
-        )
+        return cls._is_plural_form_sibling(child_id, base_key)
 
     def _group_plural_units(self) -> dict[str, Any]:
         """
@@ -418,6 +598,9 @@ class AppleStringsXliffFile(xliff.Xliff1File):
             unit._plural_source = multistring(source_strings)
             unit._plural_target = multistring(target_strings)
             unit._plural_base_key = base_key
+            unit._plural_forms = {tag: form.xmlelement for tag, form in forms.items()}
+            unit._plural_tags = plural_tags
+            unit._plural_dirty_targets.clear()
             unit.format_value_type = group_data["format_type"]
             unit._plural_dirty = False  # XML already in sync after parse
 
@@ -468,6 +651,8 @@ class AppleStringsXliffFile(xliff.Xliff1File):
         if body is None:
             return
 
+        explicit_states = unit._plural_explicit_states()
+
         # --- Ensure the container XML element has the marker structure ---
         unit.xmlelement.set("id", f"{base_key}:dict")
         # Update XML source/target nodes to NSStringPluralRuleType
@@ -507,6 +692,7 @@ class AppleStringsXliffFile(xliff.Xliff1File):
         target_strs = unit._plural_target.strings if unit._plural_target else []
 
         offset = 2
+        plural_forms = {}
         for i, tag in enumerate(plural_tags):
             src = str(source_strs[i]) if i < len(source_strs) else ""
             tgt = str(target_strs[i]) if i < len(target_strs) else ""
@@ -515,9 +701,31 @@ class AppleStringsXliffFile(xliff.Xliff1File):
             form_el = self._make_trans_unit_xml_element(
                 f"{base_key}:dict/{tag}:dict/:string", src, tgt
             )
+            explicit_metadata = explicit_states.get(tag)
+            explicit_state = unit._plural_state_override
+            state_qualifier = (
+                explicit_metadata[1] if explicit_metadata is not None else None
+            )
+            if explicit_state is None and (
+                tag not in unit._plural_dirty_targets or tgt
+            ):
+                explicit_state = (
+                    explicit_metadata[0] if explicit_metadata is not None else None
+                )
+            if explicit_state is not None:
+                target_node = next(
+                    form_el.iterchildren(unit.namespaced("target")),
+                )
+                unit._set_target_state(target_node, explicit_state)
+                if state_qualifier is not None:
+                    target_node.set("state-qualifier", state_qualifier)
             body.insert(marker_pos + offset, form_el)
+            plural_forms[tag] = form_el
             offset += 1
 
+        unit._plural_forms = plural_forms
+        unit._plural_tags = plural_tags
+        unit._plural_dirty_targets.clear()
         unit._plural_dirty = False
 
     def removeunit(self, unit: AppleStringsXliffUnit) -> None:


### PR DESCRIPTION
Apple-generated XLIFF relies on target state and bare notes instead of generic approval metadata. Infer singular state accordingly, aggregate and propagate folded plural state, and keep explicit untranslated and approval transitions serializable.

Fixes #3583