### PR TITLE
fix(wordfast): restore Unicode output and language metadata

### DIFF
--- a/tests/translate/convert/test_po2wordfast.py
+++ b/tests/translate/convert/test_po2wordfast.py
@@ -1,0 +1,90 @@
+from codecs import BOM_UTF16_LE
+from io import BytesIO
+
+from translate.convert import po2wordfast
+from translate.storage import wordfast
+
+from . import test_convert
+
+MINIPO = """msgid "Curve"
+msgstr "Kurwe"
+"""
+
+NON_LATIN1_PO = """msgid "Cross"
+msgstr "Крест"
+"""
+
+
+class TestPO2Wordfast:
+    @staticmethod
+    def po2wordfast(
+        posource: str, sourcelanguage="en", targetlanguage="af"
+    ) -> wordfast.WordfastTMFile:
+        inputfile = BytesIO(posource.encode())
+        outputfile = BytesIO()
+        outputfile.wffile = wordfast.WordfastTMFile()  # ty:ignore[unresolved-attribute]
+        po2wordfast.convertpo(
+            inputfile,
+            outputfile,
+            templatefile=None,
+            sourcelanguage=sourcelanguage,
+            targetlanguage=targetlanguage,
+        )
+        return outputfile.wffile  # ty:ignore[unresolved-attribute]
+
+    def test_languages(self) -> None:
+        store = self.po2wordfast(MINIPO, sourcelanguage="en", targetlanguage="af_ZA")
+        assert store.sourcelanguage == "en"
+        assert store.targetlanguage == "af-za"
+        assert store.header.header["src-lang"] == "%EN-01"
+        assert store.header.header["target-lang"] == "%AF-ZA"
+        assert store.units[0].metadata["src-lang"] == "EN-01"
+        assert store.units[0].metadata["target-lang"] == "AF-ZA"
+
+    def test_non_latin1_output(self) -> None:
+        store = self.po2wordfast(NON_LATIN1_PO)
+        output = BytesIO()
+        store.serialize(output)
+        assert output.getvalue().startswith(BOM_UTF16_LE)
+
+
+class TestPO2WordfastCommand(test_convert.TestConvertCommand, TestPO2Wordfast):
+    """Tests running actual po2wordfast commands on files."""
+
+    convertmodule = po2wordfast
+    expected_options = [
+        "-l LANG, --language=LANG",
+        "--source-language=LANG",
+    ]
+
+    def test_command_languages(self) -> None:
+        self.create_testfile("test.po", MINIPO)
+        self.run_command(
+            "test.po",
+            "test.txt",
+            language="af_ZA",
+            source_language="xh",
+        )
+        content = self.read_testfile("test.txt")
+        store = wordfast.WordfastTMFile(BytesIO(content))
+        assert store.sourcelanguage == "xh"
+        assert store.targetlanguage == "af-za"
+        assert store.header.header["src-lang"] == "%XH-01"
+        assert store.header.header["target-lang"] == "%AF-ZA"
+        assert store.units[0].metadata["src-lang"] == "XH-01"
+        assert store.units[0].metadata["target-lang"] == "AF-ZA"
+
+    def test_command_default_source_language(self) -> None:
+        self.create_testfile("test.po", MINIPO)
+        self.run_command("test.po", "test.txt", language="af")
+        store = wordfast.WordfastTMFile(BytesIO(self.read_testfile("test.txt")))
+        assert store.header.header["src-lang"] == "%EN-01"
+        assert store.header.header["target-lang"] == "%AF-01"
+
+    def test_command_utf16_fallback(self) -> None:
+        self.create_testfile("test.po", NON_LATIN1_PO)
+        self.run_command("test.po", "test.txt", language="ru")
+        content = self.read_testfile("test.txt")
+        assert content.startswith(BOM_UTF16_LE)
+        store = wordfast.WordfastTMFile(BytesIO(content))
+        assert store.units[0].target == "Крест"

--- a/tests/translate/storage/test_factory.py
+++ b/tests/translate/storage/test_factory.py
@@ -1,5 +1,6 @@
 import os
 from bz2 import BZ2File
+from codecs import BOM_UTF16_BE, BOM_UTF16_LE
 from gzip import GzipFile
 from io import BytesIO
 
@@ -171,3 +172,23 @@ class TestWordfastFactory(BaseTestFactory):
         b"""%20070801~103212	%User ID,S,S SMURRAY,SMS Samuel Murray-Smit,SM Samuel Murray-Smit,MW Mary White,DS Deepak Shota,MT! Machine translation (15),AL! Alignment (10),SM Samuel Murray,	%TU=00000075	%AF-ZA	%Wordfast TM v.5.51r/00	%EN-ZA	%---80597535	Subject (5),EL,EL Electronics,AC Accounting,LE Legal,ME Mechanics,MD Medical,LT Literary,AG Agriculture,CO Commercial	Client (5),LS,LS LionSoft Corp,ST SuperTron Inc,CA CompArt Ltd			"""
         b"""20070801~103248	SM	0	AF-ZA	Langeraad en duimpie	EN-ZA	Big Ben and Little John	EL	LS"""
     )
+
+    @pytest.mark.parametrize(
+        ("encoding", "bom"),
+        [("utf-16-le", BOM_UTF16_LE), ("utf-16-be", BOM_UTF16_BE)],
+    )
+    def test_utf16_getobject(self, encoding: str, bom: bytes) -> None:
+        content = bom + self.file_content.decode("iso-8859-1").encode(encoding)
+        store = factory.getobject(givefile(self.filename, content))
+        assert isinstance(store, self.expected_instance)
+        assert store.encoding == "utf-16"
+
+    @pytest.mark.parametrize(
+        ("encoding", "bom"),
+        [("utf-16-le", BOM_UTF16_LE), ("utf-16-be", BOM_UTF16_BE)],
+    )
+    def test_utf16_getobject_without_name(self, encoding: str, bom: bytes) -> None:
+        content = bom + self.file_content.decode("iso-8859-1").encode(encoding)
+        store = factory.getobject(BytesIO(content))
+        assert isinstance(store, self.expected_instance)
+        assert store.encoding == "utf-16"

--- a/tests/translate/storage/test_wordfast.py
+++ b/tests/translate/storage/test_wordfast.py
@@ -1,4 +1,6 @@
 import time
+from codecs import BOM_UTF16_LE
+from io import BytesIO
 
 from translate.storage import wordfast as wf
 
@@ -19,6 +21,26 @@ class TestWFTime:
         assert wftime.time is None
         wftime.time = time.strptime("19990327~000000", wf.WF_TIMEFORMAT)
         wftime.timestring = "19990327~000000"
+
+
+class TestWFHeader:
+    def test_language_setting(self) -> None:
+        """Wordfast language codes use uppercase and -01 for no variant."""
+        header = wf.WordfastHeader()
+        header.sourcelang = "en"
+        header.targetlang = "af_ZA"
+        assert header.header["src-lang"] == "%EN-01"
+        assert header.header["target-lang"] == "%AF-ZA"
+        assert header.sourcelang == "en"
+        assert header.targetlang == "af-za"
+
+    def test_unknown_language_setting(self) -> None:
+        """Do not truncate language codes outside the legacy five-character form."""
+        header = wf.WordfastHeader()
+        header.sourcelang = "sr_Latn"
+        header.targetlang = "ast"
+        assert header.header["src-lang"] == "%SR-LATN"
+        assert header.header["target-lang"] == "%AST"
 
 
 class TestWFUnit(test_base.TestTranslationUnit):
@@ -78,10 +100,14 @@ class TestWFUnit(test_base.TestTranslationUnit):
         assert unit.metadata["source"] == "One\\nTwo"
 
     def test_language_setting(self) -> None:
-        """Check that we can set the target language."""
+        """Check that we can set source and target languages."""
         unit = self.UnitClass("Test")
-        unit.targetlang = "AF"
-        assert unit.metadata["target-lang"] == "AF"
+        unit.sourcelang = "en"
+        unit.targetlang = "af_ZA"
+        assert unit.metadata["src-lang"] == "EN-01"
+        assert unit.metadata["target-lang"] == "AF-ZA"
+        assert unit.sourcelang == "en"
+        assert unit.targetlang == "af-za"
 
     def test_istranslated(self) -> None:
         unit = self.UnitClass()
@@ -94,3 +120,77 @@ class TestWFUnit(test_base.TestTranslationUnit):
 
 class TestWFFile(test_base.TestTranslationStore):
     StoreClass = wf.WordfastTMFile
+
+    @staticmethod
+    def serialize(source="Bézier curve", target="Bézier-kurwe") -> bytes:
+        store = wf.WordfastTMFile()
+        unit = store.addsourceunit(source)
+        unit.target = target
+        output = BytesIO()
+        store.serialize(output)
+        return output.getvalue()
+
+    def test_language_detection(self) -> None:
+        store = wf.WordfastTMFile()
+        store.header.header["src-lang"] = "%EN-01"
+        store.header.header["target-lang"] = "%AF-ZA"
+        unit = store.addsourceunit("Test")
+        unit.sourcelang = "de"
+        unit.targetlang = "fr"
+        assert store.getsourcelanguage() == "en"
+        assert store.gettargetlanguage() == "af-za"
+        assert store.sourcelanguage == "en"
+        assert store.targetlanguage == "af-za"
+
+        store.sourcelanguage = "de"
+        store.targetlanguage = "fr_CA"
+        assert store.getsourcelanguage() == "de"
+        assert store.gettargetlanguage() == "fr-ca"
+        assert store.header.header["src-lang"] == "%DE-01"
+        assert store.header.header["target-lang"] == "%FR-CA"
+
+        store.header.header["src-lang"] = ""
+        store.header.header["target-lang"] = ""
+        assert store.getsourcelanguage() is None
+        assert store.gettargetlanguage() is None
+
+    def test_latin1_serialization(self) -> None:
+        content = self.serialize()
+        assert not content.startswith(BOM_UTF16_LE)
+        assert content.count(b"\r\n") == 2
+        assert b"\r\r\n" not in content
+
+        reparsed = wf.WordfastTMFile(BytesIO(content))
+        assert reparsed.encoding == "iso-8859-1"
+        assert reparsed.units[0].source == "Bézier curve"
+        assert reparsed.units[0].target == "Bézier-kurwe"
+
+    def test_utf16_fallback(self) -> None:
+        store = wf.WordfastTMFile()
+        unit = store.addsourceunit("Bézier †")
+        unit.target = "Kromme †"
+        output = BytesIO()
+        store.serialize(output)
+        content = output.getvalue()
+        assert content.startswith(BOM_UTF16_LE)
+        assert store.encoding == "utf-16"
+        assert "Bézier †" in content.decode(store.encoding)
+        assert content.count("\r\n".encode("utf-16-le")) == 2
+        assert b"\r\x00\r\n\x00" not in content
+
+        reparsed = wf.WordfastTMFile(BytesIO(content))
+        assert reparsed.encoding == "utf-16"
+        assert reparsed.units[0].source == "Bézier †"
+        assert reparsed.units[0].target == "Kromme †"
+
+    def test_bomless_utf16le_detection(self) -> None:
+        content = self.serialize("Bézier †", "Kromme †").removeprefix(BOM_UTF16_LE)
+        reparsed = wf.WordfastTMFile(BytesIO(content))
+        assert reparsed.encoding == "utf-16-le"
+        assert reparsed.units[0].source == "Bézier †"
+
+    def test_bomless_utf16be_detection(self) -> None:
+        content = self.serialize().decode("iso-8859-1").encode("utf-16-be")
+        reparsed = wf.WordfastTMFile(BytesIO(content))
+        assert reparsed.encoding == "utf-16-be"
+        assert reparsed.units[0].source == "Bézier curve"

--- a/translate/convert/po2wordfast.py
+++ b/translate/convert/po2wordfast.py
@@ -44,6 +44,7 @@ class po2wordfast:
             target = inunit.target
             newunit = wffile.addsourceunit(source)
             newunit.target = target
+            newunit.sourcelang = sourcelanguage
             newunit.targetlang = targetlanguage
 
 
@@ -52,7 +53,8 @@ def convertpo(
 ) -> int:
     """Reads in stdin using fromfileclass, converts using convertorclass, writes to stdout."""
     convertor = po2wordfast()
-    outputfile.wffile.header.targetlang = targetlanguage
+    outputfile.wffile.setsourcelanguage(sourcelanguage)
+    outputfile.wffile.settargetlanguage(targetlanguage)
     convertor.convertfiles(inputfile, outputfile.wffile, sourcelanguage, targetlanguage)
     return 1
 
@@ -85,7 +87,6 @@ class WfOptionParser(convert.ArchiveConvertOptionParser):
             raise ValueError("You must specify the target language")
         super().recursiveprocess(options)
         with open(options.output, "wb") as self.output:
-            # self.outputarchive.wffile.setsourcelanguage(options.sourcelanguage)
             self.outputarchive.wffile.serialize(self.output)
 
 

--- a/translate/storage/factory.py
+++ b/translate/storage/factory.py
@@ -74,14 +74,14 @@ def _examine_txt(storefile):
     if isinstance(storefile, str) and os.path.exists(storefile):
         storefile = open(storefile, "rb")
     try:
-        start = storefile.read(600).strip()
+        start = storefile.read(600)
     except AttributeError:
         raise ValueError("Need to read object to determine type") from None
     # Some encoding magic for Wordfast
     # pylint: disable-next=import-outside-toplevel
     from translate.storage import wordfast  # ruff:ignore[import-outside-top-level]
 
-    encoding = "utf-16" if wordfast.TAB_UTF16 in start.split(b"\n")[0] else "iso-8859-1"
+    encoding = wordfast.detect_encoding(start)
     start = start.decode(encoding)
     if "%Wordfast TM" in start:
         pseudo_extension = "_wftm"
@@ -96,17 +96,28 @@ def _examine_txt(storefile):
 _hiddenclasses = {"txt": _examine_txt}
 
 
+def _is_wordfast(content: bytes) -> bool:
+    """Detect Wordfast content using its supported encodings."""
+    # pylint: disable-next=import-outside-toplevel
+    from translate.storage import wordfast  # ruff:ignore[import-outside-top-level]
+
+    try:
+        return "%Wordfast TM" in content.decode(wordfast.detect_encoding(content))
+    except UnicodeDecodeError:
+        return False
+
+
 def _guess_extension(storefile):
     """
     Guesses the type of a file object by looking at the first few
     characters.  The return value is a file extension.
     """
-    start = storefile.read(300).strip()
+    start = storefile.read(600)
     if b"<xliff " in start:
         extension = "xlf"
     elif b'msgid "' in start:
         extension = "po"
-    elif b"%Wordfast TM" in start:
+    elif _is_wordfast(start):
         extension = "txt"
     elif b"<!DOCTYPE TS>" in start:
         extension = "ts"

--- a/translate/storage/wordfast.py
+++ b/translate/storage/wordfast.py
@@ -81,8 +81,10 @@ Extended Attributes
 
 import csv
 import time
+from codecs import BOM_UTF16_BE, BOM_UTF16_LE
 from io import StringIO
 
+from translate.lang import data
 from translate.storage import base
 
 WF_TIMEFORMAT = "%Y%m%d~%H%M%S"
@@ -182,7 +184,52 @@ WF_ESCAPE_MAP = (
 """Mapping of Wordfast &'XX; escapes to correct Unicode characters"""
 
 TAB_UTF16 = b"\x00\x09"
-"""The tab \\t character as it would appear in UTF-16 encoding"""
+"""The tab \\t character as it would appear in UTF-16BE encoding."""
+
+TAB_UTF16_LE = b"\x09\x00"
+"""The tab \\t character as it would appear in UTF-16LE encoding."""
+
+
+def detect_encoding(content: bytes) -> str:
+    """Detect the encodings supported by Wordfast files."""
+    if content.startswith((BOM_UTF16_LE, BOM_UTF16_BE)):
+        return "utf-16"
+    if content.startswith(b"%\x00"):
+        return "utf-16-le"
+    if content.startswith(b"\x00%"):
+        return "utf-16-be"
+
+    first_line = content.split(b"\n", maxsplit=1)[0]
+    positions = range(0, len(first_line) - 1, 2)
+    if any(
+        first_line[position : position + 2] == TAB_UTF16_LE for position in positions
+    ):
+        return "utf-16-le"
+    if any(first_line[position : position + 2] == TAB_UTF16 for position in positions):
+        return "utf-16-be"
+    if TAB_UTF16 in first_line:
+        return "utf-16"
+    return "iso-8859-1"
+
+
+def _from_wordfast_language(language: str | None) -> str | None:
+    """Convert a Wordfast language code to the toolkit representation."""
+    if not language:
+        return None
+    normalized = data.normalize_code(language.removeprefix("%"))
+    if normalized.endswith("-01"):
+        return normalized[:-3]
+    return normalized
+
+
+def _to_wordfast_language(language: str | None) -> str:
+    """Convert a toolkit language code to the Wordfast representation."""
+    if not language:
+        return ""
+    normalized = data.normalize_code(language.removeprefix("%"))
+    if len(normalized) == 2:
+        normalized = f"{normalized}-01"
+    return normalized.upper()
 
 
 def _char_to_wf(string):
@@ -276,7 +323,7 @@ class WordfastHeader:
     """A wordfast translation memory header."""
 
     def __init__(self, header=None) -> None:
-        self._header_dict = []
+        self._header_dict: dict[str, str | None] = {}
         if not header:
             self.header = self._create_default_header()
         elif isinstance(header, dict):
@@ -302,13 +349,29 @@ class WordfastHeader:
 
     header = property(getheader, setheader)
 
-    def settargetlang(self, newlang) -> None:
-        self._header_dict["target-lang"] = f"%{newlang}"  # ty:ignore[invalid-assignment]
+    def getsourcelang(self) -> str | None:
+        """Get the source language without Wordfast-specific syntax."""
+        return _from_wordfast_language(self._header_dict.get("src-lang"))
 
-    targetlang = property(None, settargetlang)
+    def setsourcelang(self, newlang: str | None) -> None:
+        """Set the source language using Wordfast-specific syntax."""
+        language = _to_wordfast_language(newlang)
+        self._header_dict["src-lang"] = f"%{language}" if language else ""
+
+    sourcelang = property(getsourcelang, setsourcelang)
+
+    def gettargetlang(self) -> str | None:
+        """Get the target language without Wordfast-specific syntax."""
+        return _from_wordfast_language(self._header_dict.get("target-lang"))
+
+    def settargetlang(self, newlang) -> None:
+        language = _to_wordfast_language(newlang)
+        self._header_dict["target-lang"] = f"%{language}" if language else ""
+
+    targetlang = property(gettargetlang, settargetlang)
 
     def settucount(self, count) -> None:
-        self._header_dict["tucount"] = f"%TU={count:08d}"  # ty:ignore[invalid-assignment]
+        self._header_dict["tucount"] = f"%TU={count:08d}"
 
     tucount = property(None, settucount)
 
@@ -353,10 +416,25 @@ class WordfastUnit(base.MetadataTranslationUnit):
         self._rich_target = None
         self._set_source_or_target("target", target)
 
-    def settargetlang(self, newlang: str) -> None:
-        self._metadata_dict["target-lang"] = newlang
+    def getsourcelang(self) -> str | None:
+        """Get the unit source language."""
+        return _from_wordfast_language(self._metadata_dict.get("src-lang"))
 
-    targetlang = property(None, settargetlang)
+    def setsourcelang(self, newlang: str | None) -> None:
+        """Set the unit source language."""
+        self._metadata_dict["src-lang"] = _to_wordfast_language(newlang)
+
+    sourcelang = property(getsourcelang, setsourcelang)
+
+    def gettargetlang(self) -> str | None:
+        """Get the unit target language."""
+        return _from_wordfast_language(self._metadata_dict.get("target-lang"))
+
+    def settargetlang(self, newlang: str | None) -> None:
+        """Set the unit target language."""
+        self._metadata_dict["target-lang"] = _to_wordfast_language(newlang)
+
+    targetlang = property(gettargetlang, settargetlang)
 
     def __str__(self) -> str:
         return str(self._metadata_dict)
@@ -384,6 +462,26 @@ class WordfastTMFile(base.TranslationStore):
         if inputfile is not None:
             self.parse(inputfile)
 
+    def getsourcelanguage(self) -> str | None:
+        """Get the file-level source language from the Wordfast header."""
+        return self.header.sourcelang
+
+    def setsourcelanguage(self, sourcelanguage: str) -> None:
+        """Set the file-level source language in the Wordfast header."""
+        self.header.sourcelang = sourcelanguage
+
+    sourcelanguage = property(getsourcelanguage, setsourcelanguage)
+
+    def gettargetlanguage(self) -> str | None:
+        """Get the file-level target language from the Wordfast header."""
+        return self.header.targetlang
+
+    def settargetlanguage(self, targetlanguage: str | None) -> None:
+        """Set the file-level target language in the Wordfast header."""
+        self.header.targetlang = targetlanguage
+
+    targetlanguage = property(gettargetlanguage, settargetlanguage)
+
     def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """Parsese the given file or file source string."""
         if hasattr(input, "name"):
@@ -394,10 +492,7 @@ class WordfastTMFile(base.TranslationStore):
             tmsrc = input.read()
             input.close()
             input = tmsrc
-        if TAB_UTF16 in input.split(b"\n")[0]:
-            self.encoding = "utf-16"
-        else:
-            self.encoding = "iso-8859-1"
+        self.encoding = detect_encoding(input)
         try:
             input = input.decode(self.encoding)
         except UnicodeDecodeError as error:
@@ -444,4 +539,15 @@ class WordfastTMFile(base.TranslationStore):
 
         for unit in translated_units:
             writer.writerow(unit.metadata)
-        out.write(output.getvalue().encode(self.encoding))
+        content = output.getvalue()
+        try:
+            if self.encoding == "utf-16":
+                serialized = BOM_UTF16_LE + content.encode("utf-16-le")
+            else:
+                serialized = content.encode(self.encoding)
+        except UnicodeEncodeError:
+            if self.encoding != self.default_encoding:
+                raise
+            self.encoding = "utf-16"
+            serialized = BOM_UTF16_LE + content.encode("utf-16-le")
+        out.write(serialized)


### PR DESCRIPTION
Prefer Latin-1 where possible but fall back to BOM-marked UTF-16LE so non-Latin translations remain valid on Windows. Populate and normalize source and target language codes in headers and units, and detect them when reading.

Closes #584

Closes #835

Closes #806