### PR TITLE
fix(checks): allow XML tags in different order in MozillaChecker without false positives

### DIFF
--- a/tests/translate/filters/test_checks.py
+++ b/tests/translate/filters/test_checks.py
@@ -1976,6 +1976,11 @@ def test_xmltags() -> None:
     )
     assert passes(
         stdchecker.xmltags,
+        'We <a href="u1">co-founded</a> the <a href="u2">WHAT-WG</a>',
+        'We <a href="u2">WHAT-WG</a> <a href="u1">co-founded</a>',
+    )
+    assert passes(
+        stdchecker.xmltags,
         'Click <a title="tip">here</a>',
         'Klik <a title="wenk">hier</a>',
     )

--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -1919,9 +1919,10 @@ class StandardChecker(TranslationChecker):
             for property2 in properties2:
                 filtered2 += [intuplelist(property2, self.config.canchangetags)]
 
-            # TODO: consider the consequences of different ordering of
-            # attributes/tags
-            if filtered1 != filtered2:
+            def _sort_key(item):
+                return [(str(v) if v is not None else "") for v in (item if isinstance(item, (list, tuple)) else [item])]
+
+            if sorted(filtered1, key=_sort_key) != sorted(filtered2, key=_sort_key):
                 raise FilterFailure("Different XML tags")
         else:
             # No tags in str1, let's just check that none were added in str2.

--- a/translate/filters/checks.py
+++ b/translate/filters/checks.py
@@ -1920,7 +1920,10 @@ class StandardChecker(TranslationChecker):
                 filtered2 += [intuplelist(property2, self.config.canchangetags)]
 
             def _sort_key(item):
-                return [(str(v) if v is not None else "") for v in (item if isinstance(item, (list, tuple)) else [item])]
+                return [
+                    (str(v) if v is not None else "")
+                    for v in (item if isinstance(item, (list, tuple)) else [item])
+                ]
 
             if sorted(filtered1, key=_sort_key) != sorted(filtered2, key=_sort_key):
                 raise FilterFailure("Different XML tags")


### PR DESCRIPTION
Fixes #3506. In languages like Bengali, sentence structure requires XML/HTML tags to appear in a different order than the source English string. The previous implementation in xmltags() compared tag property lists directly, raising false-positive FilterFailure errors when valid tags were reordered. This PR updates the check to compare sorted tag lists with a safe sorting key.