### PR TITLE
fix(storage): reject incompatible TS versions

### DIFF
--- a/tests/translate/storage/test_ts.py
+++ b/tests/translate/storage/test_ts.py
@@ -1,5 +1,7 @@
 from io import BytesIO, StringIO
 
+import pytest
+
 from translate.storage import ts
 
 
@@ -7,6 +9,18 @@ class TestTS:
     def test_construct(self) -> None:
         tsfile = ts.QtTsParser()
         tsfile.addtranslation("ryan", "Bread", "Brood", "Wit", createifmissing=True)
+
+    @pytest.mark.parametrize("version", ["1.0", "1.1"])
+    def test_accepts_legacy_version(self, version: str) -> None:
+        ts.QtTsParser(f'<TS version="{version}"></TS>')
+
+    @pytest.mark.parametrize("version", ["2.0", "2.1", "3.0", "invalid"])
+    def test_rejects_incompatible_version(self, version: str) -> None:
+        with pytest.raises(
+            ValueError,
+            match=rf"TS version '{version}'.*legacy TS format",
+        ):
+            ts.QtTsParser(f'<TS version="{version}"></TS>')
 
     def test_rejects_entity_expansion(self) -> None:
         parser_input = BytesIO(

--- a/tests/translate/storage/test_ts2.py
+++ b/tests/translate/storage/test_ts2.py
@@ -23,6 +23,8 @@ Reference implementation & tests:
 https://code.qt.io/cgit/qt/qttools.git/tree/tests/auto/linguist/lconvert/data
 """
 
+import pytest
+
 from translate.storage import ts2 as ts
 from translate.storage.placeables import parse, xliff
 
@@ -138,6 +140,18 @@ class TestTSUnit(test_base.TestTranslationUnit):
 
 class TestTSfile(test_base.TestTranslationStore):
     StoreClass = ts.tsfile
+
+    @pytest.mark.parametrize("version", ["2.0", "2.1"])
+    def test_accepts_modern_version(self, version: str) -> None:
+        ts.tsfile.parsestring(f'<TS version="{version}"></TS>')
+
+    @pytest.mark.parametrize("version", ["1.0", "1.1", "3.0", "invalid"])
+    def test_rejects_incompatible_version(self, version: str) -> None:
+        with pytest.raises(
+            ValueError,
+            match=rf"TS version '{version}'.*TS 2\.x format",
+        ):
+            ts.tsfile.parsestring(f'<TS version="{version}"></TS>')
 
     def test_basic(self) -> None:
         tsfile = ts.tsfile()

--- a/translate/storage/ts.py
+++ b/translate/storage/ts.py
@@ -77,7 +77,9 @@ class QtTsParser:
             # Preserve the original doctype so round-tripped TS files keep the
             # same declaration shape as the input.
             self.doctype = self.document.docinfo.doctype or None
-            assert self.document.getroot().tag == "TS"
+            root = self.document.getroot()
+            assert root.tag == "TS"
+            self._validate_version(root)
 
     @staticmethod
     def _parse_content(content: str | bytes) -> etree._ElementTree:
@@ -89,6 +91,15 @@ class QtTsParser:
     @staticmethod
     def _looks_like_xml(content: str) -> bool:
         return content.lstrip().startswith("<")
+
+    @staticmethod
+    def _validate_version(root: etree._Element) -> None:
+        """Ensure the document uses a legacy TS version."""
+        version = root.get("version")
+        if version is not None and not version.startswith("1."):
+            raise ValueError(
+                f"TS version '{version}' is not compatible with the legacy TS format."
+            )
 
     @staticmethod
     def _normalize_text_input(content: str) -> str:

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -446,12 +446,18 @@ class tsfile(lisa.LISAfile[tsunit]):
 
     def initbody(self) -> None:
         """Initialises self.body."""
-        self.namespace = self.document.getroot().nsmap.get(None, "")
-        self.header = self.document.getroot()
+        root = self.document.getroot()
+        version = root.get("version")
+        if version is not None and not version.startswith("2."):
+            raise ValueError(
+                f"TS version '{version}' is not compatible with the TS 2.x format."
+            )
+        self.namespace = root.nsmap.get(None, "")
+        self.header = root
         if self._contextname:
             self.body = self._getcontextnode(self._contextname)
         else:
-            self.body = self.document.getroot()
+            self.body = root
 
     def getsourcelanguage(self) -> str:
         """


### PR DESCRIPTION
Prevent legacy and modern TS parsers from silently loading documents whose declared major version they cannot safely handle.