### PR TITLE
fix(po2xliff): only split a location into linenumber when numeric

### DIFF
--- a/tests/translate/convert/test_po2xliff.py
+++ b/tests/translate/convert/test_po2xliff.py
@@ -157,6 +157,20 @@ msgstr "kunye"
             ("sourcefile", "asdf.c"),
         ]
 
+    def test_location_without_linenumber(self) -> None:
+        """Non-numeric locations must not be split into sourcefile/linenumber."""
+        location = "office:document-content[0]/office:body[0]/text:p[0]"
+        minipo = f"""#: {location}
+msgid "one"
+msgstr "kunye"
+"""
+        xliff = self.po2xliff(minipo)
+        node = xliff.units[0].xmlelement
+        assert self.getcontexttuples(node, xliff.namespace) == [
+            ("sourcefile", location)
+        ]
+        assert xliff.units[0].getlocations() == [location]
+
     def test_othercomments(self) -> None:
         minipo = r"""# Translate?
 # How?

--- a/translate/convert/po2xliff.py
+++ b/translate/convert/po2xliff.py
@@ -100,12 +100,12 @@ class po2xliff:
 
     @staticmethod
     def contextlist(location):
-        contexts = []
+        sourcefile, linenumber = location, None
         if ":" in location:
-            sourcefile, linenumber = location.split(":", 1)
-        else:
-            sourcefile, linenumber = location, None
-        contexts.append(("sourcefile", sourcefile))
+            head, tail = location.rsplit(":", 1)
+            if head and tail.isdigit():
+                sourcefile, linenumber = head, tail
+        contexts = [("sourcefile", sourcefile)]
         if linenumber:
             contexts.append(("linenumber", linenumber))
         return contexts


### PR DESCRIPTION
Closes #5553

`po2xliff.contextlist()` split every location on the first `:`, so an ODF-derived location like `office:document-content[0]/office:body[0]/text:p[0]` became `sourcefile="office"` plus a `linenumber` holding the rest of the path, and the location was lost on round-trip. It now only splits when the trailing segment is numeric, and uses `rsplit` — matching `XliffUnit.addlocation`/`getlocations` in `translate/storage/xliff.py`.

New `test_location_without_linenumber` fails on master (`('sourcefile', 'office')` + bogus linenumber) and passes with the fix; existing `test_locationcomments` (`file.c:123 asdf.c`) is unchanged.
