### PR TITLE
fix(converters): support explicit file encodings

### DIFF
--- a/docs/commands/csv2po.rst
+++ b/docs/commands/csv2po.rst
@@ -47,7 +47,8 @@ Options (csv2po):
 -t TEMPLATE, --template=TEMPLATE   read from TEMPLATE in po, pot, pot formats
 -S, --timestamp       skip conversion if the output file has newer timestamp
 -P, --pot             output PO Templates (.pot) rather than PO files (.po)
---charset=CHARSET     set charset to decode from csv files
+--encoding=ENCODING, --charset=ENCODING
+                      override the encoding of the input file
 --columnorder=COLUMNORDER   specify the order and position of columns (location,source,target,context)
 --duplicates=DUPLICATESTYLE
                       what to do with duplicate strings (identical source

--- a/docs/commands/csv2tbx.rst
+++ b/docs/commands/csv2tbx.rst
@@ -14,7 +14,7 @@ Usage
 
 ::
 
-  csv2tbx [--charset=CHARSET] [--columnorder=COLUMNORDER] <csv> <tbx>
+  csv2tbx [--encoding=ENCODING] [--columnorder=COLUMNORDER] <csv> <tbx>
 
 Where:
 
@@ -37,7 +37,8 @@ Options (csv2tbx):
 -x EXCLUDE, --exclude=EXCLUDE    exclude names matching EXCLUDE from input paths
 -o OUTPUT, --output=OUTPUT   write to OUTPUT in tbx format
 -S, --timestamp      skip conversion if the output file has newer timestamp
---charset=CHARSET    set charset to decode from csv files
+--encoding=ENCODING, --charset=ENCODING
+                      override the encoding of the input file
 --columnorder=COLUMNORDER   specify the order and position of columns (comment,source,target)
 
 

--- a/docs/commands/ini2po.rst
+++ b/docs/commands/ini2po.rst
@@ -40,6 +40,9 @@ Options (ini2po):
 -t TEMPLATE, --template=TEMPLATE  read from TEMPLATE in ini, isl, iss formats
 -S, --timestamp       skip conversion if the output file has newer timestamp
 -P, --pot    output PO Templates (.pot) rather than PO files (.po)
+--encoding=ENCODING   override the encoding of the input file
+--encoding-template=ENCODING
+                      override the encoding of the template file
 --duplicates=DUPLICATESTYLE
                       what to do with duplicate strings (identical source
                       text): :doc:`merge, msgctxt <option_duplicates>`

--- a/docs/commands/php2po.rst
+++ b/docs/commands/php2po.rst
@@ -41,6 +41,9 @@ Options (php2po):
 -t TEMPLATE, --template=TEMPLATE  read from TEMPLATE in php format
 -S, --timestamp       skip conversion if the output file has newer timestamp
 -P, --pot    output PO Templates (.pot) rather than PO files (.po)
+--encoding=ENCODING   override the encoding of the input file
+--encoding-template=ENCODING
+                      override the encoding of the template file
 --duplicates=DUPLICATESTYLE
                       what to do with duplicate strings (identical source
                       text): :doc:`merge, msgctxt <option_duplicates>`

--- a/docs/commands/prop2po.rst
+++ b/docs/commands/prop2po.rst
@@ -61,6 +61,8 @@ Options (prop2po):
                       java-utf8, skype, gaia, strings <option_personality>`
                       (for .properties files, default: java)
 --encoding=ENCODING  override the encoding set by the personality
+--encoding-template=ENCODING
+                     override the encoding of the template file
 --duplicates=DUPLICATESTYLE
                       what to do with duplicate strings (identical source
                       text): :doc:`merge, msgctxt <option_duplicates>`

--- a/docs/commands/sub2po.rst
+++ b/docs/commands/sub2po.rst
@@ -48,6 +48,9 @@ Options (sub2po):
                         read from TEMPLATE in ass, srt, ssa, sub formats
 -S, --timestamp       skip conversion if the output file has newer timestamp
 -P, --pot            output PO Templates (.pot) rather than PO files (.po)
+--encoding=ENCODING  override the encoding of the input file
+--encoding-template=ENCODING
+                     override the encoding of the template file
 --duplicates=DUPLICATESTYLE
                       what to do with duplicate strings (identical source
                       text): :doc:`merge, msgctxt <option_duplicates>`
@@ -67,6 +70,7 @@ Options (po2sub):
 -o OUTPUT, --output=OUTPUT   write to OUTPUT in srt format
 -t TEMPLATE, --template=TEMPLATE   read from TEMPLATE in txt format
 -S, --timestamp      skip conversion if the output file has newer timestamp
+--encoding=ENCODING  override the encoding of the subtitle template and output
 --threshold=PERCENT  only convert files where the translation completion is above PERCENT
 --fuzzy              use translations marked fuzzy
 --nofuzzy            don't use translations marked fuzzy (default)
@@ -100,7 +104,8 @@ Translate as normal. However, see the issues mentioned at
 
 Bugs
 ----
-There might be some issues with encodings, since the srt files don't specify
-them. We assume files to be encoded in UTF-8, so a conversion should solve this
-easily. Note that most of the handling of the srt files come from aeidon.
-
+Subtitle files do not always specify their encoding. aeidon detects it by
+default; use :opt:`--encoding` for the input subtitle file (and for the
+subtitle template and output with po2sub), or :opt:`--encoding-template` for a
+sub2po template when detection is incorrect. Most subtitle handling comes from
+aeidon.

--- a/tests/cli/__snapshots__/test_cli_snapshots.ambr
+++ b/tests/cli/__snapshots__/test_cli_snapshots.ambr
@@ -675,7 +675,7 @@
     }),
     'returncode': 2,
     'stderr': '''
-      Usage: prop2po [--version] [-h|--help] [--manpage] [--progress PROGRESS] [--errorlevel ERRORLEVEL] [-i|--input] INPUT [-x|--exclude EXCLUDE] [-o|--output] OUTPUT [-t|--template TEMPLATE] [-S|--timestamp] [-P|--pot] [--personality TYPE] [--encoding ENCODING] [--duplicates DUPLICATESTYLE]
+      Usage: prop2po [--version] [-h|--help] [--manpage] [--progress PROGRESS] [--errorlevel ERRORLEVEL] [-i|--input] INPUT [-x|--exclude EXCLUDE] [-o|--output] OUTPUT [-t|--template TEMPLATE] [-S|--timestamp] [-P|--pot] [--personality TYPE] [--encoding ENCODING] [--encoding-template ENCODING] [--duplicates DUPLICATESTYLE]
       
       prop2po: error: You need to give an inputfile or use - for stdin ; use --help for full usage instructions
   

--- a/tests/translate/convert/test_csv2po.py
+++ b/tests/translate/convert/test_csv2po.py
@@ -1,6 +1,8 @@
 import logging
 from io import BytesIO
 
+import pytest
+
 from translate.convert import csv2po
 from translate.storage import csvl10n, po
 
@@ -14,6 +16,37 @@ def test_replacestrings() -> None:
         csv2po.replacestrings("Test one two three", ("one", "een"), ("two", "twee"))
         == "Test een twee three"
     )
+
+
+@pytest.mark.parametrize("charset", ["utf8", "iso-8859-2"])
+def test_convertcsv_charset(charset) -> None:
+    """Test that convertcsv decodes its input using the requested charset."""
+    content = "source,target\ntest,zkouška sirén\n"
+    output = BytesIO()
+
+    assert (
+        csv2po.convertcsv(
+            BytesIO(content.encode(charset)), output, None, charset=charset
+        )
+        == 1
+    )
+
+    result = po.pofile(BytesIO(output.getvalue()))
+    unit = result.findunit("test")
+    assert unit is not None
+    assert unit.target == "zkouška sirén"
+    assert result.parseheader()["Content-Type"] == "text/plain; charset=UTF-8"
+
+
+def test_convertcsv_invalid_charset() -> None:
+    """Test that convertcsv does not silently ignore an invalid charset."""
+    with pytest.raises(LookupError):
+        csv2po.convertcsv(
+            BytesIO(b"source,target\ntest,translation\n"),
+            BytesIO(),
+            None,
+            charset="not-a-codec",
+        )
 
 
 class TestCSV2PO:
@@ -239,7 +272,7 @@ class TestCSV2POCommand(test_convert.TestConvertCommand, TestCSV2PO):
     expected_options = [
         "-t TEMPLATE, --template=TEMPLATE",
         "-P, --pot",
-        "--charset=CHARSET",
+        "--encoding=ENCODING, --charset=ENCODING",
         "--columnorder=COLUMNORDER",
         "--duplicates=DUPLICATESTYLE",
         "--unescape-formulas",

--- a/tests/translate/convert/test_csv2tbx.py
+++ b/tests/translate/convert/test_csv2tbx.py
@@ -1,0 +1,44 @@
+from io import BytesIO
+
+import pytest
+
+from translate.convert import csv2tbx
+from translate.storage import tbx
+
+from . import test_convert
+
+
+def test_convertcsv_encoding() -> None:
+    """Decode CSV input using the requested encoding."""
+    content = "source,target\ntest,zkouška sirén\n".encode("iso-8859-2")
+    output = BytesIO()
+
+    assert csv2tbx.convertcsv(BytesIO(content), output, None, charset="iso-8859-2") == 1
+
+    result = tbx.tbxfile(BytesIO(output.getvalue()))
+    assert len(result.units) == 1
+    assert result.units[0].source == "test"
+    assert result.units[0].target == "zkouška sirén"
+
+
+def test_convertcsv_invalid_encoding() -> None:
+    """Do not silently ignore an invalid CSV encoding."""
+    with pytest.raises(LookupError):
+        csv2tbx.convertcsv(
+            BytesIO(b"source,target\ntest,translation\n"),
+            BytesIO(),
+            None,
+            charset="not-a-codec",
+        )
+
+
+class TestCSV2TBXCommand(test_convert.TestConvertCommand):
+    """Tests running actual csv2tbx commands on files."""
+
+    convertmodule = csv2tbx
+    defaultoptions = {"progress": "none"}
+
+    expected_options = [
+        "--encoding=ENCODING, --charset=ENCODING",
+        "--columnorder=COLUMNORDER",
+    ]

--- a/tests/translate/convert/test_ini2po.py
+++ b/tests/translate/convert/test_ini2po.py
@@ -3,6 +3,7 @@ from io import BytesIO
 from pytest import importorskip
 
 from translate.convert import ini2po
+from translate.storage import po
 
 from . import test_convert
 
@@ -96,6 +97,28 @@ msgstr "valor"
         assert expected_output in output
         assert "extracted from " in output
 
+    def test_input_and_template_encoding(self) -> None:
+        """Allow input and template INI files to use different encodings."""
+        input_file = BytesIO("[section]\nkey=zkouška sirén\n".encode("iso-8859-2"))
+        template_file = BytesIO("[section]\nkey=Source — UTF-8\n".encode())
+        output_file = BytesIO()
+
+        assert (
+            ini2po.run_converter(
+                input_file,
+                output_file,
+                template_file,
+                encoding="iso-8859-2",
+                template_encoding="utf-8",
+            )
+            == 1
+        )
+
+        result = po.pofile(BytesIO(output_file.getvalue()))
+        unit = result.findunit("Source — UTF-8")
+        assert unit is not None
+        assert unit.target == "zkouška sirén"
+
     def test_merge_misaligned_files(self) -> None:
         """Check merging two files that are not aligned."""
         input_string = """[section]
@@ -151,5 +174,7 @@ class TestIni2POCommand(test_convert.TestConvertCommand, TestIni2PO):
     expected_options = [
         "-t TEMPLATE, --template=TEMPLATE",
         "-P, --pot",
+        "--encoding=ENCODING",
+        "--encoding-template=ENCODING",
         "--duplicates=DUPLICATESTYLE",
     ]

--- a/tests/translate/convert/test_php2po.py
+++ b/tests/translate/convert/test_php2po.py
@@ -72,6 +72,28 @@ class TestPhp2PO:
         assert pounit.source == "source"
         assert pounit.target == "entry"
 
+    def test_input_and_template_encoding(self) -> None:
+        """Allow input and template PHP files to use different encodings."""
+        inputfile = BytesIO("$lang['simple'] = 'zkouška sirén';".encode("iso-8859-2"))
+        templatefile = BytesIO("$lang['simple'] = 'Source — UTF-8';".encode())
+        outputfile = BytesIO()
+
+        assert (
+            php2po.run_converter(
+                inputfile,
+                outputfile,
+                templatefile,
+                encoding="iso-8859-2",
+                template_encoding="utf-8",
+            )
+            == 1
+        )
+
+        result = po.pofile(BytesIO(outputfile.getvalue()))
+        pounit = self.singleelement(result)
+        assert pounit.source == "Source — UTF-8"
+        assert pounit.target == "zkouška sirén"
+
     def test_convertphpmissing(self) -> None:
         """Checks that the convertphp function is working with missing key."""
         phpsource = """$_LANG['simple'] = 'entry';"""
@@ -282,5 +304,7 @@ class TestPhp2POCommand(test_convert.TestConvertCommand, TestPhp2PO):
     expected_options = [
         "-P, --pot",
         "-t TEMPLATE, --template=TEMPLATE",
+        "--encoding=ENCODING",
+        "--encoding-template=ENCODING",
         "--duplicates=DUPLICATESTYLE",
     ]

--- a/tests/translate/convert/test_po2sub.py
+++ b/tests/translate/convert/test_po2sub.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from pytest import importorskip
 
 from translate.convert import po2sub
-from translate.storage import po
+from translate.storage import po, subtitles
 
 from . import test_convert
 
@@ -53,6 +53,32 @@ Koei koei koei koei
         print(subexpected)
         assert subfile == subexpected
 
+    def test_encoding_override(self, monkeypatch) -> None:
+        """Override incorrect subtitle encoding detection for input and output."""
+        posource = """#: 00:00:20.000-->00:00:24.400
+msgid "Source"
+msgstr "L’été"
+"""
+        subtemplate = """1
+00:00:20,000 --> 00:00:24,400
+Source
+"""
+        input_file = BytesIO(posource.encode())
+        template_file = BytesIO(subtemplate.encode())
+        output_file = BytesIO()
+        monkeypatch.setattr(subtitles, "detect", lambda _filename: "iso-8859-1")
+
+        assert (
+            po2sub.convertsub(
+                input_file,
+                output_file,
+                template_file,
+                encoding="utf-8",
+            )
+            == 1
+        )
+        assert "L’été" in output_file.getvalue().decode()
+
 
 class TestPO2SubCommand(test_convert.TestConvertCommand, TestPO2Sub):
     """Tests running actual po2sub commands on files."""
@@ -62,6 +88,7 @@ class TestPO2SubCommand(test_convert.TestConvertCommand, TestPO2Sub):
 
     expected_options = [
         "-t TEMPLATE, --template=TEMPLATE",
+        "--encoding=ENCODING",
         "--threshold=PERCENT",
         "--fuzzy",
         "--nofuzzy",

--- a/tests/translate/convert/test_prop2po.py
+++ b/tests/translate/convert/test_prop2po.py
@@ -494,6 +494,49 @@ message-multiedit-header[many]={0,number} selected
         assert units[1].source == "Goodbye"
         assert units[1].target == "Adeu"
 
+    def test_input_and_template_encoding(self) -> None:
+        """Allow input and template property files to use different encodings."""
+        input_file = BytesIO('"greeting" = "Dobrý den";'.encode("utf-16"))
+        template_file = BytesIO('"greeting" = "Hello — UTF-8";'.encode())
+        output_file = BytesIO()
+
+        assert (
+            prop2po.convertstrings(
+                input_file,
+                output_file,
+                template_file,
+                encoding="utf-16",
+                template_encoding="utf-8",
+            )
+            == 1
+        )
+
+        result = po.pofile(BytesIO(output_file.getvalue()))
+        unit = result.findunit("Hello — UTF-8")
+        assert unit is not None
+        assert unit.target == "Dobrý den"
+
+    def test_template_encoding_falls_back_to_input_encoding(self) -> None:
+        """Keep applying the input encoding to templates unless overridden."""
+        input_file = BytesIO("greeting=Dobrý den".encode())
+        template_file = BytesIO("greeting=Hello — UTF-8".encode())
+        output_file = BytesIO()
+
+        assert (
+            prop2po.convertprop(
+                input_file,
+                output_file,
+                template_file,
+                encoding="utf-8",
+            )
+            == 1
+        )
+
+        result = po.pofile(BytesIO(output_file.getvalue()))
+        unit = result.findunit("Hello — UTF-8")
+        assert unit is not None
+        assert unit.target == "Dobrý den"
+
 
 class TestProp2POCommand(test_convert.TestConvertCommand, TestProp2PO):
     """Tests running actual prop2po commands on files."""
@@ -505,5 +548,6 @@ class TestProp2POCommand(test_convert.TestConvertCommand, TestProp2PO):
         "-t TEMPLATE, --template=TEMPLATE",
         "--personality=TYPE",
         "--encoding=ENCODING",
+        "--encoding-template=ENCODING",
         "--duplicates=DUPLICATESTYLE",
     ]

--- a/tests/translate/convert/test_sub2po.py
+++ b/tests/translate/convert/test_sub2po.py
@@ -1,0 +1,49 @@
+from io import BytesIO
+
+from translate.convert import sub2po
+from translate.storage import po, subtitles
+
+from . import test_convert
+
+
+def test_input_and_template_encoding(monkeypatch) -> None:
+    """Allow input and template subtitle files to use different encodings."""
+    input_file = BytesIO(
+        "1\n00:00:00,000 --> 00:00:01,000\nCafé\n\n".encode("iso-8859-1")
+    )
+    template_file = BytesIO(
+        "1\n00:00:00,000 --> 00:00:01,000\nSource — UTF-8\n\n".encode()
+    )
+    output_file = BytesIO()
+    monkeypatch.setattr(subtitles, "detect", lambda _filename: "utf-8")
+
+    assert (
+        sub2po.convertsub(
+            input_file,
+            output_file,
+            template_file,
+            encoding="iso-8859-1",
+            template_encoding="utf-8",
+        )
+        == 1
+    )
+
+    result = po.pofile(BytesIO(output_file.getvalue()))
+    unit = result.findunit("Source — UTF-8")
+    assert unit is not None
+    assert unit.target == "Café"
+
+
+class TestSub2POCommand(test_convert.TestConvertCommand):
+    """Tests running actual sub2po commands on files."""
+
+    convertmodule = sub2po
+    defaultoptions = {"progress": "none"}
+
+    expected_options = [
+        "-t TEMPLATE, --template=TEMPLATE",
+        "-P, --pot",
+        "--encoding=ENCODING",
+        "--encoding-template=ENCODING",
+        "--duplicates=DUPLICATESTYLE",
+    ]

--- a/tests/translate/storage/test_ini.py
+++ b/tests/translate/storage/test_ini.py
@@ -67,6 +67,15 @@ class TestINIStore(test_monolingual.TestMonolingualStore):
         assert len(store.units) == 1
         assert store.units[0].source == "value"
 
+    def test_encoding(self) -> None:
+        content = "[default]\nkey=zkouška sirén\n".encode("iso-8859-2")
+        store = self.StoreClass(encoding="iso-8859-2")
+
+        store.parse(content)
+
+        assert store.units[0].source == "zkouška sirén"
+        assert bytes(store) == content
+
     def test_new_entry_preserves_crlf(self) -> None:
         content = b"[default]\r\n; comment\r\nkey=value\r\n"
         store = self.StoreClass()

--- a/translate/convert/convert.py
+++ b/translate/convert/convert.py
@@ -124,6 +124,36 @@ class ConvertOptionParser(optrecurse.RecursiveOptionParser):
         )
         self.passthrough.append("duplicatestyle")
 
+    def add_encoding_option(
+        self,
+        *,
+        aliases: tuple[str, ...] = (),
+        dest: str = "encoding",
+        help_text: str = "override the encoding of the input file",
+        use_template: bool = False,
+    ) -> None:
+        """Add input and optional template encoding options."""
+        self.add_option(
+            "",
+            "--encoding",
+            *aliases,
+            dest=dest,
+            default=None,
+            help=help_text,
+            metavar="ENCODING",
+        )
+        self.passthrough.append(dest)
+        if use_template:
+            self.add_option(
+                "",
+                "--encoding-template",
+                dest="template_encoding",
+                default=None,
+                help="override the encoding of the template file",
+                metavar="ENCODING",
+            )
+            self.passthrough.append("template_encoding")
+
     def add_multifile_option(self, default="single") -> None:
         """Adds an option to say how to split the po/pot files."""
         self.add_option(

--- a/translate/convert/csv2po.py
+++ b/translate/convert/csv2po.py
@@ -74,6 +74,8 @@ class csv2po:
     ) -> None:
         """Construct the converter..."""
         self.pofile = templatepo
+        # Retained for compatibility with callers constructing this class directly.
+        # Input decoding is handled by csvl10n.csvfile before conversion.
         self.charset = charset
         self.duplicatestyle = duplicatestyle
         self.unescape_formulas = unescape_formulas
@@ -287,9 +289,6 @@ class csv2po:
         targetheader.addnote(f"extracted from {self.csvfile.filename}", "developer")
         mightbeheader = True
         for csvunit in self.csvfile.units:
-            # if self.charset is not None:
-            #    csvunit.source = csvunit.source.decode(self.charset)
-            #    csvunit.target = csvunit.target.decode(self.charset)
             if mightbeheader:
                 # ignore typical header strings...
                 mightbeheader = False
@@ -322,10 +321,11 @@ def convertcsv(
     Reads in inputfile using csvl10n, converts using csv2po, writes to
     outputfile.
     """
-    inputstore = csvl10n.csvfile(inputfile, fieldnames=columnorder)
+    inputstore = csvl10n.csvfile(
+        inputfile, fieldnames=columnorder, encoding=charset or "auto"
+    )
     if templatefile is None:
         convertor = csv2po(
-            charset=charset,
             duplicatestyle=duplicatestyle,
             unescape_formulas=unescape_formulas,
         )
@@ -333,7 +333,6 @@ def convertcsv(
         templatestore = po.pofile(templatefile)
         convertor = csv2po(
             templatestore,
-            charset=charset,
             duplicatestyle=duplicatestyle,
             unescape_formulas=unescape_formulas,
         )
@@ -357,13 +356,9 @@ def main(argv=None) -> None:
     parser = convert.ConvertOptionParser(
         formats, usetemplates=True, usepots=True, description=__doc__
     )
-    parser.add_option(
-        "",
-        "--charset",
+    parser.add_encoding_option(
+        aliases=("--charset",),
         dest="charset",
-        default=None,
-        help="set charset to decode from csv files",
-        metavar="CHARSET",
     )
     parser.add_option(
         "",
@@ -384,7 +379,6 @@ def main(argv=None) -> None:
         default=False,
         help="remove spreadsheet formula escaping from CSV values",
     )
-    parser.passthrough.append("charset")
     parser.passthrough.append("columnorder")
     parser.passthrough.append("unescape_formulas")
     parser.run(argv)

--- a/translate/convert/csv2tbx.py
+++ b/translate/convert/csv2tbx.py
@@ -36,6 +36,8 @@ class csv2tbx:
 
     def __init__(self, charset=None) -> None:
         """Construct the converter..."""
+        # Retained for compatibility with callers constructing this class directly.
+        # Input decoding is handled by csvl10n.csvfile before conversion.
         self.charset = charset
 
     def convertfile(self, csvfile):
@@ -70,8 +72,10 @@ def convertcsv(
     Reads in inputfile using csvl10n, converts using csv2tbx, writes to
     outputfile.
     """
-    inputstore = csvl10n.csvfile(inputfile, fieldnames=columnorder)
-    convertor = csv2tbx(charset=charset)
+    inputstore = csvl10n.csvfile(
+        inputfile, fieldnames=columnorder, encoding=charset or "auto"
+    )
+    convertor = csv2tbx()
     outputstore = convertor.convertfile(inputstore)
     if len(outputstore.units) == 0:
         return 0
@@ -79,7 +83,7 @@ def convertcsv(
     return 1
 
 
-def main() -> None:
+def main(argv=None) -> None:
     formats = {
         ("csv", "tbx"): ("tbx", convertcsv),
         ("csv", None): ("tbx", convertcsv),
@@ -87,13 +91,9 @@ def main() -> None:
     parser = convert.ConvertOptionParser(
         formats, usetemplates=False, description=__doc__
     )
-    parser.add_option(
-        "",
-        "--charset",
+    parser.add_encoding_option(
+        aliases=("--charset",),
         dest="charset",
-        default=None,
-        help="set charset to decode from csv files",
-        metavar="CHARSET",
     )
     parser.add_option(
         "",
@@ -102,9 +102,8 @@ def main() -> None:
         default=None,
         help="specify the order and position of columns (comment,source,target)",
     )
-    parser.passthrough.append("charset")
     parser.passthrough.append("columnorder")
-    parser.run()
+    parser.run(argv)
 
 
 if __name__ == "__main__":

--- a/translate/convert/ini2po.py
+++ b/translate/convert/ini2po.py
@@ -44,6 +44,8 @@ class ini2po:
         blank_msgstr=False,
         duplicate_style="msgctxt",
         dialect="default",
+        encoding=None,
+        template_encoding=None,
     ) -> None:
         """Initialize the converter."""
         if ini.INIConfig is None:
@@ -55,12 +57,16 @@ class ini2po:
 
         self.extraction_msg = None
         self.output_file = output_file
-        self.source_store = self.SourceStoreClass(input_file, dialect=dialect)
+        self.source_store = self.SourceStoreClass(
+            input_file, dialect=dialect, encoding=encoding
+        )
         self.target_store = self.TargetStoreClass()
         self.template_store = None
 
         if template_file is not None:
-            self.template_store = self.SourceStoreClass(template_file, dialect=dialect)
+            self.template_store = self.SourceStoreClass(
+                template_file, dialect=dialect, encoding=template_encoding
+            )
 
     def convert_unit(self, unit):
         """Convert a source format unit to a target format unit."""
@@ -121,6 +127,8 @@ def run_converter(
     pot=False,
     duplicatestyle="msgctxt",
     dialect="default",
+    encoding=None,
+    template_encoding=None,
 ):
     """Wrapper around converter."""
     return ini2po(
@@ -130,6 +138,8 @@ def run_converter(
         blank_msgstr=pot,
         duplicate_style=duplicatestyle,
         dialect=dialect,
+        encoding=encoding,
+        template_encoding=template_encoding,
     ).run()
 
 
@@ -140,9 +150,18 @@ def convertisl(
     pot=False,
     duplicatestyle="msgctxt",
     dialect="inno",
+    encoding=None,
+    template_encoding=None,
 ):
     return run_converter(
-        input_file, output_file, template_file, pot, duplicatestyle, dialect
+        input_file,
+        output_file,
+        template_file,
+        pot=pot,
+        duplicatestyle=duplicatestyle,
+        dialect=dialect,
+        encoding=encoding,
+        template_encoding=template_encoding,
     )
 
 
@@ -160,6 +179,7 @@ def main(argv=None) -> None:
     parser = convert.ConvertOptionParser(
         formats, usetemplates=True, usepots=True, description=__doc__
     )
+    parser.add_encoding_option(use_template=True)
     parser.add_duplicates_option()
     parser.passthrough.append("pot")
     parser.run(argv)

--- a/translate/convert/php2po.py
+++ b/translate/convert/php2po.py
@@ -41,6 +41,8 @@ class php2po:
         template_file=None,
         blank_msgstr=False,
         duplicate_style="msgctxt",
+        encoding=None,
+        template_encoding=None,
     ) -> None:
         """Initialize the converter."""
         self.blank_msgstr = blank_msgstr
@@ -48,12 +50,14 @@ class php2po:
 
         self.extraction_msg = None
         self.output_file = output_file
-        self.source_store = self.SourceStoreClass(input_file)
+        self.source_store = self.SourceStoreClass(input_file, encoding=encoding)
         self.target_store = self.TargetStoreClass()
         self.template_store = None
 
         if template_file is not None:
-            self.template_store = self.SourceStoreClass(template_file)
+            self.template_store = self.SourceStoreClass(
+                template_file, encoding=template_encoding
+            )
 
     def convert_unit(self, unit):
         """Convert a source format unit to a target format unit."""
@@ -108,7 +112,13 @@ class php2po:
 
 
 def run_converter(
-    input_file, output_file, template_file=None, pot=False, duplicatestyle="msgctxt"
+    input_file,
+    output_file,
+    template_file=None,
+    pot=False,
+    duplicatestyle="msgctxt",
+    encoding=None,
+    template_encoding=None,
 ):
     """Wrapper around converter."""
     return php2po(
@@ -117,6 +127,8 @@ def run_converter(
         template_file,
         blank_msgstr=pot,
         duplicate_style=duplicatestyle,
+        encoding=encoding,
+        template_encoding=template_encoding,
     ).run()
 
 
@@ -132,6 +144,7 @@ def main(argv=None) -> None:
     parser = convert.ConvertOptionParser(
         formats, usetemplates=True, usepots=True, description=__doc__
     )
+    parser.add_encoding_option(use_template=True)
     parser.add_duplicates_option()
     parser.passthrough.append("pot")
     parser.run(argv)

--- a/translate/convert/po2sub.py
+++ b/translate/convert/po2sub.py
@@ -28,10 +28,12 @@ from translate.storage import po, subtitles
 
 
 class po2sub:
-    def __init__(self, templatefile, inputstore, includefuzzy=False) -> None:
+    def __init__(
+        self, templatefile, inputstore, includefuzzy=False, encoding=None
+    ) -> None:
         self.includefuzzy = includefuzzy
         self.templatefile = templatefile
-        self.templatestore = subtitles.SubtitleFile(templatefile)
+        self.templatestore = subtitles.SubtitleFile(templatefile, encoding=encoding)
         self.inputstore = inputstore
 
     def convert_store(self):
@@ -50,7 +52,12 @@ class po2sub:
 
 
 def convertsub(
-    inputfile, outputfile, templatefile, includefuzzy=False, outputthreshold=None
+    inputfile,
+    outputfile,
+    templatefile,
+    includefuzzy=False,
+    outputthreshold=None,
+    encoding=None,
 ) -> int:
     if templatefile is None:
         raise ValueError("must have template file for subtitle files")
@@ -59,7 +66,7 @@ def convertsub(
     if not convert.should_output_store(inputstore, outputthreshold):
         return 0
 
-    convertor = po2sub(templatefile, inputstore, includefuzzy)
+    convertor = po2sub(templatefile, inputstore, includefuzzy, encoding)
     outputstring = convertor.convert_store()
     outputfile.write(outputstring)
     return 1
@@ -76,6 +83,9 @@ formats = {
 def main(argv=None) -> None:
     parser = convert.ConvertOptionParser(
         formats, usetemplates=True, description=__doc__
+    )
+    parser.add_encoding_option(
+        help_text="override the encoding of the subtitle template and output"
     )
     parser.add_threshold_option()
     parser.add_fuzzy_option()

--- a/translate/convert/prop2po.py
+++ b/translate/convert/prop2po.py
@@ -433,6 +433,7 @@ def convertstrings(
     pot=False,
     duplicatestyle="msgctxt",
     encoding=None,
+    template_encoding=None,
 ):
     """.strings specific convertor function."""
     return convertprop(
@@ -443,6 +444,7 @@ def convertstrings(
         pot=pot,
         duplicatestyle=duplicatestyle,
         encoding=encoding,
+        template_encoding=template_encoding,
     )
 
 
@@ -468,6 +470,7 @@ def convertprop(
     pot=False,
     duplicatestyle="msgctxt",
     encoding=None,
+    template_encoding=None,
 ) -> int:
     """
     Reads in inputfile using properties, converts using prop2po, writes to
@@ -480,7 +483,11 @@ def convertprop(
     if templatefile is None:
         outputstore = convertor.convertstore(inputstore)
     else:
-        templatestore = properties.propfile(templatefile, personality, encoding)
+        if template_encoding is None:
+            template_encoding = encoding
+        templatestore = properties.propfile(
+            templatefile, personality, template_encoding
+        )
         outputstore = convertor.mergestore(templatestore, inputstore)
     if outputstore.isempty():
         return 0
@@ -512,18 +519,12 @@ def main(argv=None) -> None:
         help=f"override the input file format: {', '.join(properties.dialects.keys())} (for .properties files, default: {properties.default_dialect})",
         metavar="TYPE",
     )
-    parser.add_option(
-        "",
-        "--encoding",
-        dest="encoding",
-        default=None,
-        help="override the encoding set by the personality",
-        metavar="ENCODING",
+    parser.add_encoding_option(
+        help_text="override the encoding set by the personality", use_template=True
     )
     parser.add_duplicates_option()
     parser.passthrough.append("pot")
     parser.passthrough.append("personality")
-    parser.passthrough.append("encoding")
     parser.run(argv)
 
 

--- a/translate/convert/sub2po.py
+++ b/translate/convert/sub2po.py
@@ -96,17 +96,25 @@ def convert_unit(input_unit, commenttype):
 
 
 def convertsub(
-    input_file, output_file, template_file=None, pot=False, duplicatestyle="msgctxt"
+    input_file,
+    output_file,
+    template_file=None,
+    pot=False,
+    duplicatestyle="msgctxt",
+    encoding=None,
+    template_encoding=None,
 ) -> int:
     """
     Reads in *input_file* using translate.subtitles, converts using
     :class:`sub2po`, writes to *output_file*.
     """
-    input_store = subtitles.SubtitleFile(input_file)
+    input_store = subtitles.SubtitleFile(input_file, encoding=encoding)
     if template_file is None:
         output_store = convert_store(input_store, duplicatestyle=duplicatestyle)
     else:
-        template_store = subtitles.SubtitleFile(template_file)
+        template_store = subtitles.SubtitleFile(
+            template_file, encoding=template_encoding
+        )
         output_store = merge_store(
             template_store, input_store, blankmsgstr=pot, duplicatestyle=duplicatestyle
         )
@@ -130,6 +138,7 @@ def main(argv=None) -> None:
     parser = convert.ConvertOptionParser(
         formats, usetemplates=True, usepots=True, description=__doc__
     )
+    parser.add_encoding_option(use_template=True)
     parser.add_duplicates_option()
     parser.passthrough.append("pot")
     parser.run(argv)

--- a/translate/storage/ini.py
+++ b/translate/storage/ini.py
@@ -158,7 +158,7 @@ class inifile(base.TranslationStore):
                 outinifile[section][entry] = value
         if outinifile:
             output = self._normalize_newlines(str(outinifile))
-            out.write(output.encode("utf-8"))
+            out.write(output.encode(self.encoding))
 
     def parse(self, input) -> None:  # ty:ignore[invalid-method-override]
         """
@@ -181,9 +181,9 @@ class inifile(base.TranslationStore):
 
         if not prepared.from_handle and base.is_path_input(input):
             with open(base.path_input_str(input), "rb") as source:
-                decoded = source.read().decode("utf-8")
+                decoded = source.read().decode(self.encoding)
         elif isinstance(input, bytes):
-            decoded = input.decode("utf-8")
+            decoded = input.decode(self.encoding)
         else:
             decoded = input
 

--- a/translate/storage/subtitles.py
+++ b/translate/storage/subtitles.py
@@ -163,7 +163,8 @@ class SubtitleFile(base.TranslationStore):
         )
 
     def _parse_subtitles(self) -> None:
-        self.encoding = detect(self.filename)
+        if self._encoding in {None, "auto"}:
+            self.encoding = detect(self.filename)
         self._format = detect_format(self.filename, self.encoding)
         self._subtitlefile = new(self._format, self.filename, self.encoding)
         for subtitle in self._subtitlefile.read():


### PR DESCRIPTION
Converters either ignored encoding options or lacked separate overrides, preventing legacy input, mixed-encoding templates, and misdetected subtitle output from being converted.

Closes #911

Closes #1009

Closes #3827

Closes #4989