### PR TITLE
feat(toml): migrate from tomlkit to tomlrt

### DIFF
--- a/docs/formats/toml.rst
+++ b/docs/formats/toml.rst
@@ -86,7 +86,7 @@ Supported Features
 * **Comments**: Developer comments are extracted as translator notes
 * **String types**: Basic strings, literal strings (single quotes), and
   multiline strings (triple quotes)
-* **Formatting preservation**: tomlkit library preserves original formatting
+* **Formatting preservation**: tomlrt library preserves original formatting
   during round-trips
 * **Plurals** (Go i18n only): CLDR plural categories
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ subtitles = [
   "aeidon>=1.15,<2.1"
 ]
 toml = [
-  "tomlkit>=0.13.0,<0.16.0"
+  "tomlrt>=2.2.2,<3.0"
 ]
 yaml = [
   "ruamel.yaml>=0.19.1,<0.20.0"

--- a/tests/translate/storage/test_toml.py
+++ b/tests/translate/storage/test_toml.py
@@ -28,6 +28,19 @@ class TestTOMLResourceStore(test_monolingual.TestMonolingualStore):
         store.parse("")
         assert bytes(store) == b""
 
+    def test_crlf_line_endings(self) -> None:
+        """Test that CRLF line endings survive a roundtrip."""
+        store = self.StoreClass()
+        store.parse(b'key = "value"\r\nother = "second"\r\n')
+        store.units[0].target = "changed"
+        assert bytes(store) == b'key = "changed"\r\nother = "second"\r\n'
+
+    def test_missing_trailing_newline(self) -> None:
+        """Test that a missing trailing newline is added using the file's endings."""
+        store = self.StoreClass()
+        store.parse(b'key = "value"\r\nother = "second"')
+        assert bytes(store) == b'key = "value"\r\nother = "second"\r\n'
+
     def test_edit(self) -> None:
         store = self.StoreClass()
         store.parse('key = "value"')
@@ -303,9 +316,10 @@ key2 = "value2"
         store = self.StoreClass()
         store.parse(data)
         assert len(store.units) == 2
-        # TOML comments are line-by-line, need to check the actual behavior
-        # For now, we expect the first line of comment
-        assert "This is a comment for key1" in store.units[0].getnotes()
+        assert store.units[0].getnotes() == (
+            "This is a comment for key1\nwith multiple lines\nexplaining the key"
+        )
+        assert store.units[1].getnotes() == "Another comment\nfor key2"
 
     def test_no_comment_backwards_compat(self) -> None:
         """Test that TOML without comments still works."""
@@ -317,6 +331,53 @@ key2 = "value2"
         assert len(store.units) == 2
         assert store.units[0].getnotes() == ""
         assert store.units[1].getnotes() == ""
+
+    def test_comment_extraction_nested(self) -> None:
+        """Test extracting comments for keys nested inside a table."""
+        data = """# Comment above the section
+[section]
+# Comment for nested key
+key = "value"
+"""
+        store = self.StoreClass()
+        store.parse(data)
+        assert len(store.units) == 1
+        assert store.units[0].getid() == "section.key"
+        assert store.units[0].getnotes() == "Comment for nested key"
+
+    def test_comment_extraction_list(self) -> None:
+        """Test extracting comments for individual array elements."""
+        data = """items = [
+    # first item
+    "a",
+    # second item
+    "b",
+]
+"""
+        store = self.StoreClass()
+        store.parse(data)
+        assert len(store.units) == 2
+        assert store.units[0].getnotes() == "first item"
+        assert store.units[1].getnotes() == "second item"
+        assert bytes(store).decode() == data
+
+    def test_comment_extraction_blank_separated(self) -> None:
+        """Test that only comments directly above a key become notes."""
+        data = """a = "1"
+
+# banner separated by a blank line
+
+# attached note
+b = "2"
+"""
+        store = self.StoreClass()
+        store.parse(data)
+        assert len(store.units) == 2
+        assert store.units[0].getnotes() == ""
+        # A blank line detaches the banner, so only the attached run is a note
+        assert store.units[1].getnotes() == "attached note"
+        # Both comments still survive the roundtrip untouched
+        assert bytes(store).decode() == data
 
     def test_comment_preservation_simple(self) -> None:
         """Test that comments are preserved during roundtrip."""
@@ -334,10 +395,8 @@ key2 = "value2"
         assert store.units[0].getnotes() == "This is a comment for key1"
         assert store.units[1].getnotes() == "This is a comment for key2"
 
-        # Roundtrip should preserve comments
-        output = bytes(store).decode("utf-8")
-        assert "# This is a comment for key1" in output
-        assert "# This is a comment for key2" in output
+        # Roundtrip should be byte for byte identical
+        assert bytes(store).decode("utf-8") == data
 
     def test_comment_preservation_multiline(self) -> None:
         """Test that multi-line comments are preserved during roundtrip."""
@@ -350,11 +409,8 @@ key1 = "value1"
         store.parse(data)
         assert len(store.units) == 1
 
-        # Roundtrip should preserve all comment lines
-        output = bytes(store).decode("utf-8")
-        assert "# This is a comment for key1" in output
-        assert "# with multiple lines" in output
-        assert "# explaining the key" in output
+        # Roundtrip should be byte for byte identical
+        assert bytes(store).decode("utf-8") == data
 
     def test_comment_preservation_nested(self) -> None:
         """Test that comments are preserved in nested structures."""
@@ -368,9 +424,8 @@ key = "value"
         store.parse(data)
         assert len(store.units) == 1
 
-        # Roundtrip should preserve comments
-        output = bytes(store).decode("utf-8")
-        assert "# Top-level comment" in output or "# Comment for nested key" in output
+        # Roundtrip should be byte for byte identical
+        assert bytes(store).decode("utf-8") == data
 
     def test_comment_preservation_with_modification(self) -> None:
         """Test that comments are preserved when values are modified."""
@@ -383,10 +438,10 @@ key1 = "original value"
         # Modify the value
         store.units[0].target = "modified value"
 
-        # Roundtrip should preserve comment
-        output = bytes(store).decode("utf-8")
-        assert "# This is a comment" in output
-        assert "modified value" in output
+        # Only the value should change, everything else is untouched
+        assert bytes(store).decode("utf-8") == data.replace(
+            "original value", "modified value"
+        )
 
     def test_literal_string(self) -> None:
         """Test TOML literal strings (single quotes)."""
@@ -406,7 +461,8 @@ The quick brown fox jumps over the lazy dog."""
         store = self.StoreClass()
         store.parse(data)
         assert len(store.units) == 1
-        assert "The quick brown fox" in store.units[0].source
+        assert store.units[0].source == "The quick brown fox jumps over the lazy dog."
+        assert bytes(store).decode() == data
 
     def test_multiline_literal_string(self) -> None:
         """Test TOML multiline literal strings (triple single quotes)."""
@@ -420,8 +476,11 @@ trimmed in raw strings.
         store = self.StoreClass()
         store.parse(data)
         assert len(store.units) == 1
-        assert "The first newline is" in store.units[0].source
-        assert "preserved" in store.units[0].source
+        assert store.units[0].source == (
+            "The first newline is\ntrimmed in raw strings.\n"
+            "   All other whitespace\n   is preserved.\n"
+        )
+        assert bytes(store).decode() == data
 
 
 class TestGoI18nTOMLResourceStore(test_monolingual.TestMonolingualStore):
@@ -508,9 +567,10 @@ other = "You have {{ .Count }} messages"
 
         store.units[0].target = multistring(["Un mensaje", "{{ .Count }} mensajes"])
 
-        result = bytes(store).decode("utf-8")
-        assert 'one = "Un mensaje"' in result
-        assert 'other = "{{ .Count }} mensajes"' in result
+        # Only the values should change, the layout is untouched
+        assert bytes(store).decode("utf-8") == (
+            '[messages]\none = "Un mensaje"\nother = "{{ .Count }} mensajes"\n'
+        )
 
     def test_unknown_language_single_plural_uses_other(self) -> None:
         """Test that unknown one-form plurals serialize as CLDR other."""
@@ -521,9 +581,9 @@ other = "You have {{ .Count }} messages"
         unit.setid("messages")
         store.addunit(unit)
 
-        result = bytes(store).decode("utf-8")
-        assert '[messages]\nother = "You have messages"' in result
-        assert "one =" not in result
+        assert (
+            bytes(store).decode("utf-8") == '[messages]\nother = "You have messages"\n'
+        )
 
     def test_mixed_content(self) -> None:
         """Test file with both regular and pluralized entries."""
@@ -595,6 +655,28 @@ View our <a href="/trademarks/">trademark policy</a>.
             'View our <a href="/privacy/">privacy policy</a>.' in store.units[2].source
         )
 
+    def test_comment_extraction_array_of_tables(self) -> None:
+        """Test extracting comments from array-of-tables entry headers."""
+        data = """# note for first entry
+[[messages]]
+one = "One minute"
+other = "{{ .Count }} minutes"
+
+# note for second entry
+[[messages]]
+other = "Hello"
+"""
+        store = self.StoreClass()
+        store.parse(data)
+        assert len(store.units) == 2
+        assert store.units[0].getid() == "messages[0]"
+        assert store.units[0].hasplural()
+        assert store.units[0].getnotes() == "note for first entry"
+        assert store.units[1].getid() == "messages[1]"
+        assert not store.units[1].hasplural()
+        assert store.units[1].getnotes() == "note for second entry"
+        assert bytes(store).decode() == data
+
     def test_comment_preservation_goi18n(self) -> None:
         """Test that comments are preserved in Go i18n format."""
         data = """# See https://github.com/nicksnyder/go-i18n for format documentation
@@ -610,11 +692,13 @@ other = "Get Started"
         store.parse(data)
         assert len(store.units) == 2
 
-        # Roundtrip should preserve at least top-level comments
-        output = bytes(store).decode("utf-8")
-        assert "# See https://github.com/nicksnyder/go-i18n" in output
-        # First table's comment should be preserved
-        assert "# Welcome message for the home page" in output
+        # A table is a single unit, so its header comment is that unit's note.
+        # The opening paragraph is the file preamble and belongs to no unit.
+        assert store.units[0].getnotes() == "Welcome message for the home page"
+        assert store.units[1].getnotes() == ""
+
+        # Roundtrip should be byte for byte identical
+        assert bytes(store).decode("utf-8") == data
 
     def test_comment_preservation_goi18n_plural(self) -> None:
         """Test that comments are preserved with plural forms."""
@@ -627,7 +711,7 @@ other = "{{ .Count }} minutes to read"
         store.parse(data)
         assert len(store.units) == 1
         assert store.units[0].hasplural()
+        assert store.units[0].getnotes() == "Comment about reading time"
 
-        # Roundtrip should preserve comments
-        output = bytes(store).decode("utf-8")
-        assert "# Comment about reading time" in output
+        # Roundtrip should be byte for byte identical
+        assert bytes(store).decode("utf-8") == data

--- a/translate/storage/base.py
+++ b/translate/storage/base.py
@@ -1354,6 +1354,8 @@ class UnitId:
 
 class DictUnit(TranslationUnit):
     IdClass = UnitId
+    # Factory for mappings created while serializing nested values.
+    dict_factory: Callable[[], dict] = dict
 
     def __init__(self, source=None) -> None:
         super().__init__(source)
@@ -1373,13 +1375,13 @@ class DictUnit(TranslationUnit):
         for pos, part in enumerate(parts[:-1]):
             element, key = part
             use_list = parts[pos + 1][0] == "index"
-            default = [] if use_list else {}
+            default = list if use_list else self.dict_factory
             if element == "index":
                 while len(target) <= key and not unset:
-                    target.append(default.copy())
+                    target.append(default())
             elif element == "key":
                 if key not in target:
-                    target[key] = default
+                    target[key] = default()
             else:
                 raise ValueError(f"Unsupported element: {element}")
             if not use_list and isinstance(target[key], list):
@@ -1390,7 +1392,7 @@ class DictUnit(TranslationUnit):
                 target[key] = []
             elif not isinstance(target[key], list if use_list else dict):
                 # Replace a stale scalar when the structure has changed
-                target[key] = default.copy()
+                target[key] = default()
             parent = target
             target = target[key]
         if override_key:

--- a/translate/storage/toml.py
+++ b/translate/storage/toml.py
@@ -21,12 +21,10 @@ r"""Class that manages TOML data files for translation."""
 from __future__ import annotations
 
 import uuid
+from io import BytesIO
 from typing import IO, TYPE_CHECKING, Any, cast
 
-from tomlkit import TOMLDocument, document, loads
-from tomlkit.exceptions import TOMLKitError
-from tomlkit.items import AbstractTable
-from tomlkit.items import Comment as TOMLComment
+from tomlrt import Array, Document, Table, TOMLError, dump, load
 
 from translate.lang.data import cldr_plural_categories
 from translate.misc.multistring import multistring
@@ -34,7 +32,6 @@ from translate.storage import base
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-    from io import BytesIO
 
 
 class TOMLUnit(base.DictUnit):
@@ -43,6 +40,9 @@ class TOMLUnit(base.DictUnit):
 
     Represents a single translatable string extracted from a TOML file.
     """
+
+    # New nested mappings are rendered as ``[section]`` blocks, not inline tables.
+    dict_factory = Table.section
 
     def __init__(self, source=None, **kwargs) -> None:
         """Initialize a TOML unit with optional source text."""
@@ -97,7 +97,7 @@ class TOMLFile(base.DictStore[TOMLUnit]):
     A TOML localization file.
 
     Handles plain TOML files with key-value pairs and nested structures.
-    Uses tomlkit library to preserve formatting and comments during roundtrips.
+    Uses tomlrt library to preserve formatting and comments during roundtrips.
     """
 
     UnitClass = TOMLUnit
@@ -110,9 +110,9 @@ class TOMLFile(base.DictStore[TOMLUnit]):
         if inputfile is not None:
             self.parse(inputfile)
 
-    def get_root_node(self) -> TOMLDocument:
+    def get_root_node(self) -> Document:
         """Return an empty root node for serialization."""
-        return document()
+        return Document()
 
     def serialize(self, out: IO[bytes]) -> None:
         """Serialize the store to a file."""
@@ -122,76 +122,26 @@ class TOMLFile(base.DictStore[TOMLUnit]):
 
         self.serialize_units(self._original)
 
-        # Convert TOMLDocument to string
-        result = self._original.as_string()
-        # Add trailing newline if not empty and not already present
-        if result and not result.endswith("\n"):
-            result += "\n"
-
-        # Write to file
-        out.write(result.encode(self.encoding))
-
-    def _get_key_comment(
-        self, table: AbstractTable | TOMLDocument | None, key: str | int | None
-    ) -> str | None:
-        """
-        Extract the comment that appears before a key in a TOML table.
-
-        TOML comments appear in the body as (None, Comment) tuples.
-        Returns comment text without the '#' prefix, or None if no comment.
-        """
-        if not isinstance(table, (AbstractTable, TOMLDocument)):
-            return None
-
-        # Check if the table has a body attribute
-        if not hasattr(table, "body"):
-            return None
-
-        # Find comments that appear before this key in the body
-        comments = []
-
-        for item in table.body:  # ty:ignore[not-iterable]
-            if not isinstance(item, tuple) or len(item) != 2:
-                continue
-
-            item_key, item_value = item
-
-            # If this is our key, we found it
-            if item_key is not None and str(item_key).strip() == str(key):
-                # Return the collected comments for this key
-                return "\n".join(comments) if comments else None
-
-            # If we hit another key before finding ours, reset comments
-            if item_key is not None:
-                comments = []
-                continue
-
-            # Collect comments that appear before our key
-            # Check if this is a Comment (not Whitespace)
-            if item_key is None and isinstance(item_value, TOMLComment):
-                # Get the comment text directly
-                comment_text = str(item_value)
-                if comment_text.startswith("#"):
-                    comments.append(comment_text[1:].strip())
-
-        return None
+        dump(self._original, out)
 
     def _parse_dict(
         self,
-        data: AbstractTable | TOMLDocument,
+        data: Table | Document,
         prev: base.UnitId,
-    ) -> Generator[tuple[base.UnitId, str, str | None]]:
+    ) -> Generator[tuple[base.UnitId, str, str]]:
         """Parse a TOML table/dictionary recursively, yielding units."""
+        comments = data.leading_comments
         for k, v in data.items():
-            yield from self._flatten(v, prev.extend("key", k), parent_map=data, key=k)
+            yield from self._flatten(
+                v, prev.extend("key", k), comment="\n".join(comments.get(k, ()))
+            )
 
     def _flatten(
         self,
-        data: AbstractTable | TOMLDocument,
+        data: Any,
         prev: base.UnitId | None = None,
-        parent_map: AbstractTable | TOMLDocument | None = None,
-        key: str | int | None = None,
-    ) -> Generator[tuple[base.UnitId, str, str | None]]:
+        comment: str = "",
+    ) -> Generator[tuple[base.UnitId, str, str]]:
         """
         Flatten TOML structure recursively into translatable units.
 
@@ -200,16 +150,19 @@ class TOMLFile(base.DictStore[TOMLUnit]):
         """
         if prev is None:
             prev = self.UnitClass.IdClass([])
-        if isinstance(data, (AbstractTable, TOMLDocument)):
+        if isinstance(data, dict):
             yield from self._parse_dict(data, prev)
         elif isinstance(data, str):
-            yield (prev, data, self._get_key_comment(parent_map, key))
+            yield (prev, data, comment)
         elif isinstance(data, (bool, int, float)):
-            yield (prev, str(data), self._get_key_comment(parent_map, key))
+            yield (prev, str(data), comment)
         elif isinstance(data, list):
+            # Only an Array carries element comments; an AoT keeps them on the
+            # headers of its entries, which _parse_dict reads.
+            comments = data.leading_comments if isinstance(data, Array) else {}
             for k, v in enumerate(data):
                 yield from self._flatten(
-                    v, prev.extend("index", k), parent_map=data, key=k
+                    v, prev.extend("index", k), comment="\n".join(comments.get(k, ()))
                 )
         elif data is None:
             pass
@@ -236,11 +189,15 @@ class TOMLFile(base.DictStore[TOMLUnit]):
             src = input.read()  # ty:ignore[call-non-callable]
             input.close()  # ty:ignore[unresolved-attribute]
             input = src
-        if isinstance(input, bytes):
-            input = input.decode(self.encoding)
+        if isinstance(input, str):
+            # TOML is defined to be UTF-8, load() decodes it as such.
+            input = input.encode("utf-8")
+        if input and not input.endswith(b"\n"):
+            # Ensure output ends with a newline, matching the file's line endings.
+            input += b"\r\n" if b"\r\n" in input else b"\n"
         try:
-            self._original = loads(input)
-        except TOMLKitError as e:
+            self._original = load(BytesIO(input))
+        except TOMLError as e:
             raise base.ParseError(e) from e
 
         for k, data, comment in self._flatten(self._original):
@@ -269,28 +226,26 @@ class GoI18nTOMLUnit(TOMLUnit):
         """Check if this unit contains plural strings (more than one form)."""
         return isinstance(self.target, multistring) and len(self.target.strings) > 1
 
-    def convert_target(self) -> str | dict[str, str | None]:
+    def convert_target(self) -> Table:
         """
         Convert the target value for serialization.
 
-        For Go i18n format, returns a dict with CLDR plural category keys.
+        For Go i18n format, returns a table with CLDR plural category keys.
         Singular strings are wrapped in {"other": value} to preserve structure.
         """
         if not isinstance(self.target, multistring):
-            # For Go i18n format, even singular strings should be in a dict with "other" key
-            # to preserve the table structure
-            return {"other": self.target}
+            # For Go i18n format, even singular strings should be in a table with "other"
+            # key to preserve the table structure
+            return Table.section({"other": self.target})
 
         tags = self._store.get_plural_tags(self.target)  # ty:ignore[unresolved-attribute]
 
-        # Sync plural_strings elements to plural_tags count.
+        # Sync plural_strings elements to plural_tags count. TOML has no null, so
+        # untranslated forms are serialized as blank strings.
         strings = self.sync_plural_count(self.target, tags)
-        if any(strings):
-            # Replace blank strings by None to distinguish not completed translations
-            strings = [string or None for string in strings]
 
-        # Return a dict with plural tags as keys
-        return dict(zip(tags, strings, strict=True))
+        # Return a table with plural tags as keys
+        return Table.section(dict(zip(tags, strings, strict=True)))
 
 
 class GoI18nTOMLFile(TOMLFile):
@@ -318,18 +273,22 @@ class GoI18nTOMLFile(TOMLFile):
 
     def _parse_dict(
         self,
-        data: AbstractTable | TOMLDocument,
+        data: Table | Document,
         prev: base.UnitId,
-    ) -> Generator[tuple[base.UnitId, str | multistring, str | None]]:
+    ) -> Generator[tuple[base.UnitId, str | multistring, str]]:
         """
         Parse a TOML table, checking for plural forms.
 
         Detects pluralized strings where all keys are CLDR plural categories.
         Special case: a table with only "other" key is treated as singular.
+
+        Such a table is a single unit, so its header comment is that unit's note.
         """
+        header_comment = "\n".join(data.header_leading_comments)
+
         # Special case: table with only "other" key is treated as singular
         if data and len(data) == 1 and "other" in data:
-            yield (prev, str(data["other"]), None)
+            yield (prev, str(data["other"]), header_comment)
             return
 
         # Does this look like a plural?
@@ -344,7 +303,7 @@ class GoI18nTOMLFile(TOMLFile):
             # Skip blank values (all plurals are None or empty)
             if values and not all(not value for value in values):
                 # Use blank string instead of None for missing forms
-                yield (prev, multistring(values), None)
+                yield (prev, multistring(values), header_comment)
 
             return
 


### PR DESCRIPTION
Hi -

I have been working on [tomlrt](https://pypi.org/project/tomlrt/), which is a project occupying roughly the same space as tomlkit: but hopefully with a simpler API (and faster, and less buggy).

Mostly for my own interest, I experimented with migrating this project to tomlrt - but I think it turned out to be a good enough fit that it is worth offering you this pull request.  

The tomlrt comment API saves a lot of grubbing around in internal tomlkit types.  Per the commit message and new tests: we have fixed a few bugs along the way.

(re "Only comments directly above a key become notes...".  If the old behaviour of including earlier comments separated by blank lines from the value was intended: tomlrt can do that too).

Do feel free to close out if this is of no interest, you might reasonably think that you have tomlkit working well enough already and do not need to risk change.

---

tomlrt parses into plain dicts, lists and scalars, and exposes comments as mapping views, so the storage layer no longer works against CST wrapper types. Behaviour changes worth noting:

- Comments on keys inside a [section] now become notes. _get_key_comment walked tomlkit's CST behind a hasattr(table, "body") guard that was always False for a Table, so these were silently always dropped. Array elements and Go i18n section headers now get notes too.

- Only comments directly above a key become notes. Previously a banner separated by a blank line was swept into the following key's note.

- Go i18n untranslated plural forms serialize as empty strings. They were substituted with None, which TOML cannot represent, so serializing raised.

- Serializing uses tomlrt.dump, which keeps the file's line endings. A CRLF file missing a trailing newline is no longer given an LF one.

Reading and writing go through load/dump, which are always UTF-8 as the TOML spec requires, so the store's encoding setting is no longer used.

DictUnit gains dict_factory so a format can pick the mapping type built while serializing nested values; tomlrt renders a plain dict as an inline table, and TOML localization files want [section] blocks.

Round-trip tests only checked that some comments appeared somewhere in the output. They now assert the output exactly.