### PR TITLE
fix(tmx): honor language selection

### DIFF
--- a/docs/formats/tmx.rst
+++ b/docs/formats/tmx.rst
@@ -18,8 +18,10 @@ Level 1, except that no markup is stripped.
 * All required header fields are supplied.
 * The ``adminlang`` field in the header is always English.
 * None of the optional header fields are supplied.
-* We assume that only two languages are used (source and single target
-  language).
+* Multiple language variants are supported. Source variants are selected using
+  the configured source language, a translation unit's ``srclang``, or the
+  header's ``srclang``, in that order. Target variants can be selected by
+  configuring a target language.
 * No special consideration for segmentation.
 * Currently text is treated as plain text, in other words no markup like HTML
   inside messages are stripped or interpreted as it should be for complete

--- a/tests/translate/storage/test_tmx.py
+++ b/tests/translate/storage/test_tmx.py
@@ -39,6 +39,32 @@ class TestTMXfile(test_base.TestTranslationStore):
     StoreClass = tmx.tmxfile
 
     @staticmethod
+    def language_selection_tmx(tus: str, srclang: str = "en") -> str:
+        return f"""<?xml version="1.0" encoding="utf-8"?>
+<tmx version="1.4">
+    <header creationtool="test" creationtoolversion="1" datatype="unknown"
+            segtype="sentence" adminlang="en" srclang="{srclang}" o-tmf="TMX"/>
+    <body>
+{tus}
+    </body>
+</tmx>"""
+
+    @classmethod
+    def multilingual_tmx(cls) -> str:
+        return cls.language_selection_tmx(
+            """        <tu tuid="test1">
+            <tuv xml:lang="ar"><seg>test1_ar</seg></tuv>
+            <tuv xml:lang="de"><seg>test1_de</seg></tuv>
+            <tuv xml:lang="en"><seg>test1_en</seg></tuv>
+        </tu>
+        <tu tuid="test2">
+            <tuv xml:lang="en"><seg>test2_en</seg></tuv>
+            <tuv xml:lang="de"><seg>test2_de</seg></tuv>
+            <tuv xml:lang="ar"><seg>test2_ar</seg></tuv>
+        </tu>"""
+        )
+
+    @staticmethod
     def tmxparse(tmxsource):
         """Helper that parses tmx source without requiring files."""
         dummyfile = BytesIO(tmxsource)
@@ -52,6 +78,131 @@ class TestTMXfile(test_base.TestTranslationStore):
             "A string of characters", "en", "'n String karakters", "af"
         )
         assert tmxfile.translate("A string of characters") == "'n String karakters"
+
+    def test_multilingual_configured_language_selection(self) -> None:
+        store = tmx.tmxfile(
+            BytesIO(self.multilingual_tmx().encode()),
+            sourcelanguage="de",
+            targetlanguage="en",
+        )
+
+        assert store.sourcelanguage == "de"
+        assert store.targetlanguage == "en"
+        assert [(unit.source, unit.target) for unit in store.units] == [
+            ("test1_de", "test1_en"),
+            ("test2_de", "test2_en"),
+        ]
+        assert store.translate("test1_de") == "test1_en"
+        assert store.translate("test1_ar", sourcelang="ar", targetlang="de") == (
+            "test1_de"
+        )
+        assert store.translate("test1", sourcelang="de", targetlang="en") is None
+        assert store.findid("test1").gettarget("en") == "test1_en"
+
+    def test_multilingual_parsestring_language_selection(self) -> None:
+        store = tmx.tmxfile.parsestring(
+            self.multilingual_tmx(), sourcelanguage="de", targetlanguage="ar"
+        )
+
+        assert store.units[0].source == "test1_de"
+        assert store.units[0].target == "test1_ar"
+
+    def test_multilingual_header_language_and_target_fallback(self) -> None:
+        store = tmx.tmxfile.parsestring(self.multilingual_tmx())
+
+        assert store.sourcelanguage == "en"
+        assert store.targetlanguage is None
+        assert [(unit.source, unit.target) for unit in store.units] == [
+            ("test1_en", "test1_de"),
+            ("test2_en", "test2_de"),
+        ]
+        assert store.translate("test1_en") == "test1_de"
+
+    def test_translation_unit_source_language_precedence(self) -> None:
+        source = self.language_selection_tmx(
+            """        <tu tuid="test" srclang="ar">
+            <tuv xml:lang="en"><seg>English</seg></tuv>
+            <tuv xml:lang="de"><seg>Deutsch</seg></tuv>
+            <tuv xml:lang="ar"><seg>Arabic</seg></tuv>
+        </tu>"""
+        )
+
+        store = tmx.tmxfile.parsestring(source)
+        assert store.units[0].source == "Arabic"
+        assert store.units[0].target == "Deutsch"
+
+        store = tmx.tmxfile.parsestring(
+            source, sourcelanguage="de", targetlanguage="en"
+        )
+        assert store.units[0].source == "Deutsch"
+        assert store.units[0].target == "English"
+
+    def test_all_source_languages_use_order_fallback(self) -> None:
+        source = self.language_selection_tmx(
+            """        <tu tuid="test" srclang="*all*">
+            <tuv xml:lang="ar"><seg>Arabic</seg></tuv>
+            <tuv xml:lang="de"><seg>Deutsch</seg></tuv>
+            <tuv xml:lang="en"><seg>English</seg></tuv>
+        </tu>"""
+        )
+
+        unit = tmx.tmxfile.parsestring(source).units[0]
+        assert unit.source == "Arabic"
+        assert unit.target == "Deutsch"
+
+    def test_language_matching_normalizes_case_and_separator(self) -> None:
+        source = self.language_selection_tmx(
+            """        <tu tuid="test">
+            <tuv xml:lang="de-DE"><seg>Farbe</seg></tuv>
+            <tuv xml:lang="EN-us"><seg>color</seg></tuv>
+        </tu>""",
+            srclang="de-DE",
+        )
+
+        store = tmx.tmxfile.parsestring(
+            source, sourcelanguage="de_de", targetlanguage="en_US"
+        )
+        assert store.units[0].source == "Farbe"
+        assert store.units[0].target == "color"
+        assert store.translate("Farbe", sourcelang="DE-de", targetlang="en_us") == (
+            "color"
+        )
+
+        store = tmx.tmxfile.parsestring(source, sourcelanguage="de")
+        assert store.units[0].source is None
+
+    def test_missing_configured_language_does_not_fallback(self) -> None:
+        store = tmx.tmxfile.parsestring(
+            self.multilingual_tmx(), sourcelanguage="fr", targetlanguage="es"
+        )
+
+        assert store.units[0].source is None
+        assert store.units[0].target is None
+        assert store.translate("test1_en", sourcelang="en", targetlang="es") is None
+
+    def test_multilingual_setters_preserve_other_languages(self) -> None:
+        store = tmx.tmxfile.parsestring(
+            self.multilingual_tmx(), sourcelanguage="en", targetlanguage="ar"
+        )
+        unit = store.units[0]
+
+        unit.source = "updated English"
+        unit.target = "updated Arabic"
+
+        assert unit.gettarget("en") == "updated English"
+        assert unit.gettarget("ar") == "updated Arabic"
+        assert unit.gettarget("de") == "test1_de"
+
+    def test_language_change_invalidates_indexes(self) -> None:
+        store = tmx.tmxfile.parsestring(
+            self.multilingual_tmx(), sourcelanguage="en", targetlanguage="de"
+        )
+        assert store.translate("test1_en") == "test1_de"
+
+        store.setsourcelanguage("ar")
+        store.settargetlanguage("en")
+
+        assert store.translate("test1_ar") == "test1_en"
 
     def test_addtranslation(self) -> None:
         """Tests that addtranslation() stores strings correctly."""

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -268,6 +268,157 @@ class LISAunit(base.TranslationUnit):
         return term
 
 
+def normalize_language(language: str | None) -> str | None:
+    """Normalize an XML language tag for comparison."""
+    if not language:
+        return None
+    return language.replace("_", "-").lower()
+
+
+class MultilingualLISAunit(LISAunit):
+    """A LISA unit with sibling nodes representing different languages."""
+
+    def _store_language(self, name: str) -> str | None:
+        store = getattr(self, "_store", None)
+        if store is None:
+            return None
+        return getattr(store, name, None)
+
+    def _store_language_or_default(self, name: str, default: str) -> str:
+        return self._store_language(name) or default
+
+    def _get_source_language(self) -> str | None:
+        return self._store_language("sourcelanguage")
+
+    def _get_target_language(self) -> str | None:
+        return self._store_language("targetlanguage")
+
+    def _get_language_node(self, language: str | None):
+        language = normalize_language(language)
+        if language is None:
+            return None
+        for node in self.getlanguageNodes():
+            if normalize_language(getXMLlang(node)) == language:
+                return node
+        return None
+
+    def _get_source_language_node(self):
+        return self._get_language_node(self._get_source_language())
+
+    def _get_target_language_node(self):
+        return self._get_language_node(self._get_target_language())
+
+    def _get_fallback_source_node(self):
+        language_nodes = self.getlanguageNodes()
+        target_node = self._get_target_language_node()
+        for node in language_nodes:
+            if node is not target_node:
+                return node
+        return self.getlanguageNode(lang=None, index=0)
+
+    def _get_fallback_target_node(self, language_nodes, source_node=None):
+        if len(language_nodes) < 2:
+            return None
+        target_node = self.getlanguageNode(lang=None, index=1)
+        if target_node is not None and target_node is not source_node:
+            return target_node
+        for node in language_nodes:
+            if node is not source_node:
+                return node
+        return None
+
+    def get_source_dom(self):
+        source_language = self._get_source_language()
+        if normalize_language(source_language) is not None:
+            return self._get_source_language_node()
+        return self._get_fallback_source_node()
+
+    def set_source_dom(self, dom_node) -> None:
+        source_node = self.get_source_dom()
+        if source_node is not None:
+            self.xmlelement.replace(source_node, dom_node)
+        else:
+            self.xmlelement.append(dom_node)
+
+    source_dom = property(get_source_dom, set_source_dom)
+
+    @property
+    def source(self):
+        return self.getNodeText(
+            self.source_dom, getXMLspace(self.xmlelement, self._default_xml_space)
+        )
+
+    @source.setter
+    def source(self, source) -> None:
+        self.setsource(source)
+
+    def setsource(self, text, sourcelang=None) -> None:
+        super().setsource(
+            text, sourcelang or self._store_language_or_default("sourcelanguage", "en")
+        )
+
+    def set_target_dom(self, dom_node, append=False) -> None:
+        language_nodes = self.getlanguageNodes()
+        target_node = self.get_target_dom()
+        if dom_node is None:
+            if not append and target_node is not None:
+                self.xmlelement.remove(target_node)
+            return
+
+        if append:
+            self.xmlelement.append(dom_node)
+        elif target_node is not None:
+            self.xmlelement.replace(target_node, dom_node)
+        elif not language_nodes:
+            self.xmlelement.append(dom_node)
+        else:
+            source_node = self.get_source_dom()
+            if source_node is None:
+                self.xmlelement.insert(1, dom_node)
+            else:
+                self.xmlelement.insert(self.xmlelement.index(source_node) + 1, dom_node)
+
+    def get_target_dom(self, lang=None):
+        if lang:
+            return self._get_language_node(lang)
+
+        target_language = self._get_target_language()
+        if normalize_language(target_language) is not None:
+            return self._get_target_language_node()
+
+        language_nodes = self.getlanguageNodes()
+        if len(language_nodes) == 2:
+            source_node = self._get_source_language_node()
+            if source_node is not None:
+                return (
+                    language_nodes[1]
+                    if language_nodes[0] is source_node
+                    else language_nodes[0]
+                )
+            target_node = self._get_target_language_node()
+            if target_node is not None:
+                return target_node
+            return self._get_fallback_target_node(language_nodes)
+
+        if len(language_nodes) > 2:
+            source_node = self.get_source_dom()
+            target_node = self._get_target_language_node()
+            if target_node is not None and target_node is not source_node:
+                return target_node
+            return self._get_fallback_target_node(language_nodes, source_node)
+
+        return self._get_fallback_target_node(language_nodes)
+
+    target_dom = property(get_target_dom)
+
+    def settarget(self, target, lang=None, append=False) -> None:
+        super().settarget(
+            target,
+            lang or self._store_language_or_default("targetlanguage", "xx"),
+            append=append,
+        )
+
+
 U = TypeVar("U", bound=LISAunit)
 
 

--- a/translate/storage/tbx.py
+++ b/translate/storage/tbx.py
@@ -23,7 +23,6 @@ from io import BytesIO
 from lxml import etree
 
 from translate.misc.xml_helpers import (
-    getXMLlang,
     getXMLspace,
     safely_set_text,
     setXMLlang,
@@ -31,13 +30,7 @@ from translate.misc.xml_helpers import (
 from translate.storage import lisa
 
 
-def _normalize_language(language: str | None) -> str | None:
-    if not language:
-        return None
-    return language.replace("_", "-").lower()
-
-
-class tbxunit(lisa.LISAunit):
+class tbxunit(lisa.MultilingualLISAunit):
     """
     A single term in the TBX file.  Provisional work is done to make several
     languages possible.
@@ -46,140 +39,6 @@ class tbxunit(lisa.LISAunit):
     rootNode = "termEntry"
     languageNode = "langSet"
     textNode = "term"
-
-    def _store_language(self, name: str) -> str | None:
-        store = getattr(self, "_store", None)
-        if store is None:
-            return None
-        return getattr(store, name, None)
-
-    def _store_language_or_default(self, name: str, default: str) -> str:
-        return self._store_language(name) or default
-
-    def _get_language_node(self, language: str | None):
-        language = _normalize_language(language)
-        if language is None:
-            return None
-        for node in self.getlanguageNodes():
-            if _normalize_language(getXMLlang(node)) == language:
-                return node
-        return None
-
-    def _get_source_language_node(self):
-        return self._get_language_node(self._store_language("sourcelanguage"))
-
-    def _get_target_language_node(self):
-        return self._get_language_node(self._store_language("targetlanguage"))
-
-    def _get_fallback_source_node(self):
-        language_nodes = self.getlanguageNodes()
-        target_node = self._get_target_language_node()
-        for node in language_nodes:
-            if node is not target_node:
-                return node
-        return self.getlanguageNode(lang=None, index=0)
-
-    def _get_fallback_target_node(self, language_nodes, source_node=None):
-        if len(language_nodes) < 2:
-            return None
-        target_node = self.getlanguageNode(lang=None, index=1)
-        if target_node is not None and target_node is not source_node:
-            return target_node
-        for node in language_nodes:
-            if node is not source_node:
-                return node
-        return None
-
-    def get_source_dom(self):
-        source_language = self._store_language("sourcelanguage")
-        if _normalize_language(source_language) is not None:
-            return self._get_source_language_node()
-        return self._get_fallback_source_node()
-
-    def set_source_dom(self, dom_node) -> None:
-        source_node = self.get_source_dom()
-        if source_node is not None:
-            self.xmlelement.replace(source_node, dom_node)
-        else:
-            self.xmlelement.append(dom_node)
-
-    source_dom = property(get_source_dom, set_source_dom)
-
-    @property
-    def source(self):
-        return self.getNodeText(
-            self.source_dom, getXMLspace(self.xmlelement, self._default_xml_space)
-        )
-
-    @source.setter
-    def source(self, source) -> None:
-        self.setsource(source)
-
-    def setsource(self, text, sourcelang=None) -> None:
-        super().setsource(
-            text, sourcelang or self._store_language_or_default("sourcelanguage", "en")
-        )
-
-    def set_target_dom(self, dom_node, append=False) -> None:
-        language_nodes = self.getlanguageNodes()
-        target_node = self.get_target_dom()
-        if dom_node is None:
-            if not append and target_node is not None:
-                self.xmlelement.remove(target_node)
-            return
-
-        if append:
-            self.xmlelement.append(dom_node)
-        elif target_node is not None:
-            self.xmlelement.replace(target_node, dom_node)
-        elif not language_nodes:
-            self.xmlelement.append(dom_node)
-        else:
-            source_node = self.get_source_dom()
-            if source_node is None:
-                self.xmlelement.insert(1, dom_node)
-            else:
-                self.xmlelement.insert(self.xmlelement.index(source_node) + 1, dom_node)
-
-    def get_target_dom(self, lang=None):
-        if lang:
-            return self._get_language_node(lang)
-
-        target_language = self._store_language("targetlanguage")
-        if _normalize_language(target_language) is not None:
-            return self._get_target_language_node()
-
-        language_nodes = self.getlanguageNodes()
-        if len(language_nodes) == 2:
-            source_node = self._get_source_language_node()
-            if source_node is not None:
-                return (
-                    language_nodes[1]
-                    if language_nodes[0] is source_node
-                    else language_nodes[0]
-                )
-            target_node = self._get_target_language_node()
-            if target_node is not None:
-                return target_node
-            return self._get_fallback_target_node(language_nodes)
-
-        if len(language_nodes) > 2:
-            source_node = self.get_source_dom()
-            target_node = self._get_target_language_node()
-            if target_node is not None and target_node is not source_node:
-                return target_node
-            return self._get_fallback_target_node(language_nodes, source_node)
-
-        return self._get_fallback_target_node(language_nodes)
-
-    target_dom = property(get_target_dom)
-
-    def settarget(self, target, lang=None, append=False) -> None:
-        super().settarget(
-            target,
-            lang or self._store_language_or_default("targetlanguage", "xx"),
-            append=append,
-        )
 
     def createlanguageNode(self, lang, text, purpose):  # ty:ignore[invalid-method-override]
         """Returns a langset xml Element setup with given parameters."""

--- a/translate/storage/tmx.py
+++ b/translate/storage/tmx.py
@@ -18,19 +18,38 @@
 
 """module for parsing TMX translation memory files."""
 
+from io import BytesIO
+
 from lxml import etree
 
 from translate import __version__
-from translate.misc.xml_helpers import safely_set_text, setXMLlang
+from translate.misc.xml_helpers import (
+    getXMLlang,
+    getXMLspace,
+    safely_set_text,
+    setXMLlang,
+)
 from translate.storage import lisa
 
 
-class tmxunit(lisa.LISAunit):
+class tmxunit(lisa.MultilingualLISAunit):
     """A single unit in the TMX file."""
 
     rootNode = "tu"
     languageNode = "tuv"
     textNode = "seg"
+
+    def _get_source_language(self) -> str | None:
+        store = getattr(self, "_store", None)
+        if store is not None and getattr(store, "_source_language_explicit", False):
+            language = super()._get_source_language()
+        else:
+            language = self.xmlelement.get("srclang")
+            if language is None:
+                language = super()._get_source_language()
+        if lisa.normalize_language(language) == "*all*":
+            return None
+        return language
 
     def createlanguageNode(self, lang, text, purpose):  # ty:ignore[invalid-method-override]
         """Returns a langset xml Element setup with given parameters."""
@@ -148,7 +167,7 @@ class tmxunit(lisa.LISAunit):
         return ""
 
 
-class tmxfile(lisa.LISAfile):
+class tmxfile(lisa.LISAfile[tmxunit]):
     """Class representing a TMX file store."""
 
     UnitClass = tmxunit
@@ -163,6 +182,73 @@ class tmxfile(lisa.LISAfile):
 <header></header>
 <body></body>
 </tmx>"""
+
+    def __init__(
+        self, inputfile=None, sourcelanguage=None, targetlanguage=None, **kwargs
+    ) -> None:
+        self._source_language_explicit = sourcelanguage is not None
+        if inputfile is None and sourcelanguage is None:
+            sourcelanguage = "en"
+        super().__init__(
+            inputfile,
+            sourcelanguage=sourcelanguage,
+            targetlanguage=targetlanguage,
+            **kwargs,
+        )
+        if inputfile is not None:
+            if self._source_language_explicit:
+                assert sourcelanguage is not None
+                self.setsourcelanguage(sourcelanguage)
+            else:
+                header = self.document.getroot().find(self.namespaced("header"))
+                self.sourcelanguage = (
+                    header.get("srclang") if header is not None else None
+                )
+            if targetlanguage is not None:
+                self.settargetlanguage(targetlanguage)
+
+    @classmethod
+    def parsestring(cls, storestring, sourcelanguage=None, targetlanguage=None):
+        if isinstance(storestring, str):
+            storestring = storestring.encode(cls.default_encoding)
+        return cls(
+            BytesIO(storestring),
+            sourcelanguage=sourcelanguage,
+            targetlanguage=targetlanguage,
+        )
+
+    def _invalidate_indexes(self) -> None:
+        self.locationindex = {}
+        self.sourceindex = {}
+        self.id_index = {}
+        self.languageindex = {}
+
+    def setsourcelanguage(self, sourcelanguage: str) -> None:
+        self._source_language_explicit = True
+        super().setsourcelanguage(sourcelanguage)
+        self._invalidate_indexes()
+
+    def settargetlanguage(self, targetlanguage: str | None) -> None:
+        super().settargetlanguage(targetlanguage)
+        self._invalidate_indexes()
+
+    def makeindex(self) -> None:
+        super().makeindex()
+        self.languageindex: dict[tuple[str, str], list[tmxunit]] = {}
+        for unit in self.units:
+            xml_space = getXMLspace(unit.xmlelement, unit._default_xml_space)
+            for language_node in unit.getlanguageNodes():
+                language = lisa.normalize_language(getXMLlang(language_node))
+                text = unit.getNodeText(language_node, xml_space)
+                if language is not None and text is not None:
+                    self.languageindex.setdefault((language, text), []).append(unit)
+
+    def addsourceunit(self, source):
+        unit = self.UnitClass(None)
+        unit._store = self
+        unit.source = source
+        self.addunit(unit)
+        return unit
 
     def addheader(self) -> None:
         headernode = next(
@@ -196,5 +282,16 @@ class tmxfile(lisa.LISAfile):
         setXMLlang(next(tuvs), translang)
 
     def translate(self, sourcetext, sourcelang=None, targetlang=None):  # ty:ignore[invalid-method-override]
-        """Method to test old unit tests."""
-        return getattr(self.findunit(sourcetext), "target", None)
+        """Return the requested translation for a source string."""
+        source_language = lisa.normalize_language(sourcelang)
+        if source_language is None:
+            unit = self.findunit(sourcetext)
+        else:
+            self.require_index()
+            units = self.languageindex.get((source_language, sourcetext))
+            unit = units[0] if units else None
+        if unit is None:
+            return None
+        if targetlang:
+            return unit.gettarget(targetlang)
+        return unit.target


### PR DESCRIPTION
TMX variants can be unordered and multilingual, so positional source and target selection can return incorrect translations. Reuse normalized LISA language matching and honor configured and TMX-declared languages.

Closes #4021