### PR TITLE
fix: validate QM message lengths

### DIFF
--- a/tests/translate/storage/test_qm.py
+++ b/tests/translate/storage/test_qm.py
@@ -1,8 +1,22 @@
+import struct
+from io import BytesIO
+
 import pytest
 
-from translate.storage import qm
+from translate.storage import factory, qm
 
 from . import test_base
+
+
+def make_qm(messages: bytes, trailing: bytes = b"") -> bytes:
+    """Build a QM file containing one messages section."""
+    magic = struct.pack(">4L", *qm.QM_MAGIC_NUMBER)
+    return magic + struct.pack(">BL", 0x69, len(messages)) + messages + trailing
+
+
+def make_length_record(subsection: int, length: int, payload: bytes = b"") -> bytes:
+    """Build a message record with a signed length."""
+    return bytes([subsection]) + struct.pack(">l", length) + payload
 
 
 class TestQtUnit(test_base.TestTranslationUnit):
@@ -13,9 +27,62 @@ class TestQtFile(test_base.TestTranslationStore):
     StoreClass = qm.qmfile
 
     def test_parse(self) -> None:
-        # self.reparse relies on __str__ to be output and then parsed
-        # qm.py does not implement serialization
-        pass
+        messages = (
+            make_length_record(0x03, -1)
+            + make_length_record(0x06, 6, b"source")
+            + b"\x01"
+        )
+
+        store = self.StoreClass.parsestring(make_qm(messages))
+
+        assert len(store.units) == 1
+        assert store.units[0].source == "source"
+        assert store.units[0].target == ""
+
+    @pytest.mark.parametrize("subsection", [0x06, 0x07, 0x08])
+    def test_negative_byte_string_length(self, subsection: int) -> None:
+        messages = make_length_record(subsection, -5, b"abcd")
+
+        with pytest.raises(ValueError, match="length out of range"):
+            self.StoreClass.parsestring(make_qm(messages))
+
+    def test_negative_translation_length(self) -> None:
+        with pytest.raises(ValueError, match="invalid translation length"):
+            self.StoreClass.parsestring(make_qm(make_length_record(0x03, -2)))
+
+    def test_odd_translation_length(self) -> None:
+        messages = make_length_record(0x03, 1, b"a")
+
+        with pytest.raises(ValueError, match="invalid translation length"):
+            self.StoreClass.parsestring(make_qm(messages))
+
+    @pytest.mark.parametrize("subsection", [0x03, 0x05, 0x06, 0x07, 0x08])
+    def test_truncated_message_record(self, subsection: int) -> None:
+        messages = bytes([subsection]) + b"\x00\x00\x00"
+
+        with pytest.raises(ValueError, match="message record truncated"):
+            self.StoreClass.parsestring(make_qm(messages))
+
+    @pytest.mark.parametrize("subsection", [0x03, 0x06, 0x07, 0x08])
+    def test_message_payload_out_of_range(self, subsection: int) -> None:
+        messages = make_length_record(subsection, 2)
+
+        with pytest.raises(ValueError, match="length out of range"):
+            self.StoreClass.parsestring(make_qm(messages))
+
+    def test_message_payload_cannot_cross_section_boundary(self) -> None:
+        messages = make_length_record(0x06, 1)
+        trailing_section = struct.pack(">BLB", 0x42, 1, 0)
+
+        with pytest.raises(ValueError, match="source length out of range"):
+            self.StoreClass.parsestring(make_qm(messages, trailing_section))
+
+    def test_factory_rejects_negative_length(self) -> None:
+        input_file = BytesIO(make_qm(make_length_record(0x06, -5, b"abcd")))
+        input_file.name = "evil.qm"
+
+        with pytest.raises(ValueError, match="source length out of range"):
+            factory.getobject(input_file)
 
     def test_save(self) -> None:
         # QM does not implement saving

--- a/translate/storage/qm.py
+++ b/translate/storage/qm.py
@@ -157,8 +157,9 @@ class qmfile(base.TranslationStore):
                 section_debug("Unknown", section_type, startsection, length)
             startsection = startsection + sectionheader + length
         pos = messages_start
+        messages_end = messages_start + len(messages_data)
         source = target = None
-        while pos < messages_start + len(messages_data):
+        while pos < messages_end:
             (subsection,) = struct.unpack(">B", input[pos : pos + 1])
             if subsection == 0x01:  # End
                 pos += 1
@@ -170,30 +171,48 @@ class qmfile(base.TranslationStore):
                     raise ValueError("Old .qm format with no source defined")
                 continue
             pos += 1
-            (length,) = struct.unpack(">l", input[pos : pos + 4])
+            if pos + 4 > messages_end:
+                raise ValueError("This is not a .qm file: message record truncated")
             if subsection == 0x03:  # Translation
-                if length != -1:
-                    (raw,) = struct.unpack(
-                        f">{length}s", input[pos + 4 : pos + 4 + length]
-                    )
+                (length,) = struct.unpack(">l", input[pos : pos + 4])
+                pos += 4
+                if length == -1:
+                    target = ""
+                else:
+                    if length < 0 or length % 2:
+                        raise ValueError(
+                            "This is not a .qm file: invalid translation length"
+                        )
+                    payload_end = pos + length
+                    if payload_end > messages_end:
+                        raise ValueError(
+                            "This is not a .qm file: translation length out of range"
+                        )
+                    raw = input[pos:payload_end]
                     string, _templen = codecs.utf_16_be_decode(raw)
                     if target:
                         target.extra_strings.append(string)
                     else:
                         target = multistring(string)
-                    pos = pos + 4 + length
-                else:
-                    target = ""
-                    pos += 4
-            elif subsection == 0x06:  # SourceText
-                source = input[pos + 4 : pos + 4 + length].decode("iso-8859-1")
-                pos = pos + 4 + length
-            elif subsection == 0x07:  # Context
-                # context = input[pos + 4:pos + 4 + length].decode('iso-8859-1')
-                pos = pos + 4 + length
-            elif subsection == 0x08:  # Disambiguating-comment
-                # comment = input[pos + 4:pos + 4 + length]
-                pos = pos + 4 + length
+                    pos = payload_end
+            elif subsection in {0x06, 0x07, 0x08}:
+                (length,) = struct.unpack(">L", input[pos : pos + 4])
+                pos += 4
+                payload_end = pos + length
+                if payload_end > messages_end:
+                    subsection_names = {
+                        0x06: "source",
+                        0x07: "context",
+                        0x08: "comment",
+                    }
+                    raise ValueError(
+                        f"This is not a .qm file: {subsection_names[subsection]} "
+                        "length out of range"
+                    )
+                if subsection == 0x06:  # SourceText
+                    source = input[pos:payload_end].decode("iso-8859-1")
+                # Context and disambiguating-comment are currently ignored.
+                pos = payload_end
             elif subsection == 0x05:  # hash
                 # hash = input[pos:pos + 4]
                 pos += 4


### PR DESCRIPTION
Reject malformed records before advancing the cursor. This prevents negative byte-string lengths from moving the parser backwards and causing an infinite CPU loop.