### PR TITLE
fix(ts): preserve comment types in PO conversion

### DIFF
--- a/tests/translate/convert/test_po2ts.py
+++ b/tests/translate/convert/test_po2ts.py
@@ -50,16 +50,29 @@ msgstr "†arget"'''
     def test_fullunit(self) -> None:
         """Check that an entry with various settings is converted correctly."""
         posource = """# Translator comment
-#. Automatic comment
+# Second translator line
+#. Developer comment
+#. Second developer line
 #: location.cpp:100
+msgctxt "Button label"
 msgid "Source"
 msgstr "Target"
 """
         tsfile = self.po2ts(posource)
         print(tsfile)
         # The other section are a duplicate of test_simplentry
-        # FIXME need to think about auto vs trans comments maybe in TS v1.1
-        assert "<comment>Translator comment</comment>" in tsfile
+        assert "<comment>Button label</comment>" in tsfile
+        assert (
+            "<extracomment>Developer comment\nSecond developer line</extracomment>"
+            in tsfile
+        )
+        assert (
+            "<translatorcomment>Translator comment\nSecond translator line"
+            "</translatorcomment>" in tsfile
+        )
+        assert tsfile.index("<comment>") < tsfile.index("<translation>")
+        assert tsfile.index("<extracomment>") < tsfile.index("<translation>")
+        assert tsfile.index("<translatorcomment>") < tsfile.index("<translation>")
 
     def test_fuzzyunit(self) -> None:
         """Check that we handle fuzzy units correctly."""
@@ -73,13 +86,16 @@ msgstr "Target"'''
 
     def test_obsolete(self) -> None:
         """Test that we can take back obsolete messages."""
-        posource = '''#. (obsolete)
+        posource = '''#. Keep this note
+#. (obsolete)
 #: term.cpp
 msgid "Source"
 msgstr "Target"'''
         tsfile = self.po2ts(posource)
         print(tsfile)
         assert """<translation type="obsolete">Target</translation>""" in tsfile
+        assert "<extracomment>Keep this note</extracomment>" in tsfile
+        assert "(obsolete)" not in tsfile
 
     def test_duplicates(self) -> None:
         """Test that we can handle duplicates in the same context block."""

--- a/tests/translate/convert/test_ts2po.py
+++ b/tests/translate/convert/test_ts2po.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 
-from translate.convert import ts2po
+from translate.convert import po2ts, ts2po
+from translate.storage import ts2
 
 from . import test_convert
 
@@ -140,8 +141,45 @@ new line</translation>
 """
         pofile = self.ts2po(tssource)
         assert (
-            pofile.units[1].getnotes()
+            pofile.units[1].getnotes("developer")
             == "Appears in the Help menu (on Windows and Linux) or the app menu (on macOS)."
+        )
+
+    def test_comment_types(self) -> None:
+        """Keep disambiguation, developer, and translator comments distinct."""
+        tssource = """<!DOCTYPE TS><TS>
+<context>
+    <name>Dialog</name>
+    <message>
+        <source>Open</source>
+        <comment>Button label</comment>
+        <extracomment>Shown on the welcome screen.\nKeep it short.</extracomment>
+        <translatorcomment>Needs review.\nCheck terminology.</translatorcomment>
+        <translation>Abrir</translation>
+    </message>
+</context>
+</TS>
+"""
+        pofile = self.ts2po(tssource)
+        pounit = pofile.units[1]
+        assert pounit.getcontext() == "Button label"
+        assert (
+            pounit.getnotes("developer")
+            == "Shown on the welcome screen.\nKeep it short."
+        )
+        assert pounit.getnotes("translator") == "Needs review.\nCheck terminology."
+
+        output = BytesIO()
+        po2ts.po2ts.convertstore(pofile, output)
+        roundtripped = ts2.tsfile(BytesIO(output.getvalue())).units[0]
+        assert roundtripped.getcontextname() == "Dialog"
+        assert roundtripped._get_disambiguation() == "Button label"
+        assert (
+            roundtripped.getnotes("developer")
+            == "Shown on the welcome screen.\nKeep it short."
+        )
+        assert (
+            roundtripped.getnotes("translator") == "Needs review.\nCheck terminology."
         )
 
     def test_emptycontext(self) -> None:

--- a/translate/convert/po2ts.py
+++ b/translate/convert/po2ts.py
@@ -95,7 +95,13 @@ class po2ts:
                     source = source.strings[0]
                 # If strings is empty, source remains as multistring (will be handled by tsunit)
             translation = inputunit.target
-            comment = inputunit.getnotes("translator")
+            developer_comments = inputunit.getnotes("developer")
+            developer_comment_lines = developer_comments.splitlines()
+            is_obsolete = "(obsolete)" in developer_comment_lines
+            developer_comments = "\n".join(
+                line for line in developer_comment_lines if line != "(obsolete)"
+            )
+            translator_comments = inputunit.getnotes("translator")
             locations = inputunit.getlocations()
             # If there are no locations, we still need to add the unit
             # Use the provided context or an empty string as default
@@ -114,11 +120,16 @@ class po2ts:
                     contextname = context
                 tsunit = ts2.tsunit(source)
                 tsunit.target = translation
-                if not inputunit.istranslated():
-                    tsunit.markfuzzy()
-                elif inputunit.getnotes("developer") == "(obsolete)":
+                tsunit._set_disambiguation(inputunit.getcontext())
+                if developer_comments:
+                    tsunit.addnote(developer_comments, origin="developer")
+                if translator_comments:
+                    tsunit.addnote(translator_comments, origin="translator")
+                if is_obsolete:
                     tsunit.set_state_n(tsunit.S_OBSOLETE)
-                tsfile.addunit(tsunit, True, contextname, comment, True)
+                elif not inputunit.istranslated():
+                    tsunit.markfuzzy()
+                tsfile.addunit(tsunit, True, contextname, createifmissing=True)
         tsfile.serialize(outputfile)
 
 

--- a/translate/convert/ts2po.py
+++ b/translate/convert/ts2po.py
@@ -40,7 +40,8 @@ class ts2po:
         source,
         target,
         disambiguation,
-        msgcomments,
+        developer_comments,
+        translator_comments,
         transtype,
         hasplural,
     ):
@@ -59,8 +60,10 @@ class ts2po:
             thepo.target = target
         if len(disambiguation) > 0:
             thepo.setcontext(disambiguation)
-        if len(msgcomments) > 0:
-            thepo.addnote(msgcomments)
+        if developer_comments:
+            thepo.addnote(developer_comments, origin="developer")
+        if translator_comments:
+            thepo.addnote(translator_comments, origin="translator")
         if transtype == "unfinished" and thepo.istranslated():
             thepo.markfuzzy()
         if transtype == "obsolete":
@@ -76,9 +79,7 @@ class ts2po:
 
         previouscontext = ""
         for inputunit in tsfile.units:
-            contexts = inputunit.getcontext().split("\n")
-
-            context = contexts[0].strip()
+            context = (inputunit.getcontextname() or "").strip()
             # skip the unit if the context is empty
             if not context:
                 continue
@@ -87,9 +88,9 @@ class ts2po:
                 previouscontext = context
                 messagenum = 0
 
-            disambiguation = ""
-            if len(contexts) > 1:
-                disambiguation = contexts[1]
+            disambiguation = (
+                inputunit._get_disambiguation() or inputunit.xmlelement.get("id", "")
+            )
             messagenum += 1
             thepo = self.convertmessage(
                 context,
@@ -97,7 +98,8 @@ class ts2po:
                 inputunit.source,
                 inputunit.target,
                 disambiguation,
-                inputunit.getnotes(),
+                inputunit.getnotes("developer"),
+                inputunit.getnotes("translator"),
                 inputunit._gettype(),
                 inputunit.hasplural(),
             )

--- a/translate/storage/ts2.py
+++ b/translate/storage/ts2.py
@@ -198,11 +198,11 @@ class tsunit(lisa.LISAunit):
         current_notes = self.getnotes(origin)
         self.removenotes(origin)
         if origin in {"programmer", "developer", "source code"}:
-            note = etree.SubElement(self.xmlelement, self.namespaced("extracomment"))
+            note = etree.Element(self.namespaced("extracomment"))
         else:
-            note = etree.SubElement(
-                self.xmlelement, self.namespaced("translatorcomment")
-            )
+            note = etree.Element(self.namespaced("translatorcomment"))
+        targetnode = self._gettargetnode()
+        self.xmlelement.insert(self.xmlelement.index(targetnode), note)
         if position == "append":
             safely_set_text(
                 note, "\n".join(item for item in [current_notes, text.strip()] if item)
@@ -305,14 +305,34 @@ class tsunit(lisa.LISAunit):
 
     def getcontext(self):
         contexts = [self.getcontextname()]
-        commentnode = self.xmlelement.find(self.namespaced("comment"))
-        if commentnode is not None and commentnode.text is not None:
-            contexts.append(commentnode.text)
+        contexts.append(self._get_disambiguation())
         message_id = self.xmlelement.get("id")
         if message_id is not None:
             contexts.append(message_id)
         contexts = filter(None, contexts)
         return "\n".join(contexts)
+
+    def _get_disambiguation(self) -> str:
+        """Return the message disambiguation stored in ``<comment>``."""
+        commentnode = self.xmlelement.find(self.namespaced("comment"))
+        if commentnode is None or commentnode.text is None:
+            return ""
+        return commentnode.text
+
+    def _set_disambiguation(self, value: str) -> None:
+        """Set the message disambiguation stored in ``<comment>``."""
+        commentnode = self.xmlelement.find(self.namespaced("comment"))
+        if not value:
+            if commentnode is not None:
+                self.xmlelement.remove(commentnode)
+            return
+        if commentnode is None:
+            commentnode = etree.Element(self.namespaced("comment"))
+            sourcenode = self._getsourcenode()
+            assert sourcenode is not None
+            index = self.xmlelement.index(sourcenode) + 1
+            self.xmlelement.insert(index, commentnode)
+        safely_set_text(commentnode, value)
 
     def addlocation(self, location) -> None:
         self._locations = None


### PR DESCRIPTION
Qt TS distinguishes disambiguation, developer guidance, and translator notes. Keeping these mappings separate prevents metadata loss and incorrect TS/PO round trips.

Closes #1394