### PR TITLE
fix(json): validate i18next plural values

### DIFF
--- a/tests/translate/storage/test_jsonl10n.py
+++ b/tests/translate/storage/test_jsonl10n.py
@@ -1267,6 +1267,48 @@ class TestI18NextV4Store(test_monolingual.TestMonolingualStore):
 
         assert len(store.units) == 1
 
+    def test_nested_object_with_plural_suffix(self) -> None:
+        """Do not treat a nested object as a plural form."""
+        data = """{
+    "section_other": {
+        "related_space_usage": "Analyze the space usage within the database",
+        "related_space_usage_description": "See which items take up space."
+    }
+}
+"""
+        store = self.StoreClass()
+        store.targetlanguage = "en"
+
+        store.parse(data)
+
+        assert [unit.getid() for unit in store.units] == [
+            ".section_other.related_space_usage",
+            ".section_other.related_space_usage_description",
+        ]
+        assert bytes(store).decode() == data
+
+    def test_mixed_plural_values_are_regular_entries(self) -> None:
+        """Do not partially group plural-like entries containing an object."""
+        data = """{
+    "message_one": "one",
+    "message_other": "other",
+    "message_few": {
+        "nested": "value"
+    }
+}
+"""
+        store = self.StoreClass()
+        store.targetlanguage = "en"
+
+        store.parse(data)
+
+        assert [unit.getid() for unit in store.units] == [
+            ".message_one",
+            ".message_other",
+            ".message_few.nested",
+        ]
+        assert bytes(store).decode() == data
+
     def test_plurals(self) -> None:
         store = self.StoreClass()
         store.targetlanguage = "ar"

--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -539,6 +539,20 @@ class I18NextV4File(JsonNestedFile):
         if plural_tags is None:
             plural_tags = self.get_plural_tags()
         if isinstance(data, dict):
+            valid_plural_bases = set()
+            invalid_plural_bases = set()
+            for key, value in data.items():
+                if "_" not in key:
+                    continue
+                plural_base, suffix = key.rsplit("_", 1)
+                if suffix not in cldr_plural_categories:
+                    continue
+                if isinstance(value, str):
+                    valid_plural_bases.add(plural_base)
+                else:
+                    invalid_plural_bases.add(plural_base)
+            valid_plural_bases.difference_update(invalid_plural_bases)
+
             processed_plural_bases = set()
 
             for k, v in data.items():
@@ -548,7 +562,10 @@ class I18NextV4File(JsonNestedFile):
                 if "_" in k:
                     plural_base, suffix = k.rsplit("_", 1)
 
-                if suffix in cldr_plural_categories:
+                if (
+                    suffix in cldr_plural_categories
+                    and plural_base in valid_plural_bases
+                ):
                     if plural_base in processed_plural_bases:
                         continue
                     processed_plural_bases.add(plural_base)


### PR DESCRIPTION
Nested objects can have keys ending in CLDR plural suffixes. Avoid passing those objects to multistring so valid catalogs parse without losing nested entries.