### PR TITLE
chore(typing): Extend DumpArgsType

### DIFF
--- a/translate/storage/jsonl10n.py
+++ b/translate/storage/jsonl10n.py
@@ -174,6 +174,7 @@ class DumpArgsType(TypedDict):
     indent: int
     ensure_ascii: bool
     sort_keys: NotRequired[bool]
+    cls: NotRequired[type[json.JSONEncoder]]
 
 
 JsonUnit = TypeVar("JsonUnit", bound=BaseJsonUnit)


### PR DESCRIPTION
Extend `DumpArgsType` to cover `cls` argument introduced in https://github.com/WeblateOrg/weblate/pull/21336 and accepted by `json.dumps`
