### PR TITLE
fix(markdown): avoid stale folded scalar offsets

### DIFF
--- a/tests/translate/storage/test_markdown.py
+++ b/tests/translate/storage/test_markdown.py
@@ -1292,6 +1292,30 @@ class TestMarkdownFrontmatterTranslateValues(TestCase):
         assert "  (one\n  two)\n" in out
         assert "strip: |-\n  (trimmed)\n" in out
 
+    def test_short_folded_scalar_translation_drops_fold_positions(self) -> None:
+        """Source fold offsets do not break serialization of shorter text."""
+        front_matter = (
+            "---\n"
+            "summary: >\n"
+            "  A long source sentence with enough words to establish a fold.\n"
+            "  Another source line makes the recorded offset even larger.\n"
+            "---\n"
+        )
+        translation = "进行 SAFETAG 评估可以评估工具。"
+        store = self.parse(front_matter, callback=lambda text: translation)
+        assert self.front_matter_of(store.filesrc) == (
+            f"---\nsummary: >\n  {translation}\n---\n"
+        )
+
+    def test_changed_folded_scalar_ignores_in_range_fold_positions(self) -> None:
+        """Changed text is not folded at an applicable source offset."""
+        front_matter = "---\nsummary: >\n  0123456789\n  source text\n---\n"
+        translation = "abcdefghij translated text"
+        store = self.parse(front_matter, callback=lambda text: translation)
+        assert self.front_matter_of(store.filesrc) == (
+            f"---\nsummary: >\n  {translation}\n---\n"
+        )
+
     def test_kept_block_scalar_trailing_blank_lines_preserved(self) -> None:
         """A trailing ``|+`` keep block scalar round-trips its blank lines."""
         front_matter = (

--- a/translate/storage/markdown.py
+++ b/translate/storage/markdown.py
@@ -235,9 +235,9 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
             flattened to ``- item``).
           * Block scalars (``|`` / ``>``) keep their style, chomping indicator
             and first-line comment: the trailing-newline pattern that drives
-            chomping is split off before translation and re-appended afterwards,
-            and the comment / fold positions are carried over to the re-wrapped
-            node. See ``_translate_frontmatter_child``.
+            chomping is split off before translation and re-appended afterwards.
+            Fold positions are retained only when the content is unchanged. See
+            ``_translate_frontmatter_child``.
           * Only scalar *string* values are translated. Numbers, booleans, dates
             and ``null`` are left untouched on purpose.
           * Nested maps and lists are walked recursively; list items use a
@@ -365,13 +365,17 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
 
             if is_block:
                 # Re-wrap in the same block subtype, restore the chomping via the
-                # trailing newlines, and carry over the first-line comment and
-                # (for folded scalars) the fold positions so an identity
-                # translation re-emits byte-for-byte.
+                # trailing newlines, and carry over the first-line comment.
+                # Fold positions are offsets into the scalar content, so they
+                # are safe to retain only for an identity translation.
                 new_value = type(value)(translated + trailing_newlines)
                 if hasattr(value, "comment"):
                     new_value.comment = value.comment
-                if isinstance(value, FoldedScalarString) and hasattr(value, "fold_pos"):
+                if (
+                    translated == content
+                    and isinstance(value, FoldedScalarString)
+                    and hasattr(value, "fold_pos")
+                ):
                     new_value.fold_pos = value.fold_pos
                 container[key] = new_value
             elif isinstance(value, ScalarString):


### PR DESCRIPTION
YAML fold positions refer to the source scalar and can be invalid for translated content. Retain them only for identity translations.