### PR TITLE
fix(pypo): honor the file's newline style in previous msgid comments

### DIFF
--- a/tests/translate/storage/test_pypo.py
+++ b/tests/translate/storage/test_pypo.py
@@ -938,6 +938,19 @@ msgstr "fichier"
         assert pofile.units[0].getnotes() == "Note!"
         assert bytes(pofile) == posource
 
+    def test_dos_newlines_prev_msgid(self) -> None:
+        """Checks that previous msgid comments honor dos newlines."""
+        posource = (
+            b"#, fuzzy\r\n"
+            b'#| msgid "Encryption"\r\n'
+            b'msgid "256-bit encryption"\r\n'
+            b'msgstr "test"\r\n'
+        )
+        pofile = self.poparse(posource)
+        assert len(pofile.units) == 1
+        assert pofile.units[0].prev_source == "Encryption"
+        assert bytes(pofile) == posource
+
     def test_mac_newlines(self) -> None:
         """Checks that mac newlines are properly parsed."""
         posource = b'msgid "test me"\rmsgstr ""\r'

--- a/translate/storage/pypo.py
+++ b/translate/storage/pypo.py
@@ -769,8 +769,8 @@ class pounit(pocommon.pounit):
 
         def add_prev_msgid_lines(lines, prefix, header, var) -> None:
             if var:
-                lines.append(f"{prefix} {header} {var[0]}\n")
-                lines.extend(f"{prefix} {line}\n" for line in var[1:])
+                lines.append(f"{prefix} {header} {var[0]}{self.newline}")
+                lines.extend(f"{prefix} {line}{self.newline}" for line in var[1:])
 
         def add_prev_msgid_info(lines, prefix) -> None:
             add_prev_msgid_lines(lines, prefix, "msgctxt", self.prev_msgctxt)


### PR DESCRIPTION
`PoUnit._getoutput`'s `add_prev_msgid_lines` writes `#| msgid …` (previous msgid) comment lines with a hard-coded `\n`, while every other line honors the newline style detected at parse time (`self.newline`). A CRLF catalog that carries fuzzy history therefore round-trips to mixed line endings, which gettext parsers reject.

Minimal reproduction:

```python
from translate.storage.po import pofile

content = (
    b'#, fuzzy\r\n'
    b'#| msgid "Encryption"\r\n'
    b'msgid "256-bit encryption"\r\n'
    b'msgstr "Xifratge"\r\n'
)
print(bytes(pofile.parsestring(content)))
# b'#, fuzzy\r\n#| msgid "Encryption"\nmsgid "256-bit encryption"\r\nmsgstr "Xifratge"\r\n'
#                                    ^^ bare \n in a CRLF file
```

Found live: Weblate rejects such a file on upload with `HTTP 400 — Syntax error on line 497: '#| msgid "Encryption"\nmsgid "256-bit encryption"\r\n'` (a PDFCreator catalog, CRLF throughout, merged through translate-toolkit).

The fix uses `self.newline` like the surrounding output code; the unit-level `newline` property already falls back to `"\n"` when the unit is detached from a store, so unattached units are unaffected. Regression test added beside `test_dos_newlines`, pinning the byte-identical round trip.
