### PR TITLE
fix(stringsdict): fold simple plural entries

### DIFF
--- a/docs/formats/stringsdict.rst
+++ b/docs/formats/stringsdict.rst
@@ -13,6 +13,12 @@ many, other) in a plist (property list) format.
 The Translate Toolkit supports .stringsdict files via
 ``translate.storage.stringsdict``.
 
+Entries whose localized format is a direct reference to a single plural
+variable are exposed as one plural unit. The variable name is included in the
+unit identifier, for example ``items:count``. Entries containing literal text
+in the localized format or multiple plural variables are exposed as separate
+format and plural units.
+
 .. seealso::
 
    :doc:`strings`

--- a/tests/translate/storage/test_stringsdict.py
+++ b/tests/translate/storage/test_stringsdict.py
@@ -1,9 +1,11 @@
 import plistlib
 from io import BytesIO
 
+import pytest
+
 from translate.lang import data
 from translate.misc.multistring import multistring
-from translate.storage import stringsdict
+from translate.storage import base, stringsdict
 
 from . import test_monolingual
 
@@ -32,6 +34,14 @@ class TestStringsDictUnit(test_monolingual.TestMonolingualUnit):
         unit.format_value_type = "d"
         assert unit == unit2
 
+    def test_eq_other_unit_type(self) -> None:
+        unit = self.UnitClass("Test String:p")
+        unit.target = "target"
+        unit2 = base.TranslationUnit("Test String:p")
+        unit2.target = "target"
+
+        assert unit != unit2
+
     def test_innerkey(self) -> None:
         unit = self.UnitClass()
         unit.set_unitid(unit.IdClass([("key", "Test String"), ("key", "p")]))
@@ -41,6 +51,22 @@ class TestStringsDictUnit(test_monolingual.TestMonolingualUnit):
 
 class TestStringsDictFile(test_monolingual.TestMonolingualStore):
     StoreClass = stringsdict.StringsDictFile
+
+    @staticmethod
+    def get_simple_plural(
+        localized_format="%#@count@", *, include_format=True, include_plural=True
+    ):
+        outer = {}
+        if include_format:
+            outer["NSStringLocalizedFormatKey"] = localized_format
+        if include_plural:
+            outer["count"] = {
+                "NSStringFormatSpecTypeKey": "NSStringPluralRuleType",
+                "NSStringFormatValueTypeKey": "d",
+                "one": "One item",
+                "other": "%d items",
+            }
+        return {"items": outer}
 
     def test_serialize(self) -> None:
         content = b"""<?xml version="1.0" encoding="UTF-8"?>
@@ -102,6 +128,118 @@ class TestStringsDictFile(test_monolingual.TestMonolingualStore):
 
         newstore = self.reparse(store)
         self.check_equality(store, newstore)
+
+    def test_single_plural_is_folded(self) -> None:
+        store = self.StoreClass()
+        store.settargetlanguage("en")
+        store.parse(plistlib.dumps(self.get_simple_plural()))
+
+        assert len(store.units) == 1
+        unit = store.units[0]
+        assert unit.source == "items:count"
+        assert unit.target.strings == ["", "One item", "%d items"]
+        assert unit.localized_format == "%#@count@"
+        assert unit.format_value_type == "d"
+
+        newstore = self.reparse(store)
+        self.check_equality(store, newstore)
+
+    def test_single_plural_preserves_positional_format(self) -> None:
+        store = self.StoreClass()
+        store.settargetlanguage("en")
+        store.parse(plistlib.dumps(self.get_simple_plural("%1$#@count@")))
+
+        assert len(store.units) == 1
+        assert store.units[0].localized_format == "%1$#@count@"
+
+        output = plistlib.loads(bytes(store))
+        assert output["items"]["NSStringLocalizedFormatKey"] == "%1$#@count@"
+
+        store.units[0].setid(store.units[0].getid())
+        output = plistlib.loads(bytes(store))
+        assert output["items"]["NSStringLocalizedFormatKey"] == "%1$#@count@"
+
+    def test_single_plural_with_literal_format_is_not_folded(self) -> None:
+        store = self.StoreClass()
+        store.settargetlanguage("en")
+        store.parse(plistlib.dumps(self.get_simple_plural("There are %#@count@.")))
+
+        assert [unit.source for unit in store.units] == ["items", "items:count"]
+        assert store.units[0].target == "There are %#@count@."
+        assert store.units[1].localized_format is None
+
+        newstore = self.reparse(store)
+        self.check_equality(store, newstore)
+
+    def test_format_only_plural_is_folded(self) -> None:
+        store = self.StoreClass()
+        store.settargetlanguage("en")
+        store.parse(plistlib.dumps(self.get_simple_plural(include_plural=False)))
+
+        assert len(store.units) == 1
+        unit = store.units[0]
+        assert unit.source == "items:count"
+        assert unit.target.strings == ["", "", ""]
+        assert unit.localized_format == "%#@count@"
+
+        # Do not serialize the incomplete entry.
+        assert plistlib.loads(bytes(store)) == {}
+
+        unit.target = multistring(["", "One item", "%d items"])
+        output = plistlib.loads(bytes(store))["items"]
+        assert output["NSStringLocalizedFormatKey"] == "%#@count@"
+        assert output["count"]["other"] == "%d items"
+        assert "NSStringFormatValueTypeKey" not in output["count"]
+
+    def test_plural_only_is_omitted_without_format(self) -> None:
+        store = self.StoreClass()
+        store.settargetlanguage("en")
+        store.parse(plistlib.dumps(self.get_simple_plural(include_format=False)))
+
+        assert len(store.units) == 1
+        unit = store.units[0]
+        assert unit.source == "items:count"
+        assert unit.localized_format is None
+
+        # The missing format might have contained literal text, so it cannot be
+        # reconstructed safely from the plural variable name.
+        assert plistlib.loads(bytes(store)) == {}
+
+    def test_new_plural_synthesizes_format(self) -> None:
+        store = self.StoreClass()
+        store.settargetlanguage("en")
+        unit = store.UnitClass("items:amount")
+        unit.target = multistring(["", "One item", "%d items"])
+        store.addunit(unit)
+
+        output = plistlib.loads(bytes(store))["items"]
+        assert output["NSStringLocalizedFormatKey"] == "%#@amount@"
+        assert output["amount"]["other"] == "%d items"
+
+    def test_set_unitid_plural_synthesizes_format(self) -> None:
+        store = self.StoreClass()
+        store.settargetlanguage("en")
+        unit = store.UnitClass()
+        unit.set_unitid(unit.IdClass([("key", "items"), ("key", "amount")]))
+        unit.target = multistring(["", "One item", "%d items"])
+        store.addunit(unit)
+
+        output = plistlib.loads(bytes(store))["items"]
+        assert output["NSStringLocalizedFormatKey"] == "%#@amount@"
+        assert output["amount"]["other"] == "%d items"
+
+    def test_new_plural_requires_variable_in_id(self) -> None:
+        store = self.StoreClass()
+        store.settargetlanguage("en")
+        unit = store.UnitClass("items")
+        unit.target = multistring(["", "One item", "%d items"])
+        store.addunit(unit)
+
+        with pytest.raises(
+            TypeError,
+            match="Plural stringsdict unit IDs must include a variable name",
+        ):
+            bytes(store)
 
     def test_targetlanguage_default_handlings(self) -> None:
         store = self.StoreClass()

--- a/translate/storage/stringsdict.py
+++ b/translate/storage/stringsdict.py
@@ -6,6 +6,8 @@ from translate.lang import data
 from translate.misc.multistring import multistring
 from translate.storage import base
 
+PLURAL_REFERENCE_RE = re.compile(r"%(?:\d+\$)?#@(?P<variable>[^@]+)@")
+
 
 class StringsDictId(base.UnitId):
     KEY_SEPARATOR = ":"
@@ -20,8 +22,10 @@ class StringsDictId(base.UnitId):
 class StringsDictUnit(base.DictUnit):
     """
     A single entry in a .stringsdict file.
-    One entry represents either a localized format string, or a variable used
-    within another string.
+
+    Simple plural entries are represented by their plural variable, with the
+    localized format string stored as metadata. More complex entries use one
+    unit for the localized format string and one unit for each plural variable.
     """
 
     IdClass = StringsDictId
@@ -29,6 +33,8 @@ class StringsDictUnit(base.DictUnit):
 
     def __init__(self, source=None) -> None:
         super().__init__(source=source)
+        self.format_value_type = ""
+        self.localized_format: str | None = None
 
         loc = source or ""
         if len(loc) > 0 and loc[0] == ":":  # ty:ignore[index-out-of-bounds]
@@ -45,7 +51,10 @@ class StringsDictUnit(base.DictUnit):
 
     def __eq__(self, other):
         return (
-            super().__eq__(other) and self.format_value_type == other.format_value_type
+            isinstance(other, StringsDictUnit)
+            and super().__eq__(other)
+            and self.format_value_type == other.format_value_type
+            and self.localized_format == other.localized_format
         )
 
     @property
@@ -70,8 +79,13 @@ class StringsDictUnit(base.DictUnit):
         return self.source
 
     def setid(self, value, unitid=None) -> None:
+        previous_innerkey = (
+            self.innerkey if getattr(self, "_unitid", None) is not None else None
+        )
         self.source = value
         super().setid(value, unitid)
+        if self.innerkey is not None and self.innerkey != previous_innerkey:
+            self.localized_format = f"%#@{self.innerkey}@"
 
 
 class StringsDictFile(base.DictStore):
@@ -81,8 +95,10 @@ class StringsDictFile(base.DictStore):
     One entry in a .stringsdict file consists of a format string, and any
     number of variables with plural strings.
 
-    Each entry is split up into multiple translation units, containing either
-    the format string or one of the variables.
+    Entries containing a single plural variable referenced directly by the
+    localized format string are exposed as one plural unit. Entries with
+    literal format text or multiple variables are split into a format-string
+    unit and one plural unit per variable.
     """
 
     UnitClass = StringsDictUnit
@@ -154,59 +170,151 @@ class StringsDictFile(base.DictStore):
         for key, outer in plist.items():
             if not isinstance(outer, dict):
                 raise TypeError(f"{key} is not a dict")
+
+            localized_format = outer.get("NSStringLocalizedFormatKey")
+            plural_values = []
             for innerkey, value in outer.items():
                 if innerkey == "NSStringLocalizedFormatKey":
-                    u = self.UnitClass()
-                    u.set_unitid(u.IdClass([("key", key)]))
-                    u.target = str(value)
-                    self.addunit(u)
-                elif isinstance(value, dict):
-                    spec_type = value.get("NSStringFormatSpecTypeKey", "")
-                    if spec_type and spec_type != "NSStringPluralRuleType":
-                        raise ValueError(
-                            f"{innerkey} in {key} is not of NSStringPluralRuleType"
-                        )
+                    continue
+                if not isinstance(value, dict):
+                    raise TypeError(f"Unexpected key {innerkey} in {key}")
 
-                    plural_tags = self.target_plural_tags
-                    plural_strings = [value.get(tag, "") for tag in plural_tags]
+                spec_type = value.get("NSStringFormatSpecTypeKey", "")
+                if spec_type and spec_type != "NSStringPluralRuleType":
+                    raise ValueError(
+                        f"{innerkey} in {key} is not of NSStringPluralRuleType"
+                    )
+                plural_values.append((innerkey, value))
 
-                    u = self.UnitClass()
-                    u.set_unitid(u.IdClass([("key", key), ("key", innerkey)]))
-                    u.target = multistring(plural_strings)
-                    u.format_value_type = value.get("NSStringFormatValueTypeKey", "")
-                    self.addunit(u)
-                else:
-                    raise ValueError(f"Unexpected key {innerkey} in {key}")
+            reference_match = (
+                PLURAL_REFERENCE_RE.fullmatch(localized_format)
+                if isinstance(localized_format, str)
+                else None
+            )
+            referenced_variable = (
+                reference_match.group("variable") if reference_match else None
+            )
+
+            # Fold the common one-variable representation into one plural unit.
+            # A pure format-only entry still identifies its plural variable and
+            # is handled below as an untranslated folded unit.
+            if len(plural_values) == 1 and referenced_variable == plural_values[0][0]:
+                innerkey, value = plural_values[0]
+                self._add_plural_unit(
+                    key,
+                    innerkey,
+                    value,
+                    localized_format=localized_format,
+                )
+                continue
+
+            if not plural_values and referenced_variable is not None:
+                self._add_plural_unit(
+                    key,
+                    referenced_variable,
+                    {},
+                    localized_format=localized_format,
+                )
+                continue
+
+            if localized_format is not None:
+                u = self.UnitClass()
+                u.set_unitid(u.IdClass([("key", key)]))
+                u.target = str(localized_format)
+                self.addunit(u)
+
+            for innerkey, value in plural_values:
+                self._add_plural_unit(key, innerkey, value)
+
+    def _add_plural_unit(
+        self,
+        outerkey: str,
+        innerkey: str,
+        value: dict,
+        *,
+        localized_format: str | None = None,
+    ) -> None:
+        plural_tags = self.target_plural_tags
+        plural_strings = [value.get(tag, "") for tag in plural_tags]
+
+        unit = self.UnitClass()
+        unit.set_unitid(unit.IdClass([("key", outerkey), ("key", innerkey)]))
+        unit.target = multistring(plural_strings)
+        unit.format_value_type = value.get("NSStringFormatValueTypeKey", "")
+        unit.localized_format = localized_format
+        self.addunit(unit)
+
+    def _serialize_plural(self, unit: StringsDictUnit) -> dict:
+        plurals = {"NSStringFormatSpecTypeKey": "NSStringPluralRuleType"}
+        if unit.format_value_type:
+            plurals["NSStringFormatValueTypeKey"] = unit.format_value_type
+
+        plural_tags = self._get_target_plural_tags(unit.target)
+        plural_strings = self.UnitClass.sync_plural_count(unit.target, plural_tags)
+        plurals.update(
+            (plural_tag, plural_string)
+            for plural_tag, plural_string in zip(
+                plural_tags, plural_strings, strict=True
+            )
+            if plural_string
+        )
+        return plurals
 
     def serialize(self, out) -> None:
         plist = {}
 
-        for u in self.units:
-            loc = u.outerkey
-            subkey = u.innerkey
+        grouped_units = {}
+        for unit in self.units:
+            grouped_units.setdefault(unit.outerkey, []).append(unit)
 
-            if loc not in plist:
-                plist[loc] = {}
+        for outerkey, units in grouped_units.items():
+            format_units = [unit for unit in units if unit.innerkey is None]
+            plural_units = [unit for unit in units if unit.innerkey is not None]
 
-            if subkey is not None:
-                plurals = {}
-                plurals["NSStringFormatSpecTypeKey"] = "NSStringPluralRuleType"
-                plurals["NSStringFormatValueTypeKey"] = u.format_value_type
-
-                plural_tags = self._get_target_plural_tags(u.target)
-
-                # Sync plural_strings elements to plural_tags count.
-                plural_strings = self.UnitClass.sync_plural_count(u.target, plural_tags)
-                plurals.update(
-                    (plural_tag, plural_string)
-                    for plural_tag, plural_string in zip(
-                        plural_tags, plural_strings, strict=True
-                    )
-                    if plural_string
+            # A newly created one-variable plural uses the same folded form as
+            # parsed entries. Its ID supplies the variable name and therefore
+            # the canonical localized format string.
+            if (
+                len(plural_units) == 1
+                and not format_units
+                and plural_units[0].localized_format is not None
+            ):
+                unit = plural_units[0]
+                plural_tags = self._get_target_plural_tags(unit.target)
+                plural_strings = self.UnitClass.sync_plural_count(
+                    unit.target, plural_tags
                 )
 
-                plist[loc][subkey] = plurals
-            else:
-                plist[loc]["NSStringLocalizedFormatKey"] = u.target or u.source
+                # Omit an untranslated or incomplete entry instead of writing
+                # a dictionary which Apple cannot resolve at runtime.
+                if (
+                    "other" not in plural_tags
+                    or not plural_strings[plural_tags.index("other")]
+                ):
+                    continue
+
+                plist[outerkey] = {
+                    "NSStringLocalizedFormatKey": unit.localized_format
+                    or f"%#@{unit.innerkey}@",
+                    unit.innerkey: self._serialize_plural(unit),
+                }
+                continue
+
+            # A plural-only parsed group may depend on a missing complex format
+            # sibling. Its original format cannot be reconstructed safely.
+            if plural_units and not format_units:
+                continue
+
+            output = {}
+            for unit in units:
+                if unit.innerkey is None:
+                    if isinstance(unit.target, multistring):
+                        raise TypeError(
+                            "Plural stringsdict unit IDs must include a variable name"
+                        )
+                    output["NSStringLocalizedFormatKey"] = unit.target or unit.source
+                else:
+                    output[unit.innerkey] = self._serialize_plural(unit)
+            plist[outerkey] = output
 
         out.write(plistlib.dumps(plist, sort_keys=False))


### PR DESCRIPTION
Keep direct single-variable format references with their plural unit so partial translations cannot serialize invalid sibling dictionaries.

Fixes WeblateOrg/weblate#21294