### PR TITLE
fix(storage): handle scalar container transitions

### DIFF
--- a/tests/translate/storage/test_jsonl10n.py
+++ b/tests/translate/storage/test_jsonl10n.py
@@ -638,6 +638,28 @@ class TestJSONNestedResourceStore(test_monolingual.TestMonolingualUnit):
 """
         assert bytes(store).decode() == expected
 
+    @mark.parametrize(
+        ("nested_id", "expected"),
+        [
+            ("values[0][1]", {"values": [[None, "new"]]}),
+            ("values[0].child", {"values": [{"child": "new"}]}),
+        ],
+    )
+    def test_replace_scalar_with_nested_structure(
+        self, nested_id: str, expected: dict
+    ) -> None:
+        store = self.StoreClass()
+
+        unit = self.StoreClass.UnitClass("old")
+        unit.setid("values[0]")
+        store.addunit(unit)
+
+        unit = self.StoreClass.UnitClass("new")
+        unit.setid(nested_id)
+        store.addunit(unit)
+
+        assert json.loads(bytes(store)) == expected
+
     def test_nested_list_mixed(self) -> None:
         data = """{
     "story_9795": {

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -1378,7 +1378,7 @@ class DictUnit(TranslationUnit):
                 while len(target) <= key and not unset:
                     target.append(default.copy())
             elif element == "key":
-                if key not in target or isinstance(target[key], str):
+                if key not in target:
                     target[key] = default
             else:
                 raise ValueError(f"Unsupported element: {element}")
@@ -1388,8 +1388,8 @@ class DictUnit(TranslationUnit):
             elif use_list and isinstance(target[key], dict):
                 # Replace with an empty list if needed (this loses previous content)
                 target[key] = []
-            # Handle placeholders
-            if target[key] is None:
+            elif not isinstance(target[key], list if use_list else dict):
+                # Replace a stale scalar when the structure has changed
                 target[key] = default.copy()
             parent = target
             target = target[key]


### PR DESCRIPTION
Source structure changes can leave stale scalar units before newer nested paths. Normalize those scalars into the required container to avoid serialization failures.