### PR TITLE
Fix multilingual TMX unit language handling, index invalidation, and add tests

### DIFF
--- a/tests/translate/storage/test_tbx.py
+++ b/tests/translate/storage/test_tbx.py
@@ -553,6 +553,22 @@ class TestTBXfile(test_base.TestTranslationStore):
         assert tbxfile.units[1].source == "English second term"
         assert tbxfile.units[1].target is None
 
+    def test_missing_source_target_insert_preserves_order_fallback(self) -> None:
+        tbxdata = self.language_selection_tbx(
+            """                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>"""
+        )
+        tbxfile = tbx.tbxfile.parsestring(
+            tbxdata, sourcelanguage="en", targetlanguage="fr"
+        )
+        unit = tbxfile.units[0]
+
+        assert unit.source is None
+        unit.target = "couleur"
+
+        reparsed = tbx.tbxfile.parsestring(bytes(tbxfile))
+        assert reparsed.units[0].source == "Farbe"
+        assert reparsed.units[0].target == "couleur"
+
     def test_multilingual_target_language_selection_without_source_match(self) -> None:
         tbxdata = self.language_selection_tbx(
             """                <langSet xml:lang="de"><tig><term>Farbe</term></tig></langSet>

--- a/tests/translate/storage/test_tmx.py
+++ b/tests/translate/storage/test_tmx.py
@@ -204,6 +204,131 @@ class TestTMXfile(test_base.TestTranslationStore):
 
         assert store.translate("test1_ar") == "test1_en"
 
+    def test_addtranslation_non_english_source_is_selectable(self) -> None:
+        tmxfile = tmx.tmxfile()
+
+        tmxfile.addtranslation("bonjour", "fr", "hallo", "de")
+
+        assert tmxfile.sourcelanguage == "en"
+        assert tmxfile.translate("bonjour") == "hallo"
+
+    def test_addtranslation_with_explicit_store_languages_keeps_text_order(
+        self,
+    ) -> None:
+        tmxfile = tmx.tmxfile(sourcelanguage="en", targetlanguage="de")
+
+        tmxfile.addtranslation("bonjour", "fr", "hallo", "de")
+
+        unit = tmxfile.units[0]
+        assert unit.gettarget("fr") == "bonjour"
+        assert unit.gettarget("de") == "hallo"
+
+    def test_addtranslation_target_language_matching_source_is_preserved(
+        self,
+    ) -> None:
+        tmxfile = tmx.tmxfile(sourcelanguage="en", targetlanguage="de")
+
+        tmxfile.addtranslation("hallo", "de", "bonjour", "fr")
+
+        unit = tmxfile.units[0]
+        assert unit.gettarget("de") == "hallo"
+        assert unit.gettarget("fr") == "bonjour"
+
+    def test_addtranslation_keeps_existing_implicit_source_selection(self) -> None:
+        store = tmx.tmxfile.parsestring(self.multilingual_tmx())
+
+        store.addtranslation("bonjour", "fr", "hallo", "de")
+
+        assert store.sourcelanguage == "en"
+        assert store.units[0].source == "test1_en"
+        assert store.translate("bonjour", sourcelang="fr", targetlang="de") == "hallo"
+
+    def test_unit_source_setter_preserves_unit_source_language(self) -> None:
+        source = self.language_selection_tmx(
+            """        <tu tuid="test" srclang="ar">
+            <tuv xml:lang="en"><seg>English</seg></tuv>
+            <tuv xml:lang="ar"><seg>Arabic</seg></tuv>
+        </tu>"""
+        )
+        store = tmx.tmxfile.parsestring(source)
+        unit = store.units[0]
+
+        unit.source = "Updated Arabic"
+
+        assert unit.gettarget("ar") == "Updated Arabic"
+        assert unit.source == "Updated Arabic"
+        assert unit.gettarget("en") == "English"
+
+    def test_language_index_is_invalidated_when_variant_text_changes(self) -> None:
+        store = tmx.tmxfile.parsestring(
+            self.multilingual_tmx(), sourcelanguage="en", targetlanguage="de"
+        )
+        assert store.translate("test1_de", sourcelang="de", targetlang="en") == (
+            "test1_en"
+        )
+
+        store.units[0].settarget("Guten Tag", "de")
+
+        assert store.translate("Guten Tag", sourcelang="de", targetlang="en") == (
+            "test1_en"
+        )
+        assert store.translate("test1_de", sourcelang="de", targetlang="en") is None
+
+    def test_new_target_is_inserted_after_tu_metadata(self) -> None:
+        source = self.language_selection_tmx(
+            """        <tu tuid="test">
+            <note>Note</note>
+            <prop type="x-context">Context</prop>
+            <tuv xml:lang="en"><seg>English</seg></tuv>
+        </tu>""",
+            srclang="fr",
+        )
+        store = tmx.tmxfile.parsestring(
+            source, sourcelanguage="ar", targetlanguage="de"
+        )
+
+        store.units[0].target = "Deutsch"
+
+        assert [
+            child.tag.rsplit("}", 1)[-1] for child in store.units[0].xmlelement
+        ] == [
+            "note",
+            "prop",
+            "tuv",
+            "tuv",
+        ]
+        assert store.units[0].gettarget("de") == "Deutsch"
+
+    def test_missing_source_target_preserves_order_fallback(self) -> None:
+        source = self.language_selection_tmx(
+            """        <tu tuid="test">
+            <tuv xml:lang="de"><seg>Farbe</seg></tuv>
+        </tu>""",
+            srclang="*all*",
+        )
+        store = tmx.tmxfile.parsestring(
+            source, sourcelanguage="en", targetlanguage="fr"
+        )
+        unit = store.units[0]
+
+        assert unit.source is None
+        unit.target = "couleur"
+
+        reparsed = tmx.tmxfile.parsestring(bytes(store))
+        assert reparsed.units[0].source == "Farbe"
+        assert reparsed.units[0].target == "couleur"
+
+    def test_translate_fallback_excludes_per_call_source_language(self) -> None:
+        source = self.language_selection_tmx(
+            """        <tu tuid="test">
+            <tuv xml:lang="ar"><seg>Arabic</seg></tuv>
+            <tuv xml:lang="en"><seg>English</seg></tuv>
+        </tu>"""
+        )
+        store = tmx.tmxfile.parsestring(source)
+
+        assert store.translate("Arabic", sourcelang="ar") == "English"
+
     def test_addtranslation(self) -> None:
         """Tests that addtranslation() stores strings correctly."""
         tmxfile = tmx.tmxfile()

--- a/translate/storage/lisa.py
+++ b/translate/storage/lisa.py
@@ -352,14 +352,27 @@ class MultilingualLISAunit(LISAunit):
     def source(self, source) -> None:
         self.setsource(source)
 
+    def _invalidate_store_indexes(self) -> None:
+        store = getattr(self, "_store", None)
+        if store is not None:
+            if hasattr(store, "_invalidate_indexes"):
+                store._invalidate_indexes()
+            else:
+                store.locationindex = {}
+                store.sourceindex = {}
+                store.id_index = {}
+
     def setsource(self, text, sourcelang=None) -> None:
-        super().setsource(
-            text, sourcelang or self._store_language_or_default("sourcelanguage", "en")
-        )
+        super().setsource(text, sourcelang or self._get_source_language() or "en")
+        self._invalidate_store_indexes()
 
     def set_target_dom(self, dom_node, append=False) -> None:
         language_nodes = self.getlanguageNodes()
-        target_node = self.get_target_dom()
+        target_node = (
+            self._get_language_node(getXMLlang(dom_node))
+            if dom_node is not None
+            else self.get_target_dom()
+        )
         if dom_node is None:
             if not append and target_node is not None:
                 self.xmlelement.remove(target_node)
@@ -373,10 +386,12 @@ class MultilingualLISAunit(LISAunit):
             self.xmlelement.append(dom_node)
         else:
             source_node = self.get_source_dom()
-            if source_node is None:
-                self.xmlelement.insert(1, dom_node)
+            insert_index = self.xmlelement.index(language_nodes[0])
+            if source_node is not None:
+                insert_index = self.xmlelement.index(source_node) + 1
             else:
-                self.xmlelement.insert(self.xmlelement.index(source_node) + 1, dom_node)
+                insert_index += 1
+            self.xmlelement.insert(insert_index, dom_node)
 
     def get_target_dom(self, lang=None):
         if lang:
@@ -412,11 +427,31 @@ class MultilingualLISAunit(LISAunit):
     target_dom = property(get_target_dom)
 
     def settarget(self, target, lang=None, append=False) -> None:
-        super().settarget(
-            target,
-            lang or self._store_language_or_default("targetlanguage", "xx"),
-            append=append,
+        if self._rich_target is not None:
+            self._rich_target = None
+        target_language = lang or self._store_language_or_default(
+            "targetlanguage", "xx"
         )
+        language_node = (
+            self._get_language_node(target_language)
+            if lang is not None
+            else self.target_dom
+        )
+        if target is not None:
+            if language_node is None:
+                language_node = self.createlanguageNode(
+                    target_language, target, "target"
+                )
+                self.set_target_dom(language_node, append)
+            else:
+                if self.textNode:
+                    terms = language_node.iter(self.namespaced(self.textNode))
+                    with contextlib.suppress(StopIteration):
+                        language_node = next(terms)
+                language_node.text = target
+        elif language_node is not None:
+            self.xmlelement.remove(language_node)
+        self._invalidate_store_indexes()
 
 
 U = TypeVar("U", bound=LISAunit)

--- a/translate/storage/tmx.py
+++ b/translate/storage/tmx.py
@@ -186,7 +186,8 @@ class tmxfile(lisa.LISAfile[tmxunit]):
     def __init__(
         self, inputfile=None, sourcelanguage=None, targetlanguage=None, **kwargs
     ) -> None:
-        self._source_language_explicit = sourcelanguage is not None
+        source_language_explicit = sourcelanguage is not None
+        self._source_language_explicit = source_language_explicit
         if inputfile is None and sourcelanguage is None:
             sourcelanguage = "en"
         super().__init__(
@@ -195,6 +196,7 @@ class tmxfile(lisa.LISAfile[tmxunit]):
             targetlanguage=targetlanguage,
             **kwargs,
         )
+        self._source_language_explicit = source_language_explicit
         if inputfile is not None:
             if self._source_language_explicit:
                 assert sourcelanguage is not None
@@ -243,10 +245,12 @@ class tmxfile(lisa.LISAfile[tmxunit]):
                 if language is not None and text is not None:
                     self.languageindex.setdefault((language, text), []).append(unit)
 
-    def addsourceunit(self, source):
+    def addsourceunit(self, source, sourcelang=None):
         unit = self.UnitClass(None)
         unit._store = self
-        unit.source = source
+        if sourcelang is not None:
+            unit.xmlelement.set("srclang", sourcelang)
+        unit.setsource(source, sourcelang)
         self.addunit(unit)
         return unit
 
@@ -270,16 +274,12 @@ class tmxfile(lisa.LISAfile[tmxunit]):
         self, source, srclang, translation, translang, comment=None, context=None
     ) -> None:
         """Addtranslation method for testing old unit tests."""
-        unit = self.addsourceunit(source)
-        unit.target = translation
+        unit = self.addsourceunit(source, srclang)
+        unit.settarget(translation, translang, append=True)
         if comment is not None and len(comment) > 0:
             unit.addnote(comment)
         if context is not None and len(context) > 0:
             unit.setcontext(context)
-
-        tuvs = unit.xmlelement.iterdescendants(self.namespaced("tuv"))
-        setXMLlang(next(tuvs), srclang)
-        setXMLlang(next(tuvs), translang)
 
     def translate(self, sourcetext, sourcelang=None, targetlang=None):  # ty:ignore[invalid-method-override]
         """Return the requested translation for a source string."""
@@ -294,4 +294,12 @@ class tmxfile(lisa.LISAfile[tmxunit]):
             return None
         if targetlang:
             return unit.gettarget(targetlang)
+        if source_language is not None and self.targetlanguage is None:
+            source_node = unit._get_language_node(source_language)
+            target_node = unit._get_fallback_target_node(
+                unit.getlanguageNodes(), source_node
+            )
+            return unit.getNodeText(
+                target_node, getXMLspace(unit.xmlelement, unit._default_xml_space)
+            )
         return unit.target


### PR DESCRIPTION
### Motivation
- Ensure correct source/target selection and index invalidation for multilingual TMX units when language variants are added or changed.
- Make `addtranslation` and `addsourceunit` preserve and expose non-English implicit source selection and srclang metadata.
- Ensure new target nodes are inserted in the proper position relative to existing language nodes and TU metadata.

### Description
- Added `_invalidate_store_indexes` to `MultilingualLISAunit` and call it from `setsource` and `settarget` to keep store indexes in sync when unit text changes, and replaced store-default source fallback in `setsource` with `_get_source_language()`.
- Adjusted `set_target_dom` insertion logic to insert a new target node at the index of the first language node when no explicit source node exists instead of a hard-coded position.
- Modified `tmxfile.__init__` to preserve whether the source language was explicitly provided during construction and apply it after base initialization.
- Extended `addsourceunit` to accept an optional `sourcelang` and set the TU `srclang` attribute, and updated `addtranslation` to use the new signature and to set the target via `settarget` (so indexes are invalidated correctly).
- Enhanced `translate` to handle per-call `sourcelang` when the file-level `targetlanguage` is unset by returning the appropriate fallback target node text rather than the unit-level `target` property.
- Added multiple unit tests in `tests/translate/storage/test_tmx.py` covering non-English source selection, implicit source retention, unit source setter behavior, language index invalidation on variant changes, correct insertion order for new targets after TU metadata, and fallback exclusion of per-call source language.

### Testing
- Ran the TMX storage unit tests in `tests/translate/storage/test_tmx.py`, including the newly added tests, and they all passed.
- Ran affected translation store unit tests exercising `addtranslation`, `translate`, and language-indexing behavior and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72b6e8a9588329a3da22a09037a8c8)