### PR TITLE
fix(po2rc): preserve inline RC comments

### DIFF
--- a/tests/translate/convert/test_po2rc.py
+++ b/tests/translate/convert/test_po2rc.py
@@ -181,6 +181,78 @@ msgstr "Zkopirovano"
         assert len(rc_result.units) == 1
         assert rc_result.units[0].target == "Zkopirovano"
 
+    def test_convert_inline_comment(self) -> None:
+        source = """
+STRINGTABLE
+BEGIN
+    // standalone
+    ID_1 "First" // inline
+    ID_2 "Second"
+    ID_3 "Third" // untranslated inline
+END
+"""
+        expected = """
+STRINGTABLE
+BEGIN
+    // standalone
+    ID_1                    "Translated first" // inline
+    ID_2                    "Translated second"
+    ID_3                    "Third" // untranslated inline
+END
+"""
+        self.create_testfile("simple.rc", source)
+        self.create_testfile(
+            "simple.po",
+            """
+#: STRINGTABLE.ID_1
+msgid "First"
+msgstr "Translated first"
+
+#: STRINGTABLE.ID_2
+msgid "Second"
+msgstr "Translated second"
+""",
+        )
+        self.run_command(
+            template="simple.rc", i="simple.po", o="output.rc", l="LANG_CZECH"
+        )
+
+        with self.open_testfile("output.rc") as handle:
+            assert handle.read().decode() == expected
+
+    def test_convert_dialog_inline_comment(self) -> None:
+        source = """
+IDD_TEST DIALOG 0, 0, 100, 100
+BEGIN
+    LTEXT "First",IDC_FIRST,1,2,3,4 // inline
+    LTEXT "Second",IDC_SECOND,5,6,7,8
+END
+"""
+        self.create_testfile("simple.rc", source)
+        self.create_testfile(
+            "simple.po",
+            """
+#: DIALOG.IDD_TEST.LTEXT.IDC_FIRST
+msgid "First"
+msgstr "Translated first"
+
+#: DIALOG.IDD_TEST.LTEXT.IDC_SECOND
+msgid "Second"
+msgstr "Translated second"
+""",
+        )
+        self.run_command(
+            template="simple.rc", i="simple.po", o="output.rc", l="LANG_CZECH"
+        )
+
+        with self.open_testfile("output.rc") as handle:
+            lines = handle.read().decode().splitlines()
+        assert (
+            '    LTEXT           "Translated first",IDC_FIRST,1,2,3,4 // inline'
+            in lines
+        )
+        assert '    LTEXT           "Translated second",IDC_SECOND,5,6,7,8' in lines
+
     def test_convert_double_string(self) -> None:
         self.create_testfile(
             "simple.rc",

--- a/tests/translate/storage/test_rc.py
+++ b/tests/translate/storage/test_rc.py
@@ -45,6 +45,17 @@ class TestRcFile:
         """Helper that converts source to store object and back."""
         return bytes(self.source_parse(source))
 
+    def test_one_line_comment_position(self) -> None:
+        result = rc.rc_statement().parse_string(
+            'STRINGTABLE\nBEGIN\n// standalone\nID_1 "First" // inline\nEND\n'
+        )
+
+        standalone, _control, inline = result.controls
+        assert isinstance(standalone, str)
+        assert not getattr(standalone, "inline", False)
+        assert isinstance(inline, str)
+        assert getattr(inline, "inline", False)
+
     def test_parse_only_comments(self) -> None:
         """Test parsing a RC string with only comments."""
         rc_source = r"""

--- a/translate/convert/po2rc.py
+++ b/translate/convert/po2rc.py
@@ -108,6 +108,23 @@ class rerc:
         comment = comment.removesuffix("\r")
         yield comment
 
+    @staticmethod
+    def iter_controls_with_inline_comments(controls):
+        """Yield controls together with a following same-line comment."""
+        index = 0
+        while index < len(controls):
+            control = controls[index]
+            inline_comment = None
+            if (
+                not isinstance(control, str)
+                and index + 1 < len(controls)
+                and getattr(controls[index + 1], "inline", False)
+            ):
+                inline_comment = controls[index + 1]
+                index += 1
+            yield control, inline_comment
+            index += 1
+
     def convert_caption(self, toks, name):
         yield "CAPTION "
 
@@ -141,7 +158,7 @@ class rerc:
         yield self.templatestore.newline
         addnl = False
 
-        for c in toks.controls:
+        for c, inline_comment in self.iter_controls_with_inline_comments(toks.controls):
             if isinstance(c, str):
                 yield from self.convert_comment(addnl, c)
                 addnl = True
@@ -185,6 +202,9 @@ class rerc:
                     tmp.append(a)
 
             yield ",".join(tmp)
+            if inline_comment is not None:
+                yield " "
+                yield from self.convert_comment(True, inline_comment)
             yield self.templatestore.newline
 
         if addnl:
@@ -200,7 +220,7 @@ class rerc:
         yield self.templatestore.newline
 
         addnl = False
-        for c in toks.controls:
+        for c, inline_comment in self.iter_controls_with_inline_comments(toks.controls):
             if isinstance(c, str):
                 yield from self.convert_comment(addnl, c)
                 addnl = True
@@ -229,6 +249,9 @@ class rerc:
                 yield self.templatestore.newline + " " * (24 + 4)
             yield tmp[-1]
 
+            if inline_comment is not None:
+                yield " "
+                yield from self.convert_comment(True, inline_comment)
             yield self.templatestore.newline
 
         if addnl:

--- a/translate/storage/rc.py
+++ b/translate/storage/rc.py
@@ -157,9 +157,28 @@ class rcunit(base.TranslationUnit):
         return not (self.name or self.value)  # ty:ignore[unresolved-attribute]
 
 
+class _RCComment(str):
+    """RC comment with information about its position on the source line."""
+
+    inline: bool
+
+    def __new__(cls, value: str, *, inline: bool = False):
+        comment = super().__new__(cls, value)
+        comment.inline = inline
+        return comment
+
+
+def _mark_one_line_comment(source: str, location: int, tokens):
+    """Retain whether a ``//`` comment followed content on the same line."""
+    line_start = source.rfind("\n", 0, location) + 1
+    return _RCComment(tokens[0], inline=bool(source[line_start:location].strip()))
+
+
 def rc_statement() -> ParserElement:
     """Generate a RC statement parser that can be used to parse a RC file."""
-    one_line_comment = Combine("//" + rest_of_line)
+    one_line_comment = Combine("//" + rest_of_line).set_parse_action(
+        _mark_one_line_comment
+    )
 
     comments = c_style_comment ^ one_line_comment
 


### PR DESCRIPTION
Pyparsing discarded whether // comments followed a resource entry, so po2rc moved them ahead of the next entry. Carry that position through parsing and render each comment beside its original control.

Closes #4935