### PR TITLE
Complete type annotations for the checks package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -360,7 +360,6 @@ extend-safe-fixes = [
 ignore = [
   "A001",  # TODO: Variable is shadowing a Python builtin
   "A002",  # TODO: overriding builtins (might need noqa tags)
-  "ANN",  # TODO: type annotations missing
   "ARG001",  # TODO: Unused function argument (mostly for API compatibility)
   "ARG002",  # TODO: Unused method argument (mostly for API compatibility)
   "ARG004",  # TODO: Unused static method argument
@@ -455,6 +454,8 @@ preview = true
 select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
+"!**/translate/filters/checks/**.py" = ["ANN"]  # turn annotations on for select files
+"pyproject.toml" = ["rule-codes-in-selectors"]
 "tests/**.py" = ["PLC1901", "T201"]
 "tools/benchmark.py" = ["T201"]
 "translate/misc/progressbar.py" = ["T201"]

--- a/tests/translate/filters/checks/helpers.py
+++ b/tests/translate/filters/checks/helpers.py
@@ -1,10 +1,13 @@
 """Shared assertion helpers for the checker tests."""
 
 from translate.filters import checks
+from translate.filters.decorators import BoundCheckFunction
 from translate.lang import data
 
 
-def strprep(str1, str2, message=None):
+def strprep(
+    str1: str, str2: str, message: str | None = None
+) -> tuple[str, str, str | None]:
     return (
         data.normalize(str1),
         data.normalize(str2),
@@ -12,12 +15,12 @@ def strprep(str1, str2, message=None):
     )
 
 
-def check_category(filterfunction):
+def check_category(filterfunction: BoundCheckFunction) -> bool:
     """Checks whether ``filterfunction`` has defined a category or not."""
     return filterfunction.__name__ in filterfunction.__self__.categories
 
 
-def passes(filterfunction, str1, str2):
+def passes(filterfunction: BoundCheckFunction, str1: str, str2: str) -> bool:
     """Returns whether the given strings pass on the given test, handling FilterFailures."""
     str1, str2, _no_message = strprep(str1, str2)
     try:
@@ -28,7 +31,9 @@ def passes(filterfunction, str1, str2):
     return filterresult and check_category(filterfunction)
 
 
-def fails(filterfunction, str1, str2, message=None) -> bool:
+def fails(
+    filterfunction: BoundCheckFunction, str1: str, str2: str, message: str | None = None
+) -> bool:
     """Returns whether the given strings fail on the given test, handling only FilterFailures."""
     str1, str2, message = strprep(str1, str2, message)
     try:
@@ -48,7 +53,9 @@ def fails(filterfunction, str1, str2, message=None) -> bool:
     return not filterresult
 
 
-def fails_serious(filterfunction, str1, str2, message=None) -> bool:
+def fails_serious(
+    filterfunction: BoundCheckFunction, str1: str, str2: str, message: str | None = None
+) -> bool:
     """Returns whether the given strings fail on the given test, handling only SeriousFilterFailures."""
     str1, str2, message = strprep(str1, str2, message)
     try:

--- a/tests/translate/filters/checks/test_accelerators.py
+++ b/tests/translate/filters/checks/test_accelerators.py
@@ -9,7 +9,7 @@ from translate.storage import base
 
 def test_accelerators() -> None:
     """Tests accelerators."""
-    stdchecker = checks.StandardChecker(checks.CheckerConfig(accelmarkers="&"))
+    stdchecker = checks.StandardChecker(checks.CheckerConfig(accelmarkers=["&"]))
     assert passes(stdchecker.accelerators, "&File", "&Fayile")
     assert fails(stdchecker.accelerators, "&File", "Fayile")
     assert fails(stdchecker.accelerators, "File", "&Fayile")
@@ -55,12 +55,12 @@ def test_accelerators() -> None:
 
     # Bug 289: accept accented accelerator characters
     afchecker = checks.StandardChecker(
-        checks.CheckerConfig(accelmarkers="&", targetlanguage="fi")
+        checks.CheckerConfig(accelmarkers=["&"], targetlanguage="fi")
     )
     assert passes(afchecker.accelerators, "&Reload Frame", "P&äivitä kehys")
 
     trchecker = checks.StandardChecker(
-        checks.CheckerConfig(accelmarkers="&", targetlanguage="tr")
+        checks.CheckerConfig(accelmarkers=["&"], targetlanguage="tr")
     )
     assert passes(trchecker.accelerators, "&Download", "&İndir")
     assert passes(trchecker.accelerators, "&Business", "İ&ş")
@@ -143,7 +143,7 @@ def test_noaccelerators_only_in_mozilla_checker() -> None:
         checkerconfig=checks.CheckerConfig(targetlanguage="gl")
     )
     stdchecker = checks.StandardChecker(
-        checkerconfig=checks.CheckerConfig(accelmarkers="&", targetlanguage="as")
+        checkerconfig=checks.CheckerConfig(accelmarkers=["&"], targetlanguage="as")
     )
 
     # Accelerators check passes for Assamesse in Mozilla checker. It fails for

--- a/tests/translate/filters/checks/test_capitalisation.py
+++ b/tests/translate/filters/checks/test_capitalisation.py
@@ -38,7 +38,7 @@ def test_startcaps() -> None:
     )
     assert fails(stdchecker.startcaps, "A text enclosed...", "ḽiṅwalwa ḽo katelwaho...")
     # Accelerators
-    stdchecker = checks.StandardChecker(checks.CheckerConfig(accelmarkers="&"))
+    stdchecker = checks.StandardChecker(checks.CheckerConfig(accelmarkers=["&"]))
     assert passes(stdchecker.startcaps, "&Find", "Vi&nd")
     # Numbers - we really can't tell what should happen with numbers, so ignore
     # source or target that start with a number

--- a/tests/translate/filters/checks/test_checkers.py
+++ b/tests/translate/filters/checks/test_checkers.py
@@ -141,7 +141,7 @@ def test_skip_checks_per_language_in_some_checkers() -> None:
     # Prepare the checkers and the unit.
     mozillachecker = checks.MozillaChecker(checkerconfig=checker_config)
     stdchecker = checks.StandardChecker(
-        checkerconfig=checks.CheckerConfig(accelmarkers="&", targetlanguage="gl")
+        checkerconfig=checks.CheckerConfig(accelmarkers=["&"], targetlanguage="gl")
     )
 
     str1, str2, __ = strprep("&Check for updates", "আপডেইটসমূহৰ বাবে নিৰীক্ষণ কৰক")

--- a/tests/translate/filters/checks/test_content.py
+++ b/tests/translate/filters/checks/test_content.py
@@ -19,7 +19,7 @@ def test_untranslated() -> None:
 
 def test_unchanged() -> None:
     """Tests unchanged entries."""
-    stdchecker = checks.StandardChecker(checks.CheckerConfig(accelmarkers="&"))
+    stdchecker = checks.StandardChecker(checks.CheckerConfig(accelmarkers=["&"]))
     assert fails(stdchecker.unchanged, "Unchanged", "Unchanged")
     assert fails(stdchecker.unchanged, "&Unchanged", "Un&changed")
     assert passes(stdchecker.unchanged, "Unchanged", "Changed")

--- a/tests/translate/filters/checks/test_format.py
+++ b/tests/translate/filters/checks/test_format.py
@@ -93,7 +93,7 @@ def test_printf() -> None:
     assert fails(stdchecker.printf, "delete %'d items", "supprimer éléments")
     assert fails(stdchecker.printf, "delete %'d items", "supprimer %d éléments")
     # checking omitted plural format string placeholder %.0s
-    stdchecker.hasplural = 1
+    stdchecker.hasplural = True
     assert passes(stdchecker.printf, "%d plurals", "%.0s plural")
     # checking POSIX thousands separator flag with plural
     assert passes(stdchecker.printf, "delete %'d items", "supprimer %'d éléments")

--- a/tests/translate/filters/checks/test_standard_batch_run.py
+++ b/tests/translate/filters/checks/test_standard_batch_run.py
@@ -5,9 +5,12 @@ This used to be the ``__main__`` block of ``translate.filters.checks``, which
 only printed the failures it found; the failures are asserted here instead.
 """
 
+from collections.abc import Mapping
+
 from pytest import mark
 
 from translate.filters import checks
+from translate.filters.checks.checker import CheckFailureInfo
 from translate.filters.decorators import Category
 from translate.lang import data
 from translate.storage import base
@@ -44,7 +47,9 @@ TESTSET = [
 ]
 
 
-def run_filters(str1, str2, categorised=False):
+def run_filters(
+    str1: str, str2: str, categorised: bool = False
+) -> Mapping[str, str | CheckFailureInfo]:
     """Runs the standard checks over a pair of strings."""
     unit = base.TranslationUnit(data.normalize(str1))
     unit.target = data.normalize(str2)
@@ -53,7 +58,7 @@ def run_filters(str1, str2, categorised=False):
 
 
 @mark.parametrize(("source", "target", "expected"), TESTSET)
-def test_standard_batch_run(source, target, expected) -> None:
+def test_standard_batch_run(source: str, target: str, expected: list[str]) -> None:
     """Tests that the standard checks flag exactly the expected problems."""
     failures = run_filters(source, target)
 

--- a/tests/translate/filters/checks/test_words.py
+++ b/tests/translate/filters/checks/test_words.py
@@ -306,7 +306,7 @@ def test_spellcheck() -> None:
     assert fails(stdchecker.spellcheck, "Final deadline", "End of the road")
     # Bug 289: filters accelerators before spell checking
     stdchecker = checks.StandardChecker(
-        checks.CheckerConfig(accelmarkers="&", targetlanguage="fi")
+        checks.CheckerConfig(accelmarkers=["&"], targetlanguage="fi")
     )
     assert passes(stdchecker.spellcheck, "&Reload Frame", "P&äivitä kehys")
     # Ensure we don't check notranslatewords

--- a/translate/filters/checks/cclicense.py
+++ b/translate/filters/checks/cclicense.py
@@ -19,14 +19,21 @@
 
 """Checks specific to Creative Commons licenses."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Unpack
+
 from translate.filters.checks.config import CheckerConfig
 from translate.filters.checks.standard import StandardChecker
+
+if TYPE_CHECKING:
+    from translate.filters.checks.checker import CheckerKwargs
 
 cclicenseconfig = CheckerConfig(varmatches=[("@", "@")])
 
 
 class CCLicenseChecker(StandardChecker):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Unpack[CheckerKwargs]) -> None:
         checkerconfig = kwargs.get("checkerconfig")
 
         if checkerconfig is None:

--- a/translate/filters/checks/checker.py
+++ b/translate/filters/checks/checker.py
@@ -21,21 +21,51 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, TypedDict
+
 from translate.filters import helpers, prefilters
 from translate.filters.checks.config import CheckerConfig
 from translate.filters.checks.exceptions import FilterFailure
 from translate.filters.checks.tags import tag_re
 from translate.lang import data
 
+if TYPE_CHECKING:
+    from types import FunctionType
 
-def cache_results(f):
-    def cached_f(self, param1):
+    from translate.filters.decorators import CheckFunction
+    from translate.storage.base import TranslationStore, TranslationUnit
+
+#: Signature of the callback invoked when a check raises an unexpected error.
+CheckerErrorHandler = Callable[..., object]
+
+
+class CheckerKwargs(TypedDict, total=False):
+    """Keyword arguments accepted by :class:`UnitChecker` and its subclasses."""
+
+    checkerconfig: CheckerConfig | None
+    excludefilters: dict[str, object] | None
+    limitfilters: list[str] | None
+    errorhandler: CheckerErrorHandler | None
+
+
+class CheckFailureInfo(TypedDict):
+    message: str
+    category: int
+
+
+#: Result of :meth:`UnitChecker.run_filters`, keyed by check/filter name.
+CheckFailures = Mapping[str, str | CheckFailureInfo]
+
+
+def cache_results(f: FunctionType) -> FunctionType:
+    def cached_f(self: UnitChecker, param1: str) -> str:
         key = (f.__name__, param1)
         res_cache = self.results_cache
 
         if key in res_cache:
             return res_cache[key]
-        value = f(self, param1)
+        value: str = f(self, param1)
         res_cache[key] = value
         return value
 
@@ -48,20 +78,20 @@ class UnitChecker:
     available in derived classes.
     """
 
-    preconditions = {}
+    preconditions: dict[str, tuple[str, ...]] = {}
 
     def __init__(
         self,
-        checkerconfig=None,
-        excludefilters=None,
-        limitfilters=None,
-        errorhandler=None,
+        checkerconfig: CheckerConfig | None = None,
+        excludefilters: dict[str, object] | None = None,
+        limitfilters: list[str] | None = None,
+        errorhandler: CheckerErrorHandler | None = None,
     ) -> None:
         self.errorhandler = errorhandler
 
         #: Categories where each checking function falls into
         #: Function names are used as keys, categories are the values
-        self.categories = {}
+        self.categories: dict[str, int] = {}
 
         if checkerconfig is None:
             self.setconfig(CheckerConfig())
@@ -78,9 +108,13 @@ class UnitChecker:
                 self.helperfunctions[functionname] = function
 
         self.defaultfilters = self.getfilters(excludefilters, limitfilters)
-        self.results_cache = {}
+        self.results_cache: dict[tuple[str, str], str] = {}
 
-    def getfilters(self, excludefilters=None, limitfilters=None):
+    def getfilters(
+        self,
+        excludefilters: dict[str, object] | None = None,
+        limitfilters: list[str] | None = None,
+    ) -> dict[str, CheckFunction]:
         """
         Returns dictionary of available filters, including/excluding those
         in the given lists.
@@ -112,7 +146,7 @@ class UnitChecker:
 
         return filters
 
-    def setconfig(self, config) -> None:
+    def setconfig(self, config: CheckerConfig) -> None:
         """Sets the accelerator list."""
         self.config = config
         self.accfilters = [
@@ -128,7 +162,7 @@ class UnitChecker:
             for startmatch, endmatch in self.config.varmatches
         ]
 
-    def setsuggestionstore(self, store) -> None:
+    def setsuggestionstore(self, store: TranslationStore[TranslationUnit]) -> None:
         """
         Sets the filename that a checker should use for evaluating
         suggestions.
@@ -139,26 +173,28 @@ class UnitChecker:
             self.suggestion_store.require_index()
 
     @cache_results
-    def filtervariables(self, str1):
+    def filtervariables(self, str1: str) -> str:
         """Filter out variables from ``str1``."""
         return helpers.multifilter(str1, self.varfilters)
 
     @cache_results
-    def removevariables(self, str1):
+    def removevariables(self, str1: str) -> str:
         """Remove variables from ``str1``."""
         return helpers.multifilter(str1, self.removevarfilter)
 
     @cache_results
-    def filteraccelerators(self, str1):
+    def filteraccelerators(self, str1: str) -> str:
         """Filter out accelerators from ``str1``."""
         return helpers.multifilter(str1, self.accfilters, None)
 
-    def filteraccelerators_by_list(self, str1, acceptlist=None):
+    def filteraccelerators_by_list(
+        self, str1: str, acceptlist: list[str] | None = None
+    ) -> str:
         """Filter out accelerators from ``str1``."""
         return helpers.multifilter(str1, self.accfilters, acceptlist)
 
     @cache_results
-    def filterwordswithpunctuation(self, str1):
+    def filterwordswithpunctuation(self, str1: str) -> str:
         """
         Replaces words with punctuation with their unpunctuated
         equivalents.
@@ -166,12 +202,12 @@ class UnitChecker:
         return prefilters.filterwordswithpunctuation(str1)
 
     @cache_results
-    def filterxml(self, str1):
+    def filterxml(self, str1: str) -> str:
         """Filter out XML from the string so only text remains."""
         return tag_re.sub("", str1)
 
     @staticmethod
-    def run_test(test, unit):
+    def run_test(test: Callable[..., object], unit: TranslationUnit) -> object:
         """
         Runs the given test on the given unit.
 
@@ -180,11 +216,11 @@ class UnitChecker:
         return test(unit)
 
     @property
-    def checker_name(self):
+    def checker_name(self) -> str:
         """Extract checker name, for example 'mozilla' from MozillaChecker."""
         return str(self.__class__.__name__).lower()[: -len("checker")]
 
-    def get_ignored_filters(self):
+    def get_ignored_filters(self) -> list[str]:
         """Return checker's additional filters for current language."""
         return list(
             set(
@@ -193,7 +229,9 @@ class UnitChecker:
             )
         )
 
-    def run_filters(self, unit, categorised: bool = False) -> dict[str, dict]:
+    def run_filters(
+        self, unit: TranslationUnit, categorised: bool = False
+    ) -> CheckFailures:
         """
         Run all the tests in this suite.
 
@@ -202,7 +240,7 @@ class UnitChecker:
            {'testname': { 'message': message_or_exception, 'category': failure_category } }
         """
         self.results_cache = {}
-        failures = {}
+        failures: dict[str, CheckFailureInfo] = {}
         ignores = self.get_ignored_filters()
         functionnames = self.defaultfilters.keys()
         priorityfunctionnames = self.preconditions.keys()
@@ -259,8 +297,7 @@ class UnitChecker:
         self.results_cache = {}
 
         if not categorised:
-            for name, info in failures.items():
-                failures[name] = info["message"]
+            return {name: info["message"] for name, info in failures.items()}
         return failures
 
 
@@ -274,16 +311,16 @@ class TranslationChecker(UnitChecker):
 
     def __init__(
         self,
-        checkerconfig=None,
-        excludefilters=None,
-        limitfilters=None,
-        errorhandler=None,
+        checkerconfig: CheckerConfig | None = None,
+        excludefilters: dict[str, object] | None = None,
+        limitfilters: list[str] | None = None,
+        errorhandler: CheckerErrorHandler | None = None,
     ) -> None:
         super().__init__(checkerconfig, excludefilters, limitfilters, errorhandler)
 
         self.locations = []
 
-    def run_test(self, test, unit):
+    def run_test(self, test: Callable[..., object], unit: TranslationUnit) -> object:
         """
         Runs the given test on the given unit.
 
@@ -307,7 +344,9 @@ class TranslationChecker(UnitChecker):
             return filterresult
         return test(self.str1, self.str2)
 
-    def run_filters(self, unit, categorised=False):
+    def run_filters(
+        self, unit: TranslationUnit, categorised: bool = False
+    ) -> CheckFailures:
         """
         Do some optimisation by caching some data of the unit for the
         benefit of :meth:`~TranslationChecker.run_test`.

--- a/translate/filters/checks/config.py
+++ b/translate/filters/checks/config.py
@@ -19,7 +19,16 @@
 
 """Configuration of the checkers."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
 from translate.lang import data, factory
+
+if TYPE_CHECKING:
+    from translate.filters.checks.tags import TagProperty
+
+_T = TypeVar("_T")
 
 # (tag, attribute, value) specifies a certain attribute which can be changed/
 # ignored if it exists inside tag. In the case where there is a third element
@@ -28,8 +37,8 @@ from translate.lang import data, factory
 # If a certain item is None, it indicates that it is relevant for all values of
 # the property/tag that is specified as None. A non-None value of "value"
 # indicates that the value of the attribute must be taken into account.
-common_ignoretags = [(None, "xml-lang", None)]
-common_canchangetags = [
+common_ignoretags: list[TagProperty] = [(None, "xml-lang", None)]
+common_canchangetags: list[TagProperty] = [
     ("img", "alt", None),
     (None, "title", None),
     (None, "dir", None),
@@ -43,18 +52,18 @@ class CheckerConfig:
 
     def __init__(
         self,
-        targetlanguage=None,
-        accelmarkers=None,
-        varmatches=None,
-        notranslatewords=None,
-        musttranslatewords=None,
-        validchars=None,
-        punctuation=None,
-        endpunctuation=None,
-        ignoretags=None,
-        canchangetags=None,
-        criticaltests=None,
-        credit_sources=None,
+        targetlanguage: str | None = None,
+        accelmarkers: list[str] | None = None,
+        varmatches: list[tuple[str, str | int | None]] | None = None,
+        notranslatewords: list[str] | None = None,
+        musttranslatewords: list[str] | None = None,
+        validchars: str | None = None,
+        punctuation: str | None = None,
+        endpunctuation: str | None = None,
+        ignoretags: list[TagProperty] | None = None,
+        canchangetags: list[TagProperty] | None = None,
+        criticaltests: list[str] | None = None,
+        credit_sources: list[str] | None = None,
     ) -> None:
         # Init lists
         self.accelmarkers = self._init_list(accelmarkers)
@@ -89,7 +98,7 @@ class CheckerConfig:
         self.updatevalidchars(validchars)
 
     @staticmethod
-    def _init_list(list: list | None) -> list:
+    def _init_list(list: list[_T] | None) -> list[_T]:
         """
         Initialise configuration parameters that are lists.
 
@@ -101,7 +110,7 @@ class CheckerConfig:
         return list
 
     @staticmethod
-    def _init_default(param, default):
+    def _init_default(param: _T | None, default: _T) -> _T:
         """
         Initialise parameters that can have default options.
 
@@ -114,7 +123,7 @@ class CheckerConfig:
 
         return param
 
-    def update(self, otherconfig) -> None:
+    def update(self, otherconfig: CheckerConfig) -> None:
         """Combines the info in ``otherconfig`` into this config object."""
         self.targetlanguage = otherconfig.targetlanguage or self.targetlanguage
         self.updatetargetlanguage(self.targetlanguage)
@@ -133,7 +142,7 @@ class CheckerConfig:
         self.criticaltests.extend(otherconfig.criticaltests)
         self.credit_sources = otherconfig.credit_sources
 
-    def updatevalidchars(self, validchars) -> None:
+    def updatevalidchars(self, validchars: str | None) -> None:
         """Updates the map that eliminates valid characters."""
         if validchars is None:
             return
@@ -143,7 +152,7 @@ class CheckerConfig:
         }
         self.validcharsmap.update(validcharsmap)
 
-    def updatetargetlanguage(self, langcode) -> None:
+    def updatetargetlanguage(self, langcode: str | None) -> None:
         """
         Updates the target language in the config to the given target
         language and sets its script.

--- a/translate/filters/checks/drupal.py
+++ b/translate/filters/checks/drupal.py
@@ -19,8 +19,15 @@
 
 """Checks specific to Drupal."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Unpack
+
 from translate.filters.checks.config import CheckerConfig
 from translate.filters.checks.standard import StandardChecker
+
+if TYPE_CHECKING:
+    from translate.filters.checks.checker import CheckerKwargs
 
 drupalconfig = CheckerConfig(
     varmatches=[("%", None), ("@", None), ("!", None)],
@@ -28,7 +35,7 @@ drupalconfig = CheckerConfig(
 
 
 class DrupalChecker(StandardChecker):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Unpack[CheckerKwargs]) -> None:
         checkerconfig = kwargs.get("checkerconfig")
 
         if checkerconfig is None:

--- a/translate/filters/checks/exceptions.py
+++ b/translate/filters/checks/exceptions.py
@@ -26,7 +26,7 @@ class FilterFailure(Exception):
     explanation or a comment.
     """
 
-    def __init__(self, messages) -> None:
+    def __init__(self, messages: str | list[str]) -> None:
         if not isinstance(messages, list):
             messages = [messages]
 

--- a/translate/filters/checks/gnome.py
+++ b/translate/filters/checks/gnome.py
@@ -19,12 +19,18 @@
 
 """Checks specific to GNOME."""
 
+from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING, Unpack
 
 from translate.filters.checks.config import CheckerConfig
 from translate.filters.checks.exceptions import FilterFailure
 from translate.filters.checks.standard import StandardChecker
 from translate.filters.decorators import functional
+
+if TYPE_CHECKING:
+    from translate.filters.checks.checker import CheckerKwargs
 
 gconf_attribute_re = re.compile(r'"[a-z_]+?"')
 
@@ -36,7 +42,7 @@ gnomeconfig = CheckerConfig(
 
 
 class GnomeChecker(StandardChecker):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Unpack[CheckerKwargs]) -> None:
         checkerconfig = kwargs.get("checkerconfig")
 
         if checkerconfig is None:
@@ -47,7 +53,7 @@ class GnomeChecker(StandardChecker):
         super().__init__(**kwargs)
 
     @functional
-    def gconf(self, str1, str2) -> bool:
+    def gconf(self, str1: str, str2: str) -> bool:
         """
         Checks if we have any gconf config settings translated.
 

--- a/translate/filters/checks/ios.py
+++ b/translate/filters/checks/ios.py
@@ -19,8 +19,15 @@
 
 """Checks specific to iOS."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Unpack
+
 from translate.filters.checks.config import CheckerConfig
 from translate.filters.checks.standard import StandardChecker
+
+if TYPE_CHECKING:
+    from translate.filters.checks.checker import CheckerKwargs
 
 iosconfig = CheckerConfig(
     varmatches=[("$(", ")"), ("%", "@")],
@@ -28,7 +35,7 @@ iosconfig = CheckerConfig(
 
 
 class IOSChecker(StandardChecker):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Unpack[CheckerKwargs]) -> None:
         checkerconfig = kwargs.get("checkerconfig")
 
         if checkerconfig is None:

--- a/translate/filters/checks/kde.py
+++ b/translate/filters/checks/kde.py
@@ -19,8 +19,15 @@
 
 """Checks specific to KDE."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Unpack
+
 from translate.filters.checks.config import CheckerConfig
 from translate.filters.checks.standard import StandardChecker
+
+if TYPE_CHECKING:
+    from translate.filters.checks.checker import CheckerKwargs
 
 kdeconfig = CheckerConfig(
     accelmarkers=["&"],
@@ -30,7 +37,7 @@ kdeconfig = CheckerConfig(
 
 
 class KdeChecker(StandardChecker):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Unpack[CheckerKwargs]) -> None:
         # TODO allow setup of KDE plural and translator comments so that they do
         # not create false positives
         checkerconfig = kwargs.get("checkerconfig")

--- a/translate/filters/checks/libreoffice.py
+++ b/translate/filters/checks/libreoffice.py
@@ -19,7 +19,10 @@
 
 """Checks specific to LibreOffice."""
 
+from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING, Unpack
 
 from translate.filters.checks.config import CheckerConfig
 from translate.filters.checks.exceptions import FilterFailure
@@ -27,6 +30,9 @@ from translate.filters.checks.openoffice import openofficeconfig
 from translate.filters.checks.standard import StandardChecker
 from translate.filters.checks.tags import tagname
 from translate.filters.decorators import critical
+
+if TYPE_CHECKING:
+    from translate.filters.checks.checker import CheckerKwargs
 
 # XML/HTML tags in LibreOffice help and readme, exclude short tags
 lo_tag_re = re.compile(r"""</?(?P<tag>[a-z][a-z_-]+)(?: +[a-z]+="[^"]+")* */?>""")
@@ -62,7 +68,7 @@ libreofficeconfig = CheckerConfig(
 
 
 class LibreOfficeChecker(StandardChecker):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Unpack[CheckerKwargs]) -> None:
         checkerconfig = kwargs.get("checkerconfig")
 
         if checkerconfig is None:
@@ -74,7 +80,7 @@ class LibreOfficeChecker(StandardChecker):
         super().__init__(**kwargs)
 
     @critical
-    def validxml(self, str1, str2) -> bool:
+    def validxml(self, str1: str, str2: str) -> bool:
         """
         Check that all XML/HTML open/close tags has close/open pair in the
         translation.
@@ -112,6 +118,6 @@ class LibreOfficeChecker(StandardChecker):
         return True
 
     @critical
-    def pythonbraceformat(self, str1, str2) -> bool:
+    def pythonbraceformat(self, str1: str, str2: str) -> bool:
         """Not used in LibreOffice."""
         return True

--- a/translate/filters/checks/minimal.py
+++ b/translate/filters/checks/minimal.py
@@ -19,14 +19,21 @@
 
 """Checkers running only a small selection of the standard checks."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Unpack
+
 from translate.filters.checks.config import CheckerConfig
 from translate.filters.checks.standard import StandardChecker
+
+if TYPE_CHECKING:
+    from translate.filters.checks.checker import CheckerKwargs
 
 minimalconfig = CheckerConfig()
 
 
 class MinimalChecker(StandardChecker):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Unpack[CheckerKwargs]) -> None:
         checkerconfig = kwargs.get("checkerconfig")
 
         if checkerconfig is None:
@@ -47,7 +54,7 @@ reducedconfig = CheckerConfig()
 
 
 class ReducedChecker(StandardChecker):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Unpack[CheckerKwargs]) -> None:
         checkerconfig = kwargs.get("checkerconfig")
 
         if checkerconfig is None:

--- a/translate/filters/checks/mozilla.py
+++ b/translate/filters/checks/mozilla.py
@@ -19,14 +19,21 @@
 
 """Checks specific to Mozilla."""
 
+from __future__ import annotations
+
 import re
 import string
+from typing import TYPE_CHECKING, Unpack
 
 from translate.filters import decoration
 from translate.filters.checks.config import CheckerConfig
 from translate.filters.checks.exceptions import FilterFailure
 from translate.filters.checks.standard import StandardChecker
 from translate.filters.decorators import cosmetic, critical, extraction, functional
+
+if TYPE_CHECKING:
+    from translate.filters.checks.checker import CheckerKwargs, CheckFailures
+    from translate.storage.base import TranslationUnit
 
 mozillaconfig = CheckerConfig(
     accelmarkers=["&"],
@@ -67,7 +74,7 @@ class MozillaChecker(StandardChecker):
         # spellchecker:on
     ]
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Unpack[CheckerKwargs]) -> None:
         checkerconfig = kwargs.get("checkerconfig")
 
         if checkerconfig is None:
@@ -78,7 +85,7 @@ class MozillaChecker(StandardChecker):
         super().__init__(**kwargs)
 
     @extraction
-    def credits(self, str1, str2) -> bool:
+    def credits(self, str1: str, str2: str) -> bool:
         """
         Checks for messages containing translation credits instead of
         normal translations.
@@ -109,7 +116,7 @@ class MozillaChecker(StandardChecker):
     mozilla_dialog_valid_units = ["em", "px", "ch"]
 
     @critical
-    def dialogsizes(self, str1, str2) -> bool:
+    def dialogsizes(self, str1: str, str2: str) -> bool:
         """
         Checks that dialog sizes are not translated.
 
@@ -154,7 +161,7 @@ class MozillaChecker(StandardChecker):
         return True
 
     @functional
-    def numbers(self, str1, str2):
+    def numbers(self, str1: str, str2: str) -> bool:
         """
         Checks that numbers are not translated.
 
@@ -166,7 +173,7 @@ class MozillaChecker(StandardChecker):
         return super().numbers(str1, str2)
 
     @functional
-    def unchanged(self, str1, str2):
+    def unchanged(self, str1: str, str2: str) -> bool:
         """
         Checks whether a translation is basically identical to the original
         string.
@@ -182,7 +189,7 @@ class MozillaChecker(StandardChecker):
         return super().unchanged(str1, str2)
 
     @cosmetic
-    def accelerators(self, str1, str2):
+    def accelerators(self, str1: str, str2: str) -> bool:
         """
         Checks whether accelerators are consistent between the
         two strings.
@@ -230,7 +237,7 @@ class L20nChecker(MozillaChecker):
     ]
     complex_unit_pattern = "->"
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Unpack[CheckerKwargs]) -> None:
         checkerconfig = kwargs.get("checkerconfig")
 
         if checkerconfig is None:
@@ -239,7 +246,9 @@ class L20nChecker(MozillaChecker):
 
         super().__init__(**kwargs)
 
-    def run_filters(self, unit, categorised=False):
+    def run_filters(
+        self, unit: TranslationUnit, categorised: bool = False
+    ) -> CheckFailures:
         is_unit_complex = (
             self.complex_unit_pattern in unit.source
             or self.complex_unit_pattern in unit.target

--- a/translate/filters/checks/openoffice.py
+++ b/translate/filters/checks/openoffice.py
@@ -19,8 +19,15 @@
 
 """Checks specific to OpenOffice.org."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Unpack
+
 from translate.filters.checks.config import CheckerConfig
 from translate.filters.checks.standard import StandardChecker
+
+if TYPE_CHECKING:
+    from translate.filters.checks.checker import CheckerKwargs
 
 openofficeconfig = CheckerConfig(
     accelmarkers=["~"],
@@ -52,7 +59,7 @@ openofficeconfig = CheckerConfig(
 
 
 class OpenOfficeChecker(StandardChecker):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Unpack[CheckerKwargs]) -> None:
         checkerconfig = kwargs.get("checkerconfig")
 
         if checkerconfig is None:

--- a/translate/filters/checks/standard.py
+++ b/translate/filters/checks/standard.py
@@ -59,7 +59,7 @@ class StandardChecker(TranslationChecker):
     """The basic test suite for source -> target translations."""
 
     @extraction
-    def untranslated(self, str1, str2) -> bool:
+    def untranslated(self, str1: str, str2: str) -> bool:
         """
         Checks whether a string has been translated at all.
 
@@ -71,7 +71,7 @@ class StandardChecker(TranslationChecker):
         return not (len(str1.strip()) > 0 and len(str2) == 0)
 
     @functional
-    def unchanged(self, str1, str2) -> bool:
+    def unchanged(self, str1: str, str2: str) -> bool:
         """
         Checks whether a translation is basically identical to the original
         string.
@@ -110,7 +110,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @functional
-    def blank(self, str1, str2) -> bool:
+    def blank(self, str1: str, str2: str) -> bool:
         """
         Checks whether a translation is totally blank.
 
@@ -127,7 +127,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @functional
-    def short(self, str1, str2) -> bool:
+    def short(self, str1: str, str2: str) -> bool:
         """
         Checks whether a translation is much shorter than the original
         string.
@@ -145,7 +145,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @functional
-    def long(self, str1, str2) -> bool:
+    def long(self, str1: str, str2: str) -> bool:
         """
         Checks whether a translation is much longer than the original
         string.
@@ -164,7 +164,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @critical
-    def escapes(self, str1, str2) -> bool:
+    def escapes(self, str1: str, str2: str) -> bool:
         r"""
         Checks whether escaping is consistent between the two strings.
 
@@ -182,7 +182,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @critical
-    def newlines(self, str1, str2) -> bool:
+    def newlines(self, str1: str, str2: str) -> bool:
         r"""
         Checks whether newlines are consistent between the two strings.
 
@@ -201,7 +201,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @critical
-    def tabs(self, str1, str2) -> bool:
+    def tabs(self, str1: str, str2: str) -> bool:
         r"""
         Checks whether tabs are consistent between the two strings.
 
@@ -213,7 +213,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @cosmetic
-    def singlequoting(self, str1, str2) -> bool:
+    def singlequoting(self, str1: str, str2: str) -> bool:
         """
         Checks whether singlequoting is consistent between the two strings.
 
@@ -238,7 +238,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Different quotation marks")
 
     @cosmetic
-    def doublequoting(self, str1, str2) -> bool:
+    def doublequoting(self, str1: str, str2: str) -> bool:
         """
         Checks whether doublequoting is consistent between the two strings.
 
@@ -259,7 +259,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Different quotation marks")
 
     @cosmetic
-    def doublespacing(self, str1, str2) -> bool:
+    def doublespacing(self, str1: str, str2: str) -> bool:
         """
         Checks for bad double-spaces by comparing to original.
 
@@ -276,7 +276,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Different use of double spaces")
 
     @cosmetic
-    def puncspacing(self, str1, str2) -> bool:
+    def puncspacing(self, str1: str, str2: str) -> bool:
         """
         Checks for bad spacing after punctuation.
 
@@ -351,7 +351,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @critical
-    def printf(self, str1, str2) -> int:
+    def printf(self, str1: str, str2: str) -> int:
         """
         Checks whether printf format strings match.
 
@@ -481,11 +481,11 @@ class StandardChecker(TranslationChecker):
         return 1
 
     @critical
-    def pythonbraceformat(self, str1, str2) -> int:
+    def pythonbraceformat(self, str1: str, str2: str) -> int:
         """Checks whether python brace format strings match."""
 
         # Helper function
-        def max_anons(anons):
+        def max_anons(anons: list[str]) -> int:
             """
             Takes a list of anonymous placeholder variables, e.g.
             ['', '1', ...]
@@ -572,7 +572,7 @@ class StandardChecker(TranslationChecker):
         )
 
     @functional
-    def accelerators(self, str1, str2) -> bool:
+    def accelerators(self, str1: str, str2: str) -> bool:
         """
         Checks whether accelerators are consistent between the two strings.
 
@@ -646,7 +646,7 @@ class StandardChecker(TranslationChecker):
     #        return True
 
     @critical
-    def variables(self, str1, str2) -> bool:
+    def variables(self, str1: str, str2: str) -> bool:
         """
         Checks whether variables of various forms are consistent between the
         two strings.
@@ -660,7 +660,7 @@ class StandardChecker(TranslationChecker):
         mismatch1, mismatch2 = [], []
         varnames1, varnames2 = [], []
 
-        def redecorate(startmaker, endmaker, var):
+        def redecorate(startmaker: str, endmaker: str | int | None, var: str) -> str:
             if startmarker and endmarker:
                 if isinstance(endmarker, int):
                     return startmarker + var
@@ -706,7 +706,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @functional
-    def functions(self, str1, str2) -> bool:
+    def functions(self, str1: str, str2: str) -> bool:
         """
         Checks that function names are not translated.
 
@@ -721,7 +721,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Different functions")
 
     @functional
-    def emails(self, str1, str2) -> bool:
+    def emails(self, str1: str, str2: str) -> bool:
         """
         Checks that emails are not translated.
 
@@ -735,7 +735,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Different e-mails")
 
     @functional
-    def urls(self, str1, str2) -> bool:
+    def urls(self, str1: str, str2: str) -> bool:
         """
         Checks that URLs are not translated.
 
@@ -752,7 +752,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Different URLs")
 
     @functional
-    def numbers(self, str1, str2) -> bool:
+    def numbers(self, str1: str, str2: str) -> bool:
         """
         Checks whether numbers of various forms are consistent between the
         two strings.
@@ -768,7 +768,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Different numbers")
 
     @cosmetic
-    def startwhitespace(self, str1, str2) -> bool:
+    def startwhitespace(self, str1: str, str2: str) -> bool:
         """
         Checks whether whitespace at the beginning of the strings matches.
 
@@ -779,7 +779,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Different whitespace at the start")
 
     @cosmetic
-    def endwhitespace(self, str1, str2) -> bool:
+    def endwhitespace(self, str1: str, str2: str) -> bool:
         """
         Checks whether whitespace at the end of the strings matches.
 
@@ -800,7 +800,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Different whitespace at the end")
 
     @cosmetic
-    def startpunc(self, str1, str2) -> bool:
+    def startpunc(self, str1: str, str2: str) -> bool:
         """
         Checks whether punctuation at the beginning of the strings match.
 
@@ -823,7 +823,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Different punctuation at the start")
 
     @cosmetic
-    def endpunc(self, str1, str2) -> bool:
+    def endpunc(self, str1: str, str2: str) -> bool:
         """
         Checks whether punctuation at the end of the strings match.
 
@@ -863,7 +863,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Different punctuation at the end")
 
     @functional
-    def purepunc(self, str1, str2) -> bool:
+    def purepunc(self, str1: str, str2: str) -> bool:
         """
         Checks that strings that are purely punctuation are not changed.
 
@@ -881,7 +881,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Consider not translating punctuation")
 
     @cosmetic
-    def brackets(self, str1, str2) -> bool:
+    def brackets(self, str1: str, str2: str) -> bool:
         """
         Checks that the number of brackets in both strings match.
 
@@ -916,7 +916,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @functional
-    def sentencecount(self, str1, str2) -> bool:
+    def sentencecount(self, str1: str, str2: str) -> bool:
         """
         Checks that the number of sentences in both strings match.
 
@@ -942,7 +942,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @functional
-    def options(self, str1, str2) -> bool:
+    def options(self, str1: str, str2: str) -> bool:
         """
         Checks that command line options are not translated.
 
@@ -971,7 +971,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @cosmetic
-    def startcaps(self, str1, str2) -> bool:
+    def startcaps(self, str1: str, str2: str) -> bool:
         """
         Checks that the message starts with the correct capitalisation.
 
@@ -1005,7 +1005,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @cosmetic
-    def simplecaps(self, str1, str2) -> bool:
+    def simplecaps(self, str1: str, str2: str) -> bool:
         """
         Checks the capitalisation of two strings isn't wildly different.
 
@@ -1053,7 +1053,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("Different capitalization")
 
     @functional
-    def acronyms(self, str1, str2) -> bool:
+    def acronyms(self, str1: str, str2: str) -> bool:
         """
         Checks that acronyms that appear are unchanged.
 
@@ -1094,7 +1094,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @cosmetic
-    def doublewords(self, str1, str2) -> bool:
+    def doublewords(self, str1: str, str2: str) -> bool:
         """
         Checks for repeated words in the translation.
 
@@ -1123,7 +1123,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @functional
-    def notranslatewords(self, str1, str2) -> bool:
+    def notranslatewords(self, str1: str, str2: str) -> bool:
         """
         Checks that words configured as untranslatable appear in the
         translation too.
@@ -1159,7 +1159,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @functional
-    def musttranslatewords(self, str1, str2) -> bool:
+    def musttranslatewords(self, str1: str, str2: str) -> bool:
         """
         Checks that words configured as definitely translatable don't appear
         in the translation.
@@ -1196,7 +1196,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @cosmetic
-    def validchars(self, str1, str2) -> bool:
+    def validchars(self, str1: str, str2: str) -> bool:
         """
         Checks that only characters specified as valid appear in the
         translation.
@@ -1231,7 +1231,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @functional
-    def filepaths(self, str1, str2) -> bool:
+    def filepaths(self, str1: str, str2: str) -> bool:
         """
         Checks that file paths have not been translated.
 
@@ -1246,7 +1246,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @critical
-    def xmltags(self, str1, str2) -> bool:
+    def xmltags(self, str1: str, str2: str) -> bool:
         """
         Checks that XML/HTML tags have not been translated.
 
@@ -1296,7 +1296,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @functional
-    def kdecomments(self, str1, str2):
+    def kdecomments(self, str1: str, str2: str) -> bool:
         r"""
         Checks to ensure that no KDE style comments appear in the
         translation.
@@ -1308,7 +1308,7 @@ class StandardChecker(TranslationChecker):
         return str2.find("\n_:") == -1 and not str2.startswith("_:")
 
     @extraction
-    def compendiumconflicts(self, str1, str2):
+    def compendiumconflicts(self, str1: str, str2: str) -> bool:
         """
         Checks for Gettext compendium conflicts (#-#-#-#-#).
 
@@ -1320,7 +1320,7 @@ class StandardChecker(TranslationChecker):
         return str2.find("#-#-#-#-#") == -1
 
     @cosmetic
-    def simpleplurals(self, str1, str2) -> bool:
+    def simpleplurals(self, str1: str, str2: str) -> bool:
         """
         Checks for English style plural(s) for you to review.
 
@@ -1337,7 +1337,7 @@ class StandardChecker(TranslationChecker):
         simply test that nothing like "(s)" was used in the translation.
         """
 
-        def numberofpatterns(string, patterns):
+        def numberofpatterns(string: str, patterns: list[str]) -> int:
             number = 0
 
             for pattern in patterns:
@@ -1360,7 +1360,7 @@ class StandardChecker(TranslationChecker):
         raise FilterFailure("The original uses plural(s)")
 
     @functional
-    def spellcheck(self, str1, str2) -> bool:
+    def spellcheck(self, str1: str, str2: str) -> bool:
         """
         Checks words that don't pass a spell check.
 
@@ -1418,7 +1418,7 @@ class StandardChecker(TranslationChecker):
         return True
 
     @extraction
-    def credits(self, str1, str2) -> bool:
+    def credits(self, str1: str, str2: str) -> bool:
         """
         Checks for messages containing translation credits instead of
         normal translations.

--- a/translate/filters/checks/tee.py
+++ b/translate/filters/checks/tee.py
@@ -19,9 +19,25 @@
 
 """A checker delegating to several other checkers."""
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 from translate.filters.checks.standard import StandardChecker
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from translate.filters.checks.checker import (
+        CheckerErrorHandler,
+        CheckFailureInfo,
+        CheckFailures,
+        UnitChecker,
+    )
+    from translate.filters.checks.config import CheckerConfig
+    from translate.filters.decorators import CheckFunction
+    from translate.storage.base import TranslationStore, TranslationUnit
 
 logger = logging.getLogger(__name__)
 
@@ -31,16 +47,16 @@ class TeeChecker:
 
     #: Categories where each checking function falls into
     #: Function names are used as keys, categories are the values
-    categories = {}
+    categories: dict[str, int] = {}
 
     def __init__(
         self,
-        checkerconfig=None,
-        excludefilters=None,
-        limitfilters=None,
-        checkerclasses=None,
-        errorhandler=None,
-        languagecode=None,
+        checkerconfig: CheckerConfig | None = None,
+        excludefilters: dict[str, object] | None = None,
+        limitfilters: list[str] | None = None,
+        checkerclasses: Sequence[type[UnitChecker]] | None = None,
+        errorhandler: CheckerErrorHandler | None = None,
+        languagecode: str | None = None,
     ) -> None:
         """Construct a TeeChecker from the given checkers."""
         self.limitfilters = limitfilters
@@ -71,7 +87,11 @@ class TeeChecker:
         self.combinedfilters = self.getfilters(excludefilters, limitfilters)
         self.config = checkerconfig or self.checkers[0].config
 
-    def getfilters(self, excludefilters=None, limitfilters=None):
+    def getfilters(
+        self,
+        excludefilters: dict[str, object] | None = None,
+        limitfilters: list[str] | None = None,
+    ) -> dict[str, CheckFunction]:
         """
         Returns a dictionary of available filters, including/excluding
         those in the given lists.
@@ -96,16 +116,18 @@ class TeeChecker:
 
         return self.combinedfilters
 
-    def run_filters(self, unit, categorised=False):
+    def run_filters(
+        self, unit: TranslationUnit, categorised: bool = False
+    ) -> CheckFailures:
         """Run all the tests in the checker's suites."""
-        failures = {}
+        failures: dict[str, str | CheckFailureInfo] = {}
 
         for checker in self.checkers:
             failures.update(checker.run_filters(unit, categorised))
 
         return failures
 
-    def setsuggestionstore(self, store) -> None:
+    def setsuggestionstore(self, store: TranslationStore[TranslationUnit]) -> None:
         """
         Sets the filename that a checker should use for evaluating
         suggestions.

--- a/translate/filters/checks/term.py
+++ b/translate/filters/checks/term.py
@@ -19,14 +19,21 @@
 
 """Checks specific to terminology files."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Unpack
+
 from translate.filters.checks.config import CheckerConfig
 from translate.filters.checks.standard import StandardChecker
+
+if TYPE_CHECKING:
+    from translate.filters.checks.checker import CheckerKwargs
 
 termconfig = CheckerConfig()
 
 
 class TermChecker(StandardChecker):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Unpack[CheckerKwargs]) -> None:
         checkerconfig = kwargs.get("checkerconfig")
 
         if checkerconfig is None:

--- a/translate/filters/checks/unit.py
+++ b/translate/filters/checks/unit.py
@@ -19,15 +19,22 @@
 
 """Checks that inspect a whole translation unit rather than its strings."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from translate.filters.checks.checker import UnitChecker
 from translate.filters.decorators import critical, extraction
+
+if TYPE_CHECKING:
+    from translate.storage.base import TranslationUnit
 
 
 class StandardUnitChecker(UnitChecker):
     """The standard checks for common checks on translation units."""
 
     @extraction
-    def isfuzzy(self, unit) -> bool:
+    def isfuzzy(self, unit: TranslationUnit) -> bool:
         """
         Check if the unit has been marked fuzzy.
 
@@ -39,7 +46,7 @@ class StandardUnitChecker(UnitChecker):
         return not unit.isfuzzy()
 
     @extraction
-    def isreview(self, unit) -> bool:
+    def isreview(self, unit: TranslationUnit) -> bool:
         """
         Check if the unit has been marked review.
 
@@ -56,7 +63,7 @@ class StandardUnitChecker(UnitChecker):
         return not unit.isreview()
 
     @critical
-    def nplurals(self, unit):
+    def nplurals(self, unit: TranslationUnit) -> bool:
         """
         Checks for the correct number of noun forms for plural translations.
 
@@ -75,7 +82,7 @@ class StandardUnitChecker(UnitChecker):
         return True
 
     @extraction
-    def hassuggestion(self, unit) -> bool:
+    def hassuggestion(self, unit: TranslationUnit) -> bool:
         """
         Checks if there is at least one suggested translation for this unit.
 

--- a/translate/filters/decorators.py
+++ b/translate/filters/decorators.py
@@ -18,7 +18,11 @@
 
 """Decorators to categorize pofilter checks."""
 
+from collections.abc import Callable
 from functools import wraps
+from typing import Protocol, TypeVar, cast
+
+R_co = TypeVar("R_co", covariant=True)
 
 
 #: Quality checks' failure categories
@@ -30,60 +34,103 @@ class Category:
     NO_CATEGORY = 0
 
 
-def annotate_check(checkfunc) -> None:
+class Categorizable(Protocol):
+    """The part of a checker that the decorators below record categories in."""
+
+    categories: dict[str, int]
+
+
+class BoundCheckFunction(Protocol[R_co]):
+    """A :class:`CheckFunction` accessed on a checker instance."""
+
+    #: Short description of the check, taken from its docstring
+    title: str
+    #: Name of the wrapped check, copied over by :func:`functools.wraps`
+    __name__: str
+    #: The checker the check is bound to
+    __self__: Categorizable
+
+    def __call__(self, *args, **kwargs) -> R_co: ...
+
+
+class UndecoratedCheck(Protocol[R_co]):
+    """A check method before one of the category decorators below is applied."""
+
+    #: Name of the check, used as the key to record its category under
+    __name__: str
+
+    def __call__(self, *args, **kwargs) -> R_co: ...
+
+
+class CheckFunction(Protocol[R_co]):
+    """A check function as returned by the decorators below."""
+
+    #: Short description of the check, taken from its docstring
+    title: str
+    #: Name of the wrapped check, copied over by :func:`functools.wraps`
+    __name__: str
+
+    def __call__(self, *args, **kwargs) -> R_co: ...
+
+    def __get__(
+        self, instance: Categorizable, owner: type | None = None
+    ) -> BoundCheckFunction[R_co]:
+        """Checks are methods, so looking one up on a checker binds it."""
+
+
+def annotate_check(checkfunc: Callable[..., R_co]) -> CheckFunction[R_co]:
     """
     Annotate check function with title attribute.
 
     This is generated from the first list of docstring removing any
     extra whitespace caused by indentation.
     """
-    docstring = checkfunc.__doc__.strip().split("\n\n")[0]
-    checkfunc.title = " ".join(docstring.split())
+    check = cast("CheckFunction[R_co]", checkfunc)
+    docstring = (checkfunc.__doc__ or "").strip().split("\n\n")[0]
+    check.title = " ".join(docstring.split())
+
+    return check
 
 
-def critical(f):
+def critical(f: UndecoratedCheck[R_co]) -> CheckFunction[R_co]:
     @wraps(f)
-    def critical_f(self, *args, **kwargs):
+    def critical_f(self: Categorizable, *args, **kwargs) -> R_co:
         if f.__name__ not in self.categories:
             self.categories[f.__name__] = Category.CRITICAL
 
         return f(self, *args, **kwargs)
 
-    annotate_check(critical_f)
-    return critical_f
+    return annotate_check(critical_f)
 
 
-def functional(f):
+def functional(f: UndecoratedCheck[R_co]) -> CheckFunction[R_co]:
     @wraps(f)
-    def functional_f(self, *args, **kwargs):
+    def functional_f(self: Categorizable, *args, **kwargs) -> R_co:
         if f.__name__ not in self.categories:
             self.categories[f.__name__] = Category.FUNCTIONAL
 
         return f(self, *args, **kwargs)
 
-    annotate_check(functional_f)
-    return functional_f
+    return annotate_check(functional_f)
 
 
-def cosmetic(f):
+def cosmetic(f: UndecoratedCheck[R_co]) -> CheckFunction[R_co]:
     @wraps(f)
-    def cosmetic_f(self, *args, **kwargs):
+    def cosmetic_f(self: Categorizable, *args, **kwargs) -> R_co:
         if f.__name__ not in self.categories:
             self.categories[f.__name__] = Category.COSMETIC
 
         return f(self, *args, **kwargs)
 
-    annotate_check(cosmetic_f)
-    return cosmetic_f
+    return annotate_check(cosmetic_f)
 
 
-def extraction(f):
+def extraction(f: UndecoratedCheck[R_co]) -> CheckFunction[R_co]:
     @wraps(f)
-    def extraction_f(self, *args, **kwargs):
+    def extraction_f(self: Categorizable, *args, **kwargs) -> R_co:
         if f.__name__ not in self.categories:
             self.categories[f.__name__] = Category.EXTRACTION
 
         return f(self, *args, **kwargs)
 
-    annotate_check(extraction_f)
-    return extraction_f
+    return annotate_check(extraction_f)


### PR DESCRIPTION
Complete type annotations in `translate.filters.checks` and corresponding tests

Configure ruff to check annotations in those two directories only

Ruff 0.16.4 also insists on rewriting rule codes to names in pyproject.toml, this is also ignored for now but should probably be auto-fixed in a subsequent PR