### PR TITLE
fix(dtd): round-trip apostrophe entities

### DIFF
--- a/tests/translate/convert/test_dtd2po.py
+++ b/tests/translate/convert/test_dtd2po.py
@@ -71,12 +71,32 @@ class TestDTD2PO:
         assert unit.source == "Save As..."
         assert unit.target == ""
 
-    def test_apos(self) -> None:
-        """Apostrophe should not break a single-quoted entity definition, bug 69."""
-        dtdsource = "<!ENTITY test.me 'bananas &apos; for sale'>\n"
+    @mark.parametrize("quotechar", ["'", '"'])
+    def test_apos(self, quotechar) -> None:
+        """Decode apostrophes regardless of the entity's outer quotes."""
+        dtdsource = f"<!ENTITY test.me {quotechar}bananas &apos; for sale{quotechar}>\n"
         pofile = self.dtd2po(dtdsource)
         pounit = self.singleelement(pofile)
         assert pounit.source == "bananas ' for sale"
+
+    def test_apos_in_attribute(self) -> None:
+        """Keep apostrophe entities in attributes to preserve their context."""
+        dtdsource = "<!ENTITY test.me \"<a title='Bob&apos;s'>Hi</a>\">\n"
+        pofile = self.dtd2po(dtdsource)
+        pounit = self.singleelement(pofile)
+        assert pounit.source == "<a title='Bob&apos;s'>Hi</a>"
+
+    def test_decimal_quote_in_attribute(self) -> None:
+        """Keep decimal quote references in attributes lexical."""
+        dtdsource = "<!ENTITY test.me '<a title=\"Bob&#34;s\">Hi</a>'>\n"
+        pofile = self.dtd2po(dtdsource)
+        pounit = self.singleelement(pofile)
+        assert pounit.source == '<a title="Bob&#34;s">Hi</a>'
+
+        dtdsource = "<!ENTITY test.me \"<a title='Bob&#39;s'>Hi</a>\">\n"
+        pofile = self.dtd2po(dtdsource)
+        pounit = self.singleelement(pofile)
+        assert pounit.source == "<a title='Bob&#39;s'>Hi</a>"
 
     def test_quotes(self) -> None:
         """Quotes should be handled in a single-quoted entity definition."""

--- a/tests/translate/convert/test_po2dtd.py
+++ b/tests/translate/convert/test_po2dtd.py
@@ -437,8 +437,16 @@ msgstr "Simple string 3"
             r"""'Quote Escape "" '""", r'''"Quote Escape &quot;&quot; "'''
         )
         self.check_roundtrip(r'''"Double-Quote Escape &quot;&quot; "''')
-        self.check_roundtrip(r'''"Single-Quote ' "''')
-        self.check_roundtrip(r'''"Single-Quote Escape \' "''')
+        self.check_roundtrip(r'''"Single-Quote ' "''', r'''"Single-Quote &apos; "''')
+        self.check_roundtrip(
+            r'''"Single-Quote Escape \' "''',
+            r'''"Single-Quote Escape \&apos; "''',
+        )
+        self.check_roundtrip("\"<a href='http'>link</a>\"")
+        self.check_roundtrip("\"<a href = 'http'>link</a>\"")
+        self.check_roundtrip("\"<a title='Bob&apos;s'>Hi</a>\"")
+        self.check_roundtrip("'<a title=\"Bob&#34;s\">Hi</a>'")
+        self.check_roundtrip("\"<a title='Bob&#39;s'>Hi</a>\"")
         # NOTE: during the roundtrip, if " quote mark is present, then ' is
         # converted to &apos; and " is converted to &quot; Also the resulting
         # string is always enclosed between " characters independently of which

--- a/tests/translate/misc/test_xml_helpers.py
+++ b/tests/translate/misc/test_xml_helpers.py
@@ -1,6 +1,23 @@
 from lxml import etree
 
-from translate.misc.xml_helpers import parse_xml, reindent
+from translate.misc.xml_helpers import XMLTextParser, parse_xml, reindent
+
+
+class UppercaseXMLTextParser(XMLTextParser):
+    def process_string(self, content: str) -> tuple[str, bool, bool]:
+        return content.upper(), False, False
+
+
+def test_xml_text_parser_preserves_markup() -> None:
+    source = (
+        "<root>plain<é title='Bob&apos;s'>inner</é>"
+        "<![CDATA[Don't]]><!-- Don't --><?test Don't?>&brand;</root>"
+    )
+
+    assert UppercaseXMLTextParser(source).parse() == (
+        "PLAIN<é title='Bob&apos;s'>INNER</é>"
+        "<![CDATA[Don't]]><!-- Don't --><?test Don't?>&brand;"
+    )
 
 
 class TestReindent:

--- a/tests/translate/storage/test_dtd.py
+++ b/tests/translate/storage/test_dtd.py
@@ -18,6 +18,7 @@
 
 from io import BytesIO
 
+from lxml import etree
 from pytest import mark
 
 from translate.storage import dtd
@@ -52,10 +53,22 @@ def test_roundtrip_quoting() -> None:
         "&#x00A0;",
         "&intro-point2-a;",
         "&basePBMenu.label;",
-        # "Don't buy",
-        # "Don't \"buy\"",
+        "Don't buy",
+        'Don\'t "buy"',
         'A "thing"',
         '<a href="http',
+        "<a href='http'>link</a>",
+        '<a href = "http">link</a>',
+        "<é href='x'>Hi</é>",
+        "<![CDATA[Don't]]>",
+        '<![CDATA[Don\'t say "x"]]>',
+        "<!-- Don't -->",
+        '<!-- Don\'t say "x" -->',
+        "<?test Don't?>",
+        '<?test Don\'t say "x"?>',
+        '<a title="Don\'t">Hi</a>',
+        '<a title="Bob&#34;s">Hi</a>',
+        "<a title='Bob&#39;s'>Hi</a>",
     ]
     for special in specials:
         quoted_special = dtd.quotefordtd(special)
@@ -83,18 +96,90 @@ def test_quotefordtd() -> None:
     assert dtd.quotefordtd("&#x00A0;") == '"&#x00A0;"'
     assert dtd.quotefordtd("&intro-point2-a;") == '"&intro-point2-a;"'
     assert dtd.quotefordtd("&basePBMenu.label;") == '"&basePBMenu.label;"'
-    # The ' character isn't escaped as &apos; since the " char isn't present.
-    assert dtd.quotefordtd("Don't buy") == '"Don\'t buy"'
-    # The ' character is escaped as &apos; because the " character is present.
+    assert dtd.quotefordtd("Don't buy") == '"Don&apos;t buy"'
     assert dtd.quotefordtd('Don\'t "buy"') == '"Don&apos;t &quot;buy&quot;"'
     assert dtd.quotefordtd('A "thing"') == '"A &quot;thing&quot;"'
     # The " character is not escaped when it indicates an attribute value.
     assert dtd.quotefordtd('<a href="http') == "'<a href=\"http'"
+    # The ' character is not escaped when it indicates an attribute value.
+    assert dtd.quotefordtd("<a href='http'>link</a>") == ("\"<a href='http'>link</a>\"")
+    assert dtd.quotefordtd("<a href = 'http'>link</a>") == (
+        "\"<a href = 'http'>link</a>\""
+    )
+    assert dtd.quotefordtd("<a href='http'>Don't</a>") == (
+        "\"<a href='http'>Don&apos;t</a>\""
+    )
+    assert dtd.quotefordtd('<a href = "http">link</a>') == (
+        "'<a href = \"http\">link</a>'"
+    )
+    assert dtd.quotefordtd('<a title="Bob&#34;s">Hi</a>') == (
+        "'<a title=\"Bob&#34;s\">Hi</a>'"
+    )
+    assert dtd.quotefordtd("<a title='Bob&#39;s'>Hi</a>") == (
+        "\"<a title='Bob&#39;s'>Hi</a>\""
+    )
+    assert dtd.quotefordtd("<é href='x'>Hi</é>") == "\"<é href='x'>Hi</é>\""
+    assert dtd.quotefordtd("<![CDATA[Don't]]>") == '"<![CDATA[Don\'t]]>"'
+    assert dtd.quotefordtd('<![CDATA[Don\'t say "x"]]>') == (
+        "'<![CDATA[Don&#39;t say \"x\"]]>'"
+    )
+    assert dtd.quotefordtd("<!-- Don't -->") == '"<!-- Don\'t -->"'
+    assert dtd.quotefordtd("<?test Don't?>") == '"<?test Don\'t?>"'
     # &amp;
     assert dtd.quotefordtd("Color & Light") == '"Color &amp; Light"'
     assert dtd.quotefordtd("Color & &block;") == '"Color &amp; &block;"'
     assert dtd.quotefordtd("Color&Light &red;") == '"Color&amp;Light &red;"'
     assert dtd.quotefordtd("Color & Light; Yes") == '"Color &amp; Light; Yes"'
+    # Preserve apostrophes when malformed markup prevents contextual processing.
+    assert dtd.quotefordtd("Don't & &block; <b>") == ('"Don\'t &amp; &block; <b>"')
+
+
+@mark.parametrize(
+    ("markup", "tag", "attributes", "text"),
+    [
+        ("<a href='http'>link</a>", "a", {"href": "http"}, "link"),
+        ('<a href = "http">link</a>', "a", {"href": "http"}, "link"),
+        ('<a title="Don\'t">Hi</a>', "a", {"title": "Don't"}, "Hi"),
+        ("<é href='x'>Hi</é>", "é", {"href": "x"}, "Hi"),
+        ("<a title='Bob&apos;s'>Hi</a>", "a", {"title": "Bob's"}, "Hi"),
+    ],
+)
+def test_quotefordtd_attribute_quotes_are_valid_markup(
+    markup: str, tag: str, attributes: dict[str, str], text: str
+) -> None:
+    """Inline attribute quotes remain syntactic after entity expansion."""
+    value = dtd.quotefordtd(markup)
+    document = f"<!DOCTYPE root [<!ENTITY test {value}>]><root>&test;</root>"
+    parser = etree.XMLParser(load_dtd=True, resolve_entities=True)
+
+    root = etree.fromstring(document.encode(), parser)
+
+    assert root[0].tag == tag
+    assert root[0].attrib == attributes
+    assert root[0].text == text
+
+
+@mark.parametrize(
+    ("markup", "expected"),
+    [
+        ("<![CDATA[Don't]]>", b"<root>Don't</root>"),
+        ('<![CDATA[Don\'t say "x"]]>', b'<root>Don\'t say "x"</root>'),
+        ("<!-- Don't -->", b"<root><!-- Don't --></root>"),
+        ('<!-- Don\'t say "x" -->', b'<root><!-- Don\'t say "x" --></root>'),
+        ("<?test Don't?>", b"<root><?test Don't?></root>"),
+        ('<?test Don\'t say "x"?>', b'<root><?test Don\'t say "x"?></root>'),
+    ],
+)
+def test_quotefordtd_opaque_xml_preserves_apostrophes(
+    markup: str, expected: bytes
+) -> None:
+    value = dtd.quotefordtd(markup)
+    document = f"<!DOCTYPE root [<!ENTITY test {value}>]><root>&test;</root>"
+    parser = etree.XMLParser(load_dtd=True, resolve_entities=True)
+
+    root = etree.fromstring(document.encode(), parser)
+
+    assert etree.tostring(root) == expected
 
 
 @mark.xfail(reason="Not Implemented")
@@ -118,14 +203,34 @@ def test_unquotefromdtd() -> None:
     # &amp;
     assert dtd.unquotefromdtd('"Color &amp; Light"') == "Color & Light"
     assert dtd.unquotefromdtd('"Color &amp; &block;"') == "Color & &block;"
+    assert dtd.unquotefromdtd('"Don&apos;t &amp; &block; <b>"') == (
+        "Don't & &block; <b>"
+    )
+    assert dtd.unquotefromdtd('"A &quot;thing&quot; <b>"') == 'A "thing" <b>'
+    assert dtd.unquotefromdtd('"A &#x0022;thing&#x0022; <b>"') == 'A "thing" <b>'
+    assert dtd.unquotefromdtd("'<a title=\"Bob&#34;s\">Hi</a>'") == (
+        '<a title="Bob&#34;s">Hi</a>'
+    )
+    assert dtd.unquotefromdtd("\"<a title='Bob&#39;s'>Hi</a>\"") == (
+        "<a title='Bob&#39;s'>Hi</a>"
+    )
+    assert dtd.unquotefromdtd('"R&amp;D&apos;s"') == "R&D's"
+    assert dtd.unquotefromdtd(dtd.quotefordtd("R&D's")) == "R&D's"
     # nbsp
     assert dtd.unquotefromdtd('"&#x00A0;"') == "&#x00A0;"
     # '
     assert dtd.unquotefromdtd("'Don&apos;t buy'") == "Don't buy"
+    assert dtd.unquotefromdtd('"Don&apos;t buy"') == "Don't buy"
     # "
     assert dtd.unquotefromdtd("'Don&apos;t &quot;buy&quot;'") == 'Don\'t "buy"'
     assert dtd.unquotefromdtd('"A &quot;thing&quot;"') == 'A "thing"'
     assert dtd.unquotefromdtd('"A &#x0022;thing&#x0022;"') == 'A "thing"'
+    assert dtd.unquotefromdtd("\"<a title='Bob&apos;s'>Hi</a>\"") == (
+        "<a title='Bob&apos;s'>Hi</a>"
+    )
+    assert dtd.unquotefromdtd('"<![CDATA[Don&apos;t]]>"') == ("<![CDATA[Don&apos;t]]>")
+    assert dtd.unquotefromdtd('"<!-- Don&apos;t -->"') == "<!-- Don&apos;t -->"
+    assert dtd.unquotefromdtd('"<?test Don&apos;t?>"') == "<?test Don&apos;t?>"
     assert dtd.unquotefromdtd("'<a href=\"http'") == '<a href="http'
     # other chars
     assert dtd.unquotefromdtd('"&#187;"') == "»"

--- a/translate/misc/xml_helpers.py
+++ b/translate/misc/xml_helpers.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import re
 from typing import TYPE_CHECKING, BinaryIO, TextIO
+from xml.parsers.expat import XML_PARAM_ENTITY_PARSING_NEVER, ParserCreate
 
 from lxml import etree
 
@@ -94,6 +95,101 @@ def parse_xml_file(
             collect_ids=collect_ids,
         ),
     )
+
+
+class XMLTextParser:
+    """Process XML character data while preserving the original markup."""
+
+    EMIT_DEPTH = 1
+    FOREIGN_DTD = True
+
+    def __init__(self, text: str) -> None:
+        self.text = text.encode("utf-8")
+        self.output: list[str] = []
+        self.emit_start: int | None = None
+        self.character_data = False
+        self.raw_string = True
+        self.in_string = False
+        self.do_cleanup = False
+        self.depth = 0
+        self.parser = parser = ParserCreate()
+        if self.FOREIGN_DTD:
+            parser.UseForeignDTD(self.FOREIGN_DTD)
+        parser.SetParamEntityParsing(XML_PARAM_ENTITY_PARSING_NEVER)
+        parser.StartElementHandler = self.StartElementHandler
+        parser.EndElementHandler = self.EndElementHandler
+        parser.CharacterDataHandler = self.CharacterDataHandler
+        parser.StartCdataSectionHandler = self.StartCdataSectionHandler
+        parser.EndCdataSectionHandler = self.EndCdataSectionHandler
+        parser.DefaultHandler = self.DefaultHandler
+
+    def process_string(self, content: str) -> tuple[str, bool, bool]:
+        """Transform a character-data section and return cleanup flags."""
+        return content, False, False
+
+    def cleanup_text(self, text: str) -> str:
+        """Remove leading whitespace from the first transformed section."""
+        if not self.output:
+            return text.lstrip()
+        return text
+
+    def emit(self) -> None:
+        """Emit the raw or transformed input since the previous parser event."""
+        if self.emit_start is not None:
+            text = self.text[self.emit_start : self.parser.CurrentByteIndex].decode(
+                "utf-8"
+            )
+            self.do_cleanup = not self.raw_string
+            if not self.raw_string:
+                text, cleanup_start, self.do_cleanup = self.process_string(text)
+                if cleanup_start:
+                    text = self.cleanup_text(text)
+            self.output.append(text)
+            self.emit_start = None
+        self.character_data = False
+        self.raw_string = True
+        self.in_string = False
+
+    def StartElementHandler(self, _name, _attributes) -> None:
+        self.emit()
+        if self.depth >= self.EMIT_DEPTH:
+            self.emit_start = self.parser.CurrentByteIndex
+        self.depth += 1
+
+    def EndElementHandler(self, _name) -> None:
+        self.emit()
+        if self.depth >= self.EMIT_DEPTH:
+            self.emit_start = self.parser.CurrentByteIndex
+        self.depth -= 1
+
+    def CharacterDataHandler(self, _data) -> None:
+        if not self.character_data and not self.in_string:
+            self.emit()
+            self.emit_start = self.parser.CurrentByteIndex
+            self.raw_string = False
+            self.in_string = True
+
+    def StartCdataSectionHandler(self) -> None:
+        self.emit()
+        self.character_data = True
+        self.emit_start = self.parser.CurrentByteIndex
+
+    def EndCdataSectionHandler(self) -> None:
+        self.character_data = False
+
+    def DefaultHandler(self, _data) -> None:
+        if self.depth >= self.EMIT_DEPTH:
+            self.emit()
+            self.emit_start = self.parser.CurrentByteIndex
+
+    def parse(self) -> str:
+        """Parse and return the transformed XML text."""
+        self.parser.Parse(self.text, True)
+        if self.depth >= self.EMIT_DEPTH:
+            self.emit()
+        if self.do_cleanup and self.output:
+            self.output[-1] = self.output[-1].rstrip()
+        return "".join(self.output)
 
 
 def getText(node, xml_space="preserve"):

--- a/translate/storage/aresource.py
+++ b/translate/storage/aresource.py
@@ -26,13 +26,12 @@ import os
 import re
 import warnings
 from typing import ClassVar, cast, overload
-from xml.parsers.expat import XML_PARAM_ENTITY_PARSING_NEVER, ParserCreate
 
 from lxml import etree
 
 from translate.lang import data
 from translate.misc.multistring import multistring
-from translate.misc.xml_helpers import get_safe_xml_parser
+from translate.misc.xml_helpers import XMLTextParser, get_safe_xml_parser
 from translate.storage import base, lisa
 
 WHITESPACE = {" ", "\n", "\t"}  # Whitespace that we collapse.
@@ -53,7 +52,7 @@ ESCAPED_MARKUP_TAG = re.compile(rf"&lt;/?{XML_NAME}(?:{XML_ATTRIBUTE})*\s*/?&gt;
 CDATA_ONLY = re.compile(r"(?:<!\[CDATA\[.*?\]\]>)+", re.DOTALL)
 
 
-class DecodingXMLParser:
+class DecodingXMLParser(XMLTextParser):
     """
     XML parser that processes non CDATA strings.
 
@@ -62,30 +61,10 @@ class DecodingXMLParser:
     - process_string() is called on all other textual content
     """
 
-    EMIT_DEPTH = 1
-    FOREIGN_DTD = True
-
     def __init__(self, text: str, *, escape_all: bool = True) -> None:
-        self.text = text.encode("utf-8")
-        self.output: list[str] = []
-        self.emit_start: int | None = None
-        self.character_data = False
-        self.raw_string = True
-        self.in_string = False
         self.inside_quoted = False
-        self.do_cleanup = False
-        self.depth = 0
         self.escape_all = escape_all
-        self.parser = parser = ParserCreate()
-        if self.FOREIGN_DTD:
-            parser.UseForeignDTD(self.FOREIGN_DTD)
-        parser.SetParamEntityParsing(XML_PARAM_ENTITY_PARSING_NEVER)
-        parser.StartElementHandler = self.StartElementHandler
-        parser.EndElementHandler = self.EndElementHandler
-        parser.CharacterDataHandler = self.CharacterDataHandler
-        parser.StartCdataSectionHandler = self.StartCdataSectionHandler
-        parser.EndCdataSectionHandler = self.EndCdataSectionHandler
-        parser.DefaultHandler = self.DefaultHandler
+        super().__init__(text)
 
     @staticmethod
     def decode_unicode_escapes(match: re.Match) -> str:
@@ -167,69 +146,6 @@ class DecodingXMLParser:
             cleanup_end = False
 
         return unescaped_text, cleanup_start, cleanup_end
-
-    def cleanup_text(self, text: str) -> str:
-        """Remove leading whitespace from text."""
-        if not self.output:
-            return text.lstrip()
-        return text
-
-    def emit(self) -> None:
-        if self.emit_start is not None:
-            text = self.text[self.emit_start : self.parser.CurrentByteIndex].decode(
-                "utf-8"
-            )
-            self.do_cleanup = not self.raw_string
-            if not self.raw_string:
-                text, cleanup_start, self.do_cleanup = self.process_string(text)
-                if cleanup_start:
-                    text = self.cleanup_text(text)
-            self.output.append(text)
-            self.emit_start = None
-        self.character_data = False
-        self.raw_string = True
-        self.in_string = False
-
-    def StartElementHandler(self, _name, _attributes) -> None:
-        self.emit()
-        if self.depth >= self.EMIT_DEPTH:
-            self.emit_start = self.parser.CurrentByteIndex
-        self.depth += 1
-
-    def EndElementHandler(self, _name) -> None:
-        self.emit()
-        if self.depth >= self.EMIT_DEPTH:
-            self.emit_start = self.parser.CurrentByteIndex
-        self.depth -= 1
-
-    def CharacterDataHandler(self, _data) -> None:
-        if not self.character_data and not self.in_string:
-            self.emit()
-            self.emit_start = self.parser.CurrentByteIndex
-            self.raw_string = False
-            self.in_string = True
-
-    def StartCdataSectionHandler(self) -> None:
-        self.emit()
-        self.character_data = True
-        self.emit_start = self.parser.CurrentByteIndex
-
-    def EndCdataSectionHandler(self) -> None:
-        self.character_data = False
-
-    def DefaultHandler(self, _data) -> None:
-        if self.depth >= self.EMIT_DEPTH:
-            self.emit()
-            self.emit_start = self.parser.CurrentByteIndex
-
-    def parse(self) -> str:
-        self.parser.Parse(self.text, True)
-        if self.depth >= self.EMIT_DEPTH:
-            self.emit()
-        # Remove trailing whitespace from text
-        if self.do_cleanup and self.output:
-            self.output[-1] = self.output[-1].rstrip()
-        return "".join(self.output)
 
 
 class EncodingXMLParser(DecodingXMLParser):

--- a/translate/storage/dtd.py
+++ b/translate/storage/dtd.py
@@ -55,7 +55,7 @@ Escaping in regular DTD
 
     - The % character is escaped using &#037; or &#37; or &#x25;
     - The " character is escaped using &quot;
-    - The ' character is escaped using &apos; (partial roundtrip)
+    - The ' character is escaped using &apos;
     - The & character is escaped using &amp;
     - The < character is escaped using &lt; (not yet implemented)
     - The > character is escaped using &gt; (not yet implemented)
@@ -68,13 +68,10 @@ Escaping in regular DTD
     not yet implemented since they are not really necessary, or because its
     implementation is too hard.
 
-    A special case is the ' escaping using &apos; which doesn't provide a full
-    roundtrip conversion in order to support some special Mozilla DTD files.
-
-    Also the " character is never escaped in the case that the previous
-    character is = (the sequence =" is present on the string) in order to avoid
-    escaping the " character indicating an attribute assignment, for example in
-    a href attribute for an a tag in HTML (anchor tag).
+    Quote entities are decoded and encoded in XML character data. Attribute
+    values, CDATA, comments, and processing instructions are excluded from
+    that transformation. Numeric character references escape the selected DTD
+    declaration delimiter without changing the expanded XML content.
 
 Escaping in Android DTD
     It has the sames escapes as in regular DTD, plus this ones:
@@ -85,10 +82,12 @@ Escaping in Android DTD
 
 import re
 import warnings
+from xml.parsers.expat import ExpatError
 
 from lxml import etree
 
 from translate.misc import quote
+from translate.misc.xml_helpers import XMLTextParser
 from translate.storage import base
 
 labelsuffixes = (".label", ".title")
@@ -101,6 +100,7 @@ ending in :attr:`.labelsuffixes` into accelerator notation"""
 
 end_entity_re = re.compile(rb"[\"']\s*>")
 DTD_VALIDATION_SYSTEM_ID = "translate-toolkit.dtd"
+_DTD_XML_WRAPPER = "translate-toolkit-root"
 
 
 def quoteforandroid(source):
@@ -128,12 +128,62 @@ _DTD_CODEPOINT2NAME: dict[int, str] = {
     # ord(">"): "gt",  # Not really so useful.
 }
 
+_DTD_TEXT_CODEPOINT2NAME = {
+    ord('"'): "quot",
+    ord("'"): "apos",
+}
+
+_DTD_TEXT_NAME2CODEPOINT = {
+    "quot": ord('"'),
+    "apos": ord("'"),
+    "#x0022": ord('"'),
+}
+
+# Double quotes delimit the value only when the value contains no literal
+# double quote, so only an apostrophe can require a numeric delimiter escape.
+_DTD_DELIMITER_CODEPOINT2NAME = {
+    ord("'"): "#39",
+}
+
+_DTD_DELIMITER_NAME2CODEPOINT = {
+    "#39": ord("'"),
+}
+
+
+class _DTDEncodeParser(XMLTextParser):
+    def process_string(self, content: str) -> tuple[str, bool, bool]:
+        return quote.entityencode(content, _DTD_TEXT_CODEPOINT2NAME), False, False
+
+
+class _DTDDecodeParser(XMLTextParser):
+    def process_string(self, content: str) -> tuple[str, bool, bool]:
+        return quote.entitydecode(content, _DTD_TEXT_NAME2CODEPOINT), False, False
+
+
+def _transform_dtd_xml_text(
+    source: str, parser_class: type[XMLTextParser]
+) -> str | None:
+    """Transform XML character data while preserving raw markup."""
+    wrapped = f"<{_DTD_XML_WRAPPER}>{source}</{_DTD_XML_WRAPPER}>"
+    try:
+        return parser_class(wrapped).parse()
+    except ExpatError:
+        return None
+
 
 def quotefordtd(source):
     """Quotes and escapes a line for regular DTD files."""
     source = quote.entityencode(source, _DTD_CODEPOINT2NAME)
+    transformed = _transform_dtd_xml_text(source, _DTDEncodeParser)
+    if transformed is not None:
+        delimiter = "'" if '"' in transformed else '"'
+        if delimiter == "'":
+            transformed = quote.entityencode(transformed, _DTD_DELIMITER_CODEPOINT2NAME)
+        return f"{delimiter}{transformed}{delimiter}"
+
+    # Preserve the legacy behavior for malformed or partial XML fragments.
     if '"' in source:
-        source = source.replace("'", "&apos;")  # This seems not to run.
+        source = source.replace("'", "&apos;")
         if '="' not in source:  # Avoid escaping " chars in href attributes.
             source = source.replace('"', "&quot;")
             value = f'"{source}"'  # Quote using double quotes.
@@ -145,12 +195,10 @@ def quotefordtd(source):
 
 
 _DTD_NAME2CODEPOINT = {
-    "quot": ord('"'),
     "amp": ord("&"),
     # "lt": ord("<"),  # Not really so useful.
     # "gt": ord(">"),  # Not really so useful.
     # FIXME these should probably be handled in a more general way
-    "#x0022": ord('"'),
     "#187": ord("»"),
     "#037": ord("%"),
     "#37": ord("%"),
@@ -169,8 +217,14 @@ def unquotefromdtd(source):
     extracted, _quotefinished = quote.extractwithoutquotes(
         source, quotechar, quotechar, allowreentry=False
     )
+    transformed = _transform_dtd_xml_text(extracted, _DTDDecodeParser)
+    if transformed is not None:
+        extracted = transformed
+    else:
+        extracted = quote.entitydecode(extracted, _DTD_TEXT_NAME2CODEPOINT)
+    # quotefordtd only introduces numeric apostrophes for single-quoted values.
     if quotechar == "'":
-        extracted = extracted.replace("&apos;", "'")
+        extracted = quote.entitydecode(extracted, _DTD_DELIMITER_NAME2CODEPOINT)
     return quote.entitydecode(extracted, _DTD_NAME2CODEPOINT)
 
 


### PR DESCRIPTION
Treat &apos; like other predefined DTD entities regardless of the outer delimiter. This keeps translator-facing text literal while safely restoring entity escapes on serialization.

Closes #2740