### PR TITLE
fix(xml): honor inherited xml:space

### DIFF
--- a/tests/translate/misc/test_xml_helpers.py
+++ b/tests/translate/misc/test_xml_helpers.py
@@ -1,6 +1,13 @@
 from lxml import etree
 
-from translate.misc.xml_helpers import XMLTextParser, parse_xml, reindent
+from translate.misc.xml_helpers import (
+    XMLTextParser,
+    getText,
+    getXMLspace,
+    getXMLspaceInherited,
+    parse_xml,
+    reindent,
+)
 
 
 class UppercaseXMLTextParser(XMLTextParser):
@@ -18,6 +25,31 @@ def test_xml_text_parser_preserves_markup() -> None:
         "PLAIN<é title='Bob&apos;s'>INNER</é>"
         "<![CDATA[Don't]]><!-- Don't --><?test Don't?>&brand;"
     )
+
+
+def test_xml_space_inheritance() -> None:
+    root = parse_xml(
+        '<root xml:space="preserve"><parent xml:space="default">'
+        '<child/><sibling xml:space="preserve"/>'
+        "</parent></root>"
+    )
+    child = root[0][0]
+    sibling = root[0][1]
+
+    assert getXMLspace(child) is None
+    assert getXMLspaceInherited(child) == "default"
+    assert getXMLspaceInherited(sibling) == "preserve"
+    assert getXMLspaceInherited(etree.Element("detached"), "fallback") == "fallback"
+
+
+def test_gettext_uses_inherited_xml_space() -> None:
+    root = parse_xml(
+        '<root xml:space="preserve"><preserved> File  1 </preserved>'
+        '<normalized xml:space="default"> File  2 </normalized></root>'
+    )
+
+    assert getText(root[0], "default") == " File  1 "
+    assert getText(root[1], "preserve") == "File 2"
 
 
 class TestReindent:

--- a/tests/translate/storage/placeables/test_lisa.py
+++ b/tests/translate/storage/placeables/test_lisa.py
@@ -62,6 +62,20 @@ def test_xml_space() -> None:
     assert elem.sub == [StringElem("a "), X(id="foo[1]/bar[1]/baz[1]"), StringElem(" ")]
 
 
+def test_inherited_xml_space() -> None:
+    root = parse_xml(
+        '<root xml:space="preserve"><source> a '
+        '<x id="foo[1]/bar[1]/baz[1]"/> </source></root>'
+    )
+    elem = lisa.xml_to_strelem(root[0], xml_space="default")
+
+    assert elem.sub == [
+        StringElem(" a "),
+        X(id="foo[1]/bar[1]/baz[1]"),
+        StringElem(" "),
+    ]
+
+
 def test_chunk_list() -> None:
     left = StringElem(
         [

--- a/tests/translate/storage/test_xliff.py
+++ b/tests/translate/storage/test_xliff.py
@@ -509,7 +509,7 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert xlifffile.units[0].source == "File 1"
         root_node = xlifffile.document.getroot()
         setXMLspace(root_node, "preserve")
-        assert xlifffile.units[0].source == "File 1"
+        assert xlifffile.units[0].source == " File  1 "
         setXMLspace(root_node, "default")
         assert xlifffile.units[0].source == "File 1"
 
@@ -524,9 +524,36 @@ class TestXLIFFfile(test_base.TestTranslationStore):
         assert xlifffile.units[0].source == "File 1"
         root_node = xlifffile.document.getroot()
         setXMLspace(root_node, "preserve")
-        assert xlifffile.units[0].source == "File 1"
+        assert xlifffile.units[0].source == " File  1\n"
         setXMLspace(root_node, "default")
         assert xlifffile.units[0].source == "File 1"
+
+    def test_xml_space_inherited_from_file_and_group(self) -> None:
+        xlfsource = (
+            self.skeleton.replace(
+                '<file original="doc.txt"',
+                '<file xml:space="preserve" original="doc.txt"',
+            )
+            % """<group>
+                  <trans-unit id="1">
+                    <source> File  1 </source>
+                    <target> Target  1 </target>
+                  </trans-unit>
+                </group>"""
+        )
+        unit = self.StoreClass.parsestring(xlfsource).units[0]
+
+        assert unit.source == " File  1 "
+        assert unit.target == " Target  1 "
+        assert str(unit.rich_source[0]) == " File  1 "
+        assert str(unit.rich_target[0]) == " Target  1 "
+
+        xlfsource = xlfsource.replace("<group>", '<group xml:space="default">')
+        overridden_unit = self.StoreClass.parsestring(xlfsource).units[0]
+        assert overridden_unit.source == "File 1"
+        assert overridden_unit.target == "Target 1"
+        assert str(overridden_unit.rich_source[0]) == "File 1"
+        assert str(overridden_unit.rich_target[0]) == "Target 1"
 
     def test_parsing(self) -> None:
         xlfsource = (

--- a/tests/translate/storage/test_xliff2.py
+++ b/tests/translate/storage/test_xliff2.py
@@ -97,6 +97,33 @@ class TestXLIFF2file(test_base.TestTranslationStore):
         assert newfile.units[0].source == "Hello"
         assert newfile.units[0].target == "Hola"
 
+    def test_inherited_xml_space(self) -> None:
+        xliff2_content = b"""<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="fr">
+  <file id="f1" xml:space="preserve">
+    <unit id="preserved">
+      <segment>
+        <source> Source  1 </source>
+        <target> Target  1 </target>
+      </segment>
+    </unit>
+    <unit id="normalized" xml:space="default">
+      <segment>
+        <source> Source  2 </source>
+        <target> Target  2 </target>
+      </segment>
+    </unit>
+  </file>
+</xliff>"""
+        xliff2file = xliff2.Xliff2File.parsestring(xliff2_content)
+
+        assert xliff2file.units[0].source == " Source  1 "
+        assert xliff2file.units[0].target == " Target  1 "
+        assert str(xliff2file.units[0].rich_target[0]) == " Target  1 "
+        assert xliff2file.units[1].source == "Source 2"
+        assert xliff2file.units[1].target == "Target 2"
+        assert str(xliff2file.units[1].rich_target[0]) == "Target 2"
+
     def test_language_attributes(self) -> None:
         """Test language attributes in XLIFF 2.0."""
         xliff2file = xliff2.Xliff2File()

--- a/tests/translate/tools/test_pomerge.py
+++ b/tests/translate/tools/test_pomerge.py
@@ -407,6 +407,32 @@ msgstr "Eerste\tTweede"
         assert unit.source == "red"
         assert unit.target == "rooi"
 
+    def test_xliff_preserves_inherited_xml_space(self) -> None:
+        skeleton = self.xliffskeleton.replace(
+            '<file original="filename.po"',
+            '<file xml:space="preserve" original="filename.po"',
+        )
+        templatexliff = (
+            skeleton
+            % """<trans-unit id="Queued">
+        <source>Queued</source>
+        <target>old target text</target>
+</trans-unit>"""
+        )
+        mergexliff = (
+            skeleton
+            % """<trans-unit id="Queued">
+        <source>Queued</source>
+        <target> leading and trailing spaces </target>
+</trans-unit>"""
+        )
+
+        xlifffile = self.mergexliff(templatexliff, mergexliff)
+        unit = self.singleunit(xlifffile)
+
+        assert unit.target == " leading and trailing spaces "
+        assert unit.get_target_dom().text == " leading and trailing spaces "
+
     def test_po_into_xliff(self) -> None:
         templatexliff = (
             self.xliffskeleton

--- a/translate/misc/xml_helpers.py
+++ b/translate/misc/xml_helpers.py
@@ -196,21 +196,14 @@ def getText(node, xml_space="preserve"):
     """
     Extracts the plain text content out of the given node.
 
-    This method checks the xml:space attribute of the given node, and takes an
-    optional default to use in case nothing is specified in this node.
+    This method resolves the effective xml:space attribute of the given node,
+    and takes an optional default to use in case nothing is specified on the
+    node or its ancestors.
     """
-    xml_space = getXMLspace(node, xml_space)
+    xml_space = getXMLspaceInherited(node, xml_space)
     if xml_space == "default":
         return str(string_xpath_normalized(node))  # specific to lxml.etree
     return str(string_xpath(node))  # specific to lxml.etree
-
-    # If we want to normalise space and only preserve it when the directive
-    # xml:space="preserve" is given in node or in parents, consider this code:
-    # xml_preserves = xml_preserve_ancestors(node)
-    # if xml_preserves and xml_preserves[-1] == "preserve":
-    #    return unicode(string_xpath(node)) # specific to lxml.etree
-    # else:
-    #    return unicode(string_xpath_normalized(node)) # specific to lxml.etree
 
 
 XML_NS = "http://www.w3.org/XML/1998/namespace"
@@ -232,6 +225,14 @@ def getXMLspace(node, default=None):
     if value is None:
         return default
     return value
+
+
+def getXMLspaceInherited(node, default=None):
+    """Gets the nearest xml:space attribute on node or its ancestors."""
+    values = xml_space_ancestors(node)
+    if values:
+        return str(values[-1])
+    return default
 
 
 def setXMLspace(node, value) -> None:

--- a/translate/storage/placeables/lisa.py
+++ b/translate/storage/placeables/lisa.py
@@ -22,7 +22,7 @@ from typing import Never
 from lxml import etree
 
 from translate.misc.xml_helpers import (
-    getXMLspace,
+    getXMLspaceInherited,
     normalize_xml_space,
     parse_xml,
 )
@@ -102,7 +102,7 @@ def xml_to_strelem(dom_node, xml_space="preserve"):
         return StringElem()
     if isinstance(dom_node, str):
         dom_node = parse_xml(dom_node)
-    xml_space = getXMLspace(dom_node) or xml_space
+    xml_space = getXMLspaceInherited(dom_node, xml_space)
     normalize_xml_space(dom_node, xml_space, remove_start=True)
     result = StringElem()
     sub = result.sub  # just an optimisation


### PR DESCRIPTION
XML defines xml:space as inherited, but text readers only inspected the current element and could discard significant whitespace.

Closes #2560