### PR TITLE
fix(markdown): preserve explicit heading IDs

### DIFF
--- a/tests/translate/convert/test_md2po.py
+++ b/tests/translate/convert/test_md2po.py
@@ -224,6 +224,22 @@ def hello():
             "The others are only used to decrypt the data."
         ) in sources
 
+    def test_markdown_explicit_heading_id_extraction(self) -> None:
+        self.given_markdown_file(
+            "### Anonymous learners {/* #anonymous */}\n"
+            "### Registered learners {#registered}\n"
+        )
+        self.run_command("file.md", "test.po")
+        output = pofile()
+        with open(self.get_testfilename("test.po"), "rb") as handle:
+            output.parse(handle)
+
+        sources = [unit.source for unit in output.units]
+        assert "Anonymous learners" in sources
+        assert "Registered learners" in sources
+        assert not any("#anonymous" in source for source in sources)
+        assert not any("#registered" in source for source in sources)
+
     def test_markdown_directory_ignores_txt_files(self) -> None:
         self.given_directory_of_markdown_files()
         self.create_testfile("mddir/notes.txt", "Text file content")

--- a/tests/translate/convert/test_mdx2po.py
+++ b/tests/translate/convert/test_mdx2po.py
@@ -50,6 +50,16 @@ Another paragraph.
         assert not any("import" in source for source in sources)
         assert not any("Alert" in source for source in sources)
 
+    def test_explicit_heading_id_extraction(self):
+        """Heading IDs are preserved outside MDX translation units."""
+        store = self.mdx2po(
+            b"### Anonymous learners {/* #anonymous */}\n"
+            b"### Registered learners {#registered}\n"
+        )
+
+        sources = [unit.source for unit in store.units if unit.source]
+        assert sources == ["Anonymous learners", "Registered learners"]
+
     def test_no_code_blocks(self):
         """Code blocks can be excluded from extraction."""
         content = b"""# Title

--- a/tests/translate/convert/test_po2md.py
+++ b/tests/translate/convert/test_po2md.py
@@ -299,6 +299,117 @@ You are only coming through in waves.
             "  The first key encrypts the data. The others decrypt it.\n"
         )
 
+    def test_markdown_explicit_heading_id_translation(self) -> None:
+        self.given_markdown_file("### Anonymous learners {/* #anonymous */}\n")
+        self.given_translation_file(
+            lines=[
+                "#: file.md:1",
+                'msgid "Anonymous learners"',
+                'msgstr "Anonyme Lernende"',
+            ]
+        )
+        self.run_command("translation.po", "out.md", template="file.md")
+
+        assert self.read_testfile("out.md").decode() == (
+            "### Anonyme Lernende {/* #anonymous */}\n"
+        )
+
+    def test_markdown_explicit_heading_id_migrated_translation(self) -> None:
+        self.given_markdown_file("### Anonymous learners {/* #anonymous */}\n")
+        self.given_translation_file(
+            lines=[
+                "#: file.md:1",
+                'msgid "Anonymous learners"',
+                'msgstr "Anonyme Lernende {/* #anonymous */}"',
+            ]
+        )
+        self.run_command("translation.po", "out.md", template="file.md")
+
+        assert self.read_testfile("out.md").decode() == (
+            "### Anonyme Lernende {/* #anonymous */}\n"
+        )
+
+    @pytest.mark.parametrize(
+        "legacy_target",
+        [
+            "Anonyme Lernende",
+            "Anonyme Lernende {/* #anonymous */}",
+        ],
+    )
+    def test_markdown_explicit_heading_id_legacy_translation(
+        self, legacy_target: str
+    ) -> None:
+        self.given_markdown_file("### Anonymous learners {/* #anonymous */}\n")
+        self.given_translation_file(
+            lines=[
+                "#: file.md:1",
+                'msgid "Anonymous learners {/* #anonymous */}"',
+                f'msgstr "{legacy_target}"',
+            ]
+        )
+        self.run_command("translation.po", "out.md", template="file.md")
+
+        assert self.read_testfile("out.md").decode() == (
+            "### Anonyme Lernende {/* #anonymous */}\n"
+        )
+
+    def test_markdown_explicit_heading_id_expanded_legacy_translation(
+        self,
+    ) -> None:
+        self.given_markdown_file(
+            "### See [documentation](https://example.com) {/* #docs */}\n"
+        )
+        self.given_translation_file(
+            lines=[
+                "#: file.md:1",
+                'msgid "See [documentation](https://example.com) {/* #docs */}"',
+                'msgstr "Siehe [Dokumentation](https://example.com) {/* #docs */}"',
+            ]
+        )
+        self.run_command("translation.po", "out.md", template="file.md")
+
+        assert self.read_testfile("out.md").decode() == (
+            "### Siehe [Dokumentation](https://example.com) {/* #docs */}\n"
+        )
+
+    def test_markdown_explicit_heading_id_expanded_migrated_translation(
+        self,
+    ) -> None:
+        self.given_markdown_file(
+            "### See [documentation](https://example.com) {/* #docs */}\n"
+        )
+        self.given_translation_file(
+            lines=[
+                "#: file.md:1",
+                'msgid "See [documentation](https://example.com)"',
+                'msgstr "Siehe [Dokumentation](https://example.com) {/* #docs */}"',
+            ]
+        )
+        self.run_command("translation.po", "out.md", template="file.md")
+
+        assert self.read_testfile("out.md").decode() == (
+            "### Siehe [Dokumentation](https://example.com) {/* #docs */}\n"
+        )
+
+    def test_markdown_explicit_heading_id_identity_translation_beats_legacy(
+        self,
+    ) -> None:
+        self.given_markdown_file("### Name {#name}\n")
+        self.given_translation_file(
+            lines=[
+                "#: file.md:1",
+                'msgid "Name"',
+                'msgstr "Name"',
+                "",
+                "#: file.md:1",
+                'msgid "Name {#name}"',
+                'msgstr "Nombre {#name}"',
+            ]
+        )
+        self.run_command("translation.po", "out.md", template="file.md")
+
+        assert self.read_testfile("out.md").decode() == "### Name {#name}\n"
+
     def test_no_placeholders_simple_link(self) -> None:
         """po2md --no-placeholders: full-link msgid is translated correctly."""
         self.given_markdown_file(

--- a/tests/translate/convert/test_po2mdx.py
+++ b/tests/translate/convert/test_po2mdx.py
@@ -61,6 +61,26 @@ Another paragraph.
         assert '<Alert type="info" />' in output
         assert "Another paragraph translated." in output
 
+    def test_explicit_heading_id_translation(self):
+        """Visible heading text translates without changing its ID."""
+        template = b"### Anonymous learners {/* #anonymous */}\n"
+        output = self.translate(template, [("Anonymous learners", "Anonyme Lernende")])
+
+        assert output == b"### Anonyme Lernende {/* #anonymous */}\n"
+
+    def test_explicit_heading_id_identity_translation_beats_legacy(self):
+        """A current identity translation wins over a stale legacy unit."""
+        template = b"### Name {#name}\n"
+        output = self.translate(
+            template,
+            [
+                ("Name", "Name"),
+                ("Name {#name}", "Nombre {#name}"),
+            ],
+        )
+
+        assert output == template
+
     def test_standalone_jsx_block_children_and_attrs_translate(self):
         """Standalone JSX tag attrs and child Markdown are translated."""
         template = b"""# Title

--- a/tests/translate/storage/test_markdown.py
+++ b/tests/translate/storage/test_markdown.py
@@ -164,6 +164,49 @@ class TestMarkdownTranslationUnitExtractionAndTranslation(TestCase):
         assert translated_output == "\n## (sweet *potato*) ##\n"
         assert store.units[0].getlocations()[0].endswith("2")
 
+    def test_atx_heading_with_mdx_explicit_id(self) -> None:
+        store = self.parse("### Anonymous learners {/* #anonymous */}\n")
+        unit_sources = self.get_translation_unit_sources(store)
+        assert unit_sources == ["Anonymous learners"]
+        translated_output = self.get_translated_output(store)
+        assert translated_output == "### (Anonymous learners) {/* #anonymous */}\n"
+
+    def test_atx_heading_strips_explicit_id_from_migrated_translation(self) -> None:
+        inputfile = BytesIO(b"### Anonymous learners {/* #anonymous */}\n")
+        store = markdown.MarkdownFile(
+            inputfile=inputfile,
+            callback=lambda text: (
+                "Anonyme Lernende {/* #anonymous */}"
+                if text == "Anonymous learners"
+                else text
+            ),
+        )
+
+        assert store.filesrc == "### Anonyme Lernende {/* #anonymous */}\n"
+
+    def test_atx_heading_with_classic_explicit_id(self) -> None:
+        store = self.parse("### Anonymous *learners* {#anonymous} ###\n")
+        unit_sources = self.get_translation_unit_sources(store)
+        assert unit_sources == ["Anonymous *learners*"]
+        translated_output = self.get_translated_output(store)
+        assert translated_output == "### (Anonymous *learners*) {#anonymous} ###\n"
+
+    def test_setext_heading_with_explicit_id(self) -> None:
+        store = self.parse("Anonymous learners {/* #anonymous */}\n----------\n")
+        unit_sources = self.get_translation_unit_sources(store)
+        assert unit_sources == ["Anonymous learners"]
+        translated_output = self.get_translated_output(store)
+        assert translated_output == (
+            "(Anonymous learners) {/* #anonymous */}\n----------\n"
+        )
+
+    def test_heading_with_malformed_explicit_id(self) -> None:
+        store = self.parse("### Anonymous learners {/* #anonymous /*}\n")
+        unit_sources = self.get_translation_unit_sources(store)
+        assert unit_sources == ["Anonymous learners {/* #anonymous /*}"]
+        translated_output = self.get_translated_output(store)
+        assert translated_output == "### (Anonymous learners {/* #anonymous /*})\n"
+
     def test_empty_atx_heading(self) -> None:
         input = [
             "## \n",
@@ -729,6 +772,26 @@ class TestMarkdownNoPlaceholders(TestMarkdownTranslationUnitExtractionAndTransla
 
 
 class TestMarkdownRendering:
+    def test_legacy_explicit_heading_id_translation(self) -> None:
+        source = "### Anonymous learners {/* #anonymous */}\n"
+        legacy_source = "Anonymous learners {/* #anonymous */}"
+
+        for legacy_target in (
+            "Anonyme Lernende",
+            "Anonyme Lernende {/* #anonymous */}",
+            "Anonyme Lernende {#translated-anchor}",
+        ):
+            inputfile = BytesIO(source.encode())
+            store = markdown.MarkdownFile(
+                inputfile=inputfile,
+                callback=lambda text, target=legacy_target: (
+                    target if text == legacy_source else text
+                ),
+            )
+
+            assert [unit.source for unit in store.units] == ["Anonymous learners"]
+            assert store.filesrc == "### Anonyme Lernende {/* #anonymous */}\n"
+
     def test_hard_line_break_in_translation_unit(self) -> None:
         input = "yes box\n"
         inputfile = BytesIO(input.encode())

--- a/tests/translate/storage/test_mdxfile.py
+++ b/tests/translate/storage/test_mdxfile.py
@@ -24,6 +24,35 @@ class TestSupportedSubset:
         store = mdx_store(b"# Hello World\n\nThis is a paragraph.\n")
         assert sources(store) == ["Hello World", "This is a paragraph."]
 
+    def test_explicit_heading_ids_match_markdown(self):
+        content = b"""### Anonymous learners {/* #anonymous */}
+
+Registered learners {#registered}
+--------------------------------
+"""
+        translations = {
+            "Anonymous learners": "Anonymous learners translated",
+            "Registered learners": "Registered learners translated",
+        }
+        store = mdx_store(content, callback=lambda text: translations.get(text, text))
+
+        assert sources(store) == ["Anonymous learners", "Registered learners"]
+        assert store.filesrc == (
+            "### Anonymous learners translated {/* #anonymous */}\n\n"
+            "Registered learners translated {#registered}\n"
+            "--------------------------------\n"
+        )
+
+    def test_explicit_heading_id_does_not_expose_other_expression(self):
+        content = b"""### Result {value} {/* #result */}
+
+After.
+"""
+        store = mdx_store(content)
+
+        assert sources(store) == ["After."]
+        assert store.filesrc == content.decode()
+
     def test_top_level_esm_is_opaque(self):
         content = b"""import {
   Alert,
@@ -92,6 +121,23 @@ After.
         assert "  Translated **Markdown**." in store.filesrc
         assert "  - Translated list item" in store.filesrc
         assert store.filesrc.endswith("\nAfter.\n")
+
+    def test_simple_component_child_explicit_heading_id(self):
+        content = b"""<Tab>
+  ### Anonymous learners {/* #anonymous */}
+</Tab>
+"""
+        store = mdx_store(
+            content,
+            callback=lambda text: (
+                "Anonyme Lernende" if text == "Anonymous learners" else text
+            ),
+        )
+
+        assert sources(store) == ["Anonymous learners"]
+        assert store.filesrc == (
+            "<Tab>\n  ### Anonyme Lernende {/* #anonymous */}\n</Tab>\n"
+        )
 
     def test_simple_child_locations_and_docpaths(self):
         content = b"""# Heading

--- a/translate/convert/po2md.py
+++ b/translate/convert/po2md.py
@@ -66,6 +66,7 @@ class MarkdownTranslator:
         outputstore = markdown.MarkdownFile(
             inputfile=templatefile,
             callback=self._lookup,
+            lookup_callback=self._lookup_translation,
             max_line_length=self.maxlength if self.maxlength > 0 else None,
             extract_code_blocks=self.extract_code_blocks,
             extract_frontmatter=self.extract_frontmatter,
@@ -75,15 +76,20 @@ class MarkdownTranslator:
         return 1
 
     def _lookup(self, string: str) -> str:
+        translation = self._lookup_translation(string)
+        return string if translation is None else translation
+
+    def _lookup_translation(self, string: str) -> str | None:
+        """Return a usable translation, distinguishing misses from identity targets."""
         unit = self.inputstore.sourceindex.get(string, None)
         if unit is None:
-            return string
+            return None
         unit = unit[0]
         if unit.istranslated():
             return unit.target
         if self.includefuzzy and unit.isfuzzy():
             return unit.target
-        return unit.source
+        return None
 
 
 class PO2MDOptionParser(convert.ConvertOptionParser):

--- a/translate/convert/po2mdx.py
+++ b/translate/convert/po2mdx.py
@@ -60,6 +60,7 @@ class MDXTranslator:
         outputstore = mdxfile.MDXFile(
             inputfile=templatefile,
             callback=self._lookup,
+            lookup_callback=self._lookup_translation,
             max_line_length=self.maxlength if self.maxlength > 0 else None,
             extract_code_blocks=self.extract_code_blocks,
             extract_frontmatter=self.extract_frontmatter,
@@ -69,15 +70,20 @@ class MDXTranslator:
         return 1
 
     def _lookup(self, string: str) -> str:
+        translation = self._lookup_translation(string)
+        return string if translation is None else translation
+
+    def _lookup_translation(self, string: str) -> str | None:
+        """Return a usable translation, distinguishing misses from identity targets."""
         unit = self.inputstore.sourceindex.get(string, None)
         if unit is None:
-            return string
+            return None
         unit = unit[0]
         if unit.istranslated():
             return unit.target
         if self.includefuzzy and unit.isfuzzy():
             return unit.target
-        return unit.source
+        return None
 
 
 class PO2MDXOptionParser(convert.ConvertOptionParser):

--- a/translate/storage/markdown.py
+++ b/translate/storage/markdown.py
@@ -58,6 +58,21 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
 
+_EXPLICIT_HEADING_ID = re.compile(
+    r"(?P<title>.*?)(?P<suffix>[ \t]+(?:"
+    r"\{/\*\s*#[^\s{}*]+\s*\*/\}|"
+    r"\{#[^\s{}]+\}))$"
+)
+
+
+def _split_explicit_heading_id(text: str) -> tuple[str, str]:
+    """Split a trailing explicit heading ID from translatable text."""
+    match = _EXPLICIT_HEADING_ID.fullmatch(text)
+    if match is None:
+        return text, ""
+    return match.group("title"), match.group("suffix")
+
+
 class MarkdownUnit(base.TranslationUnit):
     """A unit of translatable/localisable markdown content."""
 
@@ -84,6 +99,7 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
         extract_frontmatter=True,
         frontmatter_translate_values=False,
         no_placeholders=False,
+        lookup_callback=None,
     ) -> None:
         """
         Construct a new object instance.
@@ -111,10 +127,18 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
           of being replaced by {n} placeholder markers. Sub-attribute extraction
           (e.g. link titles as separate units) is suppressed in this mode. If
           False (default), the classic placeholder behavior is used.
+        :param lookup_callback: a function which returns a translation for a source
+          string, or None when no translation exists. Defaults to adapting callback
+          by treating an unchanged result as missing.
         """
         base.TranslationStore.__init__(self)
         self.filename = getattr(inputfile, "name", None)
         self.callback = callback or self._dummy_callback
+        self.lookup_callback = (
+            self._default_lookup_callback
+            if lookup_callback is None
+            else lookup_callback
+        )
         self.max_line_length = max_line_length
         self.extract_code_blocks = extract_code_blocks
         self.extract_frontmatter = extract_frontmatter
@@ -176,7 +200,7 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
             block_token.Table,
             max_line_length=self.max_line_length,
             extract_code_blocks=self.extract_code_blocks,
-            lookup_callback=self.callback,
+            lookup_callback=self.lookup_callback,
             no_placeholders=self.no_placeholders,
         ) as renderer:
             document = block_token.Document(lines)
@@ -366,6 +390,11 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
     def _dummy_callback(text: str) -> str:
         return text
 
+    def _default_lookup_callback(self, text: str) -> str | None:
+        """Adapt a translation callback to the lookup callback contract."""
+        translation = self.callback(text)
+        return translation if translation != text else None
+
     def _translate_callback(self, text: str, path: list[str], docpath: str = "") -> str:
         text = text.strip()
         if not text:
@@ -389,7 +418,7 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
         *extras,
         max_line_length: int | None = None,
         extract_code_blocks: bool = True,
-        lookup_callback: Callable[[str], str] | None = None,
+        lookup_callback: Callable[[str], str | None] | None = None,
         no_placeholders: bool = False,
     ) -> None:
         super().__init__(*extras, max_line_length=max_line_length)
@@ -473,6 +502,56 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
         if self._container_stack:
             self._container_stack.pop()
             self._section_counts.pop()
+
+    @classmethod
+    def _split_explicit_heading_id_tokens(
+        cls, tokens: Iterable[mistletoe.token.Token] | None
+    ) -> tuple[list[span_token.SpanToken], str]:
+        """Remove an explicit heading ID from the final raw-text token."""
+        result: list[span_token.SpanToken] = []
+        for token in tokens or ():
+            assert isinstance(token, span_token.SpanToken)
+            result.append(token)
+        if not result or not isinstance(result[-1], span_token.RawText):
+            return result, ""
+
+        title, suffix = _split_explicit_heading_id(result[-1].content)
+        if not suffix:
+            return result, ""
+        if title:
+            result[-1] = span_token.RawText(title)
+        else:
+            result.pop()
+        return result, suffix
+
+    def _lookup_heading_translation(
+        self, source: str, translation: str, suffix: str
+    ) -> tuple[str, bool]:
+        """Look up current and legacy heading translations without ambiguity."""
+        if not suffix:
+            return translation, translation != source
+        if translation != source:
+            translated_title, _translated_suffix = _split_explicit_heading_id(
+                translation
+            )
+            return translated_title, True
+        if self.lookup_callback is None:
+            return translation, False
+
+        current_translation = self.lookup_callback(source)
+        if current_translation is not None:
+            current_title, _current_suffix = _split_explicit_heading_id(
+                current_translation
+            )
+            return current_title, True
+
+        legacy_source = source + suffix
+        legacy_translation = self.lookup_callback(legacy_source)
+        if legacy_translation is None:
+            return translation, False
+
+        legacy_title, _legacy_suffix = _split_explicit_heading_id(legacy_translation)
+        return legacy_title, True
 
     _leading_ws = re.compile(r"^(\s+)\S")
     _trailing_ws = re.compile(r"\S(\s+)$")
@@ -626,7 +705,29 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     ) -> Iterable[str]:
         self.path.append(f":{token.line_number}")  # ty:ignore[unresolved-attribute]
         self._current_docpath = self._enter_heading(token.level)
-        content = list(super().render_heading(token, max_line_length=max_line_length))
+        title_tokens, suffix = self._split_explicit_heading_id_tokens(token.children)
+        if suffix:
+            translated = next(
+                iter(
+                    self.span_to_lines(
+                        title_tokens,
+                        max_line_length=None,
+                        legacy_heading_suffix=suffix,
+                    )
+                ),
+                "",
+            )
+            heading = "#" * token.level
+            if translated:
+                heading += " " + translated
+            heading += suffix
+            if token.closing_sequence:
+                heading += " " + token.closing_sequence
+            content = [heading]
+        else:
+            content = list(
+                super().render_heading(token, max_line_length=max_line_length)
+            )
         self.path.pop()
         return content
 
@@ -635,9 +736,24 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     ) -> Iterable[str]:
         self.path.append(f":{token.line_number}")  # ty:ignore[unresolved-attribute]
         self._current_docpath = self._enter_heading(token.level)
-        content = list(
-            super().render_setext_heading(token, max_line_length=max_line_length)
-        )
+        title_tokens, suffix = self._split_explicit_heading_id_tokens(token.children)
+        if suffix:
+            content = list(
+                self.span_to_lines(
+                    title_tokens,
+                    max_line_length=max_line_length,
+                    legacy_heading_suffix=suffix,
+                )
+            )
+            if content:
+                content[-1] += suffix
+            else:
+                content.append(suffix.lstrip())
+            content.append(token.underline)
+        else:
+            content = list(
+                super().render_setext_heading(token, max_line_length=max_line_length)
+            )
         self.path.pop()
         return content
 
@@ -762,7 +878,10 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     # translation and placeholder functions
 
     def span_to_lines(
-        self, tokens: Iterable[span_token.SpanToken], max_line_length: int | None
+        self,
+        tokens: Iterable[span_token.SpanToken],
+        max_line_length: int | None,
+        legacy_heading_suffix: str = "",
     ) -> Iterable[str]:
         """Renders a sequence of span tokens to markdown, with translation."""
         # If we're in an ignore section, skip translation
@@ -808,6 +927,11 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
                     translated_md = self.translate_callback(
                         content_md, self.path, self._current_docpath
                     )
+                    translated_md, _translation_found = (
+                        self._lookup_heading_translation(
+                            content_md, translated_md, legacy_heading_suffix
+                        )
+                    )
                     translated_md = translated_md.replace("\n", "\\\n").strip(" \t")
                     translated = list(
                         self.make_fragments(span_token.tokenize_inner(translated_md))
@@ -840,23 +964,25 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
                 translated_md = self.translate_callback(
                     content_md, self.path, self._current_docpath
                 )
-                # If translation with placeholders didn't match and there are
-                # placeholders, try looking up with expanded placeholders
-                # (full markdown links, etc.) to support PO files that contain
-                # the original markdown syntax instead of placeholder markers.
-                # Note: if the translation is intentionally identical to the
-                # source, this fallback is harmless — it will also not find a
-                # different translation.
-                if (
-                    translated_md == content_md
-                    and placeholders
-                    and self.lookup_callback
-                ):
+                translated_md, translation_found = self._lookup_heading_translation(
+                    content_md, translated_md, legacy_heading_suffix
+                )
+                # If no placeholder-based translation matched, try expanded
+                # Markdown links and their legacy heading-ID form.
+                if not translation_found and placeholders and self.lookup_callback:
                     expanded_content_md = self.remove_placeholder_markers(
                         content_md, list(placeholders)
                     )
                     expanded_translated_md = self.lookup_callback(expanded_content_md)
-                    if expanded_translated_md != expanded_content_md:
+                    if expanded_translated_md is None and legacy_heading_suffix:
+                        expanded_translated_md = self.lookup_callback(
+                            expanded_content_md + legacy_heading_suffix
+                        )
+                    if expanded_translated_md is not None:
+                        if legacy_heading_suffix:
+                            expanded_translated_md, _expanded_suffix = (
+                                _split_explicit_heading_id(expanded_translated_md)
+                            )
                         translated_md = expanded_translated_md
                         # The expanded translation already contains full markdown
                         # syntax (e.g. links), so skip placeholder replacement.

--- a/translate/storage/mdxfile.py
+++ b/translate/storage/mdxfile.py
@@ -23,7 +23,13 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from translate.storage.markdown import MarkdownFile, MarkdownUnit
+from mistletoe import block_token
+
+from translate.storage.markdown import (
+    MarkdownFile,
+    MarkdownUnit,
+    _split_explicit_heading_id,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -58,6 +64,7 @@ _ESM_START = re.compile(
 )
 _FENCE = re.compile(r"^ {0,3}(?P<delimiter>`{3,}|~{3,})")
 _LOWER_HTML_START = re.compile(r"^ {0,3}<(?P<tag>[a-z][A-Za-z0-9-]*)(?:[\s>/]|$)")
+_SETEXT_HEADING_UNDERLINE = re.compile(r"^ {0,3}(?:=+|-+)[ \t]*$")
 
 
 class MDXUnit(MarkdownUnit):
@@ -78,6 +85,7 @@ class MDXFile(MarkdownFile):
         extract_frontmatter=True,
         frontmatter_translate_values=False,
         no_placeholders=False,
+        lookup_callback=None,
     ) -> None:
         """Construct an MDX store with the same options as MarkdownFile."""
         self._mdx_blocks: dict[str, tuple[str, int]] = {}
@@ -88,6 +96,7 @@ class MDXFile(MarkdownFile):
         super().__init__(
             inputfile=inputfile,
             callback=callback,
+            lookup_callback=lookup_callback,
             max_line_length=max_line_length,
             extract_code_blocks=extract_code_blocks,
             extract_frontmatter=extract_frontmatter,
@@ -239,6 +248,7 @@ class MDXFile(MarkdownFile):
         dedented_lines = [line[indent:] for line in child_lines]
         child_store = MarkdownFile(
             callback=self.callback,
+            lookup_callback=self.lookup_callback,
             max_line_length=self.max_line_length,
             extract_code_blocks=self.extract_code_blocks,
             extract_frontmatter=False,
@@ -343,7 +353,7 @@ class MDXFile(MarkdownFile):
         ):
             return False
 
-        for _, line in cls._structural_lines(lines):
+        for index, line in cls._structural_lines(lines):
             if (
                 re.search(
                     r"</?[A-Z][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*",
@@ -351,8 +361,10 @@ class MDXFile(MarkdownFile):
                 )
                 or "<>" in line
                 or "</>" in line
-                or "{" in line
-                or "}" in line
+                or (
+                    ("{" in line or "}" in line)
+                    and not cls._is_explicit_heading_id_line(lines, index)
+                )
                 or cls._is_esm_start(line.lstrip())
             ):
                 return False
@@ -520,7 +532,7 @@ class MDXFile(MarkdownFile):
     @classmethod
     def _chunk_requires_opaque(cls, lines: list[str]) -> bool:
         """Reject an ordinary Markdown block containing structural MDX."""
-        for line in lines:
+        for index, line in enumerate(lines):
             logical_line = cls._logical_line(line)
             if (
                 _COMPONENT_START.match(logical_line)
@@ -533,9 +545,26 @@ class MDXFile(MarkdownFile):
                 not cls._is_indented_code(line)
                 and not re.match(r"(?:>|[-+*]\s|\d+[.)]\s)", line.lstrip())
                 and ("{" in line or "}" in line)
+                and not cls._is_explicit_heading_id_line(lines, index)
             ):
                 return True
         return False
+
+    @classmethod
+    def _is_explicit_heading_id_line(cls, lines: list[str], index: int) -> bool:
+        """Return whether a brace-containing line has only a heading ID."""
+        line = cls._logical_line(lines[index])
+        heading_match = block_token.Heading.pattern.match(line + "\n")
+        if heading_match is not None:
+            title, suffix = _split_explicit_heading_id(heading_match.group(2) or "")
+            return bool(suffix) and "{" not in title and "}" not in title
+
+        if index + 1 >= len(lines) or not _SETEXT_HEADING_UNDERLINE.fullmatch(
+            cls._logical_line(lines[index + 1])
+        ):
+            return False
+        title, suffix = _split_explicit_heading_id(line.strip())
+        return bool(suffix) and "{" not in title and "}" not in title
 
     @staticmethod
     def _is_indented_code(line: str) -> bool:


### PR DESCRIPTION
Keep Docusaurus and classic heading IDs out of translatable PO messages so translated titles do not break stable anchors.