### PR TITLE
fix(placeables): recognise XML tags with unquoted attribute values

### DIFF
--- a/tests/translate/storage/placeables/test_general.py
+++ b/tests/translate/storage/placeables/test_general.py
@@ -121,6 +121,9 @@ def test_placeable_xml_tag() -> None:
     result = general.XMLTagPlaceable.parse('<img src="koei.jpg" />')
     assert result
     assert result[0] == general.XMLTagPlaceable(['<img src="koei.jpg" />'])
+    result = general.XMLTagPlaceable.parse("<a href=%(url)s>")
+    assert result
+    assert result[0] == general.XMLTagPlaceable(["<a href=%(url)s>"])
     # We don't want this to be recognised, so we test for None - not sure if that is a stable assumption
     assert general.XMLTagPlaceable.parse("<important word>") is None
     assert general.XMLTagPlaceable.parse('<img ="koei.jpg" />') is None

--- a/tests/translate/tools/test_podebug.py
+++ b/tests/translate/tools/test_podebug.py
@@ -145,6 +145,14 @@ msgstr[1] "%d articles"
             == "<style0>Ŧḗşŧ</style0>"
         )
 
+    def test_rewrite_unicode_preserves_html_unquoted_attribute(self) -> None:
+        """Test that HTML tags with unquoted attribute values are preserved."""
+        debug = podebug.podebug(preserveplaceholders=True)
+        assert (
+            str(debug.rewrite_unicode("<a href=%(url)s>Test</a>"))
+            == "<a href=%(url)s>Ŧḗşŧ</a>"
+        )
+
     def test_rewrite_unicode_preserves_multiple_styles_of_placeholder(self) -> None:
         """Test the unicode rewrite function."""
         debug = podebug.podebug(preserveplaceholders=True)

--- a/translate/storage/placeables/general.py
+++ b/translate/storage/placeables/general.py
@@ -329,7 +329,8 @@ class XMLTagPlaceable(RegexParseMixin, Ph):
         <                         # start of opening tag
         ([\w.:]+)                 # tag name, possibly namespaced
         (\s([\w.:]+=              # space and attribute name followed by =
-            ((".*?")|('.*?'))     # attribute value, single or double quoted
+            ((".*?")|('.*?')      # attribute value, single or double quoted
+             |([^\s'"<>]+))       # or unquoted
         )?)*/?>                   # end of opening tag, possibly self closing
         |</([\w.]+)>              # or a closing tag
         """,


### PR DESCRIPTION
Fixes #4296

`XMLTagPlaceable`'s regex only accepted quoted attribute values, so `<a href=%(url)s>` was not recognised as a tag and `podebug --rewrite=unicode` mangled it into `<ȧ ħřḗƒ=%(url)s>`. The regex now also accepts unquoted attribute values, while still rejecting `<important word>` and `<img "koei.jpg" />`.