### PR TITLE
fix(lang): correct RTL detection for script-specific and missing codes

### DIFF
--- a/tests/translate/lang/test_data.py
+++ b/tests/translate/lang/test_data.py
@@ -45,3 +45,31 @@ def test_is_rtl() -> None:
     # Edge cases
     assert data.is_rtl("") is False
     assert data.is_rtl(None) is False
+
+
+def test_is_rtl_script_specific_codes() -> None:
+    """RTL variants of languages whose base language is not RTL."""
+    # Punjabi is Gurmukhi (LTR) in India and Shahmukhi (Perso-Arabic) in Pakistan
+    assert data.is_rtl("pa") is False
+    assert data.is_rtl("pa_PK") is True
+    assert data.is_rtl("pa-PK") is True
+    # Malay is Latin by default and Jawi (Perso-Arabic) when tagged as such
+    assert data.is_rtl("ms") is False
+    assert data.is_rtl("ms_Arab") is True
+    assert data.is_rtl("ms-Arab") is True
+
+
+def test_rtl_langs_are_all_reachable() -> None:
+    """Every code listed in RTL_LANGS has to be detected by is_rtl()."""
+    assert [code for code in sorted(data.RTL_LANGS) if not data.is_rtl(code)] == []
+
+
+def test_is_rtl_perso_arabic_and_hebrew_script_languages() -> None:
+    """Languages CLDR resolves to an RTL script."""
+    for code in ("azb", "glk", "haz", "lki", "hno", "swb", "prs"):
+        assert data.is_rtl(code) is True, code
+    for code in ("jpr", "jrb", "lad"):
+        assert data.is_rtl(code) is True, code
+    # Tuareg varieties: CLDR resolves these to the Latin script
+    for code in ("tmh", "ttq", "thv"):
+        assert data.is_rtl(code) is False, code

--- a/translate/lang/data.py
+++ b/translate/lang/data.py
@@ -1156,36 +1156,56 @@ RTL_LANGS = {
     "ars",
     "arz",
     "ave",
+    "azb",
     "bal",
+    "bej",
     "bgn",
     "bqi",
+    "brh",
+    "chg",
     "ckb",
     "ckb_IR",
+    "dcc",
     "dv",
     "egy",
     "fa",
     "fa_AF",
     "fas",
+    "glk",
     "ha",
+    "hac",
+    "haz",
     "he",
     "heb",
+    "hnd",
+    "hno",
+    "jpr",
+    "jrb",
     "khw",
     "ks",
+    "lad",
+    "lki",
     "lrc",
     "luz",
+    "mey",
+    "mfa",
     "ms_Arab",
     "mzn",
     "nqo",
+    "ota",
     "pa_PK",
     "pal",
     "per",
     "phn",
+    "prs",
     "ps",
     "rhg",
+    "rmt",
     "sam",
     "sd",
     "sdh",
     "skr",
+    "swb",
     "syc",
     "syr",
     "ug",
@@ -1208,6 +1228,11 @@ def _normalize_to_underscore(code: str) -> str:
     return code.replace("-", "_").replace("@", "_").lower()
 
 
+_NORMALIZED_RTL_LANGS = {_normalize_to_underscore(code) for code in RTL_LANGS}
+"""RTL_LANGS normalized for lookup, as RTL_LANGS keeps the canonical casing of
+region and script subtags (``pa_PK``, ``ms_Arab``)."""
+
+
 def is_rtl(language_code: str | None) -> bool:
     """
     Check if a language is right-to-left.
@@ -1223,11 +1248,11 @@ def is_rtl(language_code: str | None) -> bool:
     # Normalize the language code (convert hyphens to underscores)
     normalized = _normalize_to_underscore(language_code)
     # Check both the full code and the base language code
-    if normalized in RTL_LANGS:
+    if normalized in _NORMALIZED_RTL_LANGS:
         return True
     # Check base language (e.g., 'ar' for 'ar_SA')
     base = normalized.split("_")[0]
-    return base in RTL_LANGS
+    return base in _NORMALIZED_RTL_LANGS
 
 
 def get_language(code):


### PR DESCRIPTION
Two defects in `translate.lang.data.is_rtl()`, which `po2html` uses to write the `dir` attribute (`translate/storage/html.py:765`).

**1. Two codes are listed in `RTL_LANGS` but unreachable.** `is_rtl()` lowercases its argument via `_normalize_to_underscore()`, then tests it against `RTL_LANGS`, which keeps the canonical casing of region and script subtags. On current master:

```python
>>> [c for c in sorted(data.RTL_LANGS) if not data.is_rtl(c)]
['ms_Arab', 'pa_PK']
```

The other 11 mixed-case entries (`ar_SA`, `fa_AF`, …) survive only because their base language is itself RTL. `ms` and `pa` are not, so nothing recovers them: `is_rtl("pa_PK")` is `False` for Punjabi in Shahmukhi, `is_rtl("ms_Arab")` is `False` for Malay in Jawi. CLDR `likelySubtags` maps `pa-PK` → `pa-Arab-PK` but `pa` → `pa-Guru-IN`, so the region-qualified entry is the only thing that can be right. The fix compares against a normalized copy, leaving `RTL_LANGS` itself mirroring upstream.

**2. `RTL_LANGS` is 20 codes behind the upstream it cites.** 23 codes are missing relative to `WeblateOrg/language-data`. Rather than sync blindly I resolved each through CLDR `likelySubtags` to a script and checked CLDR `scriptMetadata`:

- 20 resolve to `Arab` or `Hebr` (`rtl: YES`) and are added: azb, bej, brh, chg, dcc, glk, hac, haz, hnd, hno, jpr, jrb, lad, lki, mey, mfa, ota, prs, rmt, swb. (`prs` is a CLDR "overlong" alias of `fa-AF`, already listed.)
- **3 are deliberately left out:** `tmh` and `thv` resolve to `Latn`, and `ttq` is a CLDR macrolanguage alias of `tmh`. Upstream lists them as RTL; CLDR does not agree, so a test pins them `False`.

`test_is_rtl` enumerates 8 hand-picked codes from the same table, so neither defect could fail it. Each added test isolates one half: reverting the source fails all three, the data additions alone still fail the two reachability tests, the lookup fix alone still fails the CLDR-script test, and adding all 23 upstream codes fails the Tuareg assertions.

`uv run python -m pytest tests/` 5100 → 5103. `prek run --all-files`, `pylint translate/ tests/` (10.00/10) and `ty check` clean.
