### PR TITLE
fix(po2xliff): propagate target language from PO header

### DIFF
--- a/tests/translate/convert/test_po2xliff.py
+++ b/tests/translate/convert/test_po2xliff.py
@@ -384,6 +384,27 @@ msgstr "مرحبا"
         assert self.po2xliff(minipo).targetlanguage == "ar"
         assert self.po2xliff(minipo, targetlanguage="es").targetlanguage == "es"
 
+    def test_target_language_missing_from_po_header(self) -> None:
+        minipo = r"""msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "hello"
+msgstr "hello"
+"""
+        assert self.po2xliff(minipo).targetlanguage is None
+
+    def test_empty_target_language_in_po_header(self) -> None:
+        minipo = r"""msgid ""
+msgstr ""
+"Language: \n"
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "hello"
+msgstr "hello"
+"""
+        assert self.po2xliff(minipo).targetlanguage is None
+
     def test_variables(self) -> None:
         minipo = r'''msgid "%s%s%s%s has made %s his or her buddy%s%s"
 msgstr "%s%s%s%s het %s sy/haar vriend/vriendin gemaak%s%s"'''

--- a/tests/translate/convert/test_po2xliff.py
+++ b/tests/translate/convert/test_po2xliff.py
@@ -372,6 +372,18 @@ msgstr "Uno"
         assert xliff.sourcelanguage == "af"
         assert xliff.targetlanguage == "es"
 
+    def test_target_language_from_po_header(self) -> None:
+        minipo = r"""msgid ""
+msgstr ""
+"Language: ar\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "hello"
+msgstr "مرحبا"
+"""
+        assert self.po2xliff(minipo).targetlanguage == "ar"
+        assert self.po2xliff(minipo, targetlanguage="es").targetlanguage == "es"
+
     def test_variables(self) -> None:
         minipo = r'''msgid "%s%s%s%s has made %s his or her buddy%s%s"
 msgstr "%s%s%s%s het %s sy/haar vriend/vriendin gemaak%s%s"'''

--- a/translate/convert/po2xliff.py
+++ b/translate/convert/po2xliff.py
@@ -112,6 +112,8 @@ class po2xliff:
 
     def convertstore(self, inputstore, templatefile=None, **kwargs):
         """Converts a .po file to .xlf format."""
+        if not kwargs.get("targetlanguage"):
+            kwargs["targetlanguage"] = inputstore.parseheader().get("Language")
         if templatefile is None:
             outputstore = poxliff.PoXliffFile(**kwargs)
         else:


### PR DESCRIPTION
PO files can declare their target locale in the `Language` header, but `po2xliff` only populated XLIFF's `target-language` when callers passed it explicitly. This uses the PO header as the fallback while preserving explicit overrides, with a regression test covering both paths.

Fixes #6391
