### PR TITLE
fix(markdown): preserve identity translations before legacy fallback

### DIFF
--- a/tests/translate/convert/test_po2md.py
+++ b/tests/translate/convert/test_po2md.py
@@ -429,6 +429,24 @@ You are only coming through in waves.
         assert "Die Website [OSPO Alliance DE](https://ospo-alliance.org)" in output
         assert "OSPO Alliance EN" not in output
 
+    def test_placeholder_identity_translation_beats_expanded(self) -> None:
+        """A current identity target takes precedence over an expanded key."""
+        self.given_markdown_file("See [docs](https://example.com).\n")
+        self.given_translation_file(
+            lines=[
+                'msgid "See [docs]{1}."',
+                'msgstr "See [docs]{1}."',
+                "",
+                'msgid "See [docs](https://example.com)."',
+                'msgstr "Other [docs](https://example.com)."',
+            ]
+        )
+        self.run_command("translation.po", "out.md", template="file.md")
+
+        assert self.read_testfile("out.md").decode() == (
+            "See [docs](https://example.com).\n"
+        )
+
     def test_no_placeholders_multiple_links(self) -> None:
         """po2md --no-placeholders: paragraph with multiple links is translated."""
         self.given_markdown_file(

--- a/tests/translate/convert/test_po2mdx.py
+++ b/tests/translate/convert/test_po2mdx.py
@@ -68,6 +68,32 @@ Another paragraph.
 
         assert output == b"### Anonyme Lernende {/* #anonymous */}\n"
 
+    def test_placeholder_identity_translation_beats_expanded(self):
+        """An identity target keeps its markup despite an expanded-key match."""
+        template = b"Text.<br /> [Read](../events/index.mdx)\n"
+        source = "Text.{1} [Read]{2}"
+        output = self.translate(
+            template,
+            [
+                (source, source),
+                (
+                    "Text.<br /> [Read](../events/index.mdx)",
+                    "Other.<br /> [Read](../events/index.mdx)",
+                ),
+            ],
+        )
+
+        assert output == template
+
+    def test_expanded_translation_preserves_literal_braces(self):
+        """A fallback target uses literal markup, not placeholder markers."""
+        output = self.translate(
+            b"See [docs](url).\n",
+            [("See [docs](url).", "Read [docs](url) and {1}.")],
+        )
+
+        assert output == b"Read [docs](url) and {1}.\n"
+
     def test_explicit_heading_id_identity_translation_beats_legacy(self):
         """A current identity translation wins over a stale legacy unit."""
         template = b"### Name {#name}\n"

--- a/tests/translate/storage/test_markdown.py
+++ b/tests/translate/storage/test_markdown.py
@@ -550,6 +550,31 @@ author: John Smith
             == "([*embedded image* ![moon](moon.jpg \"(the moon y'all)\")](/uri '(link title)'))\n"
         )
 
+    def test_identity_lookup_preserves_duplicate_occurrences(self) -> None:
+        """Presence checks must not consume the next translation occurrence."""
+        source = "See [docs]{1}."
+        targets = iter([source, "Read [docs]{1}."])
+
+        def callback(text: str) -> str:
+            return next(targets) if text == source else text
+
+        store = markdown.MarkdownFile(
+            inputfile=BytesIO(b"See [docs](url).\n\nSee [docs](url).\n"),
+            callback=callback,
+        )
+
+        assert store.filesrc == "See [docs](url).\n\nRead [docs](url).\n"
+
+    def test_identity_lookup_keeps_primary_translation(self) -> None:
+        """The presence lookup must not replace a context-selected identity."""
+        store = markdown.MarkdownFile(
+            inputfile=BytesIO(b"See [docs](url).\n"),
+            callback=lambda text: text,
+            lookup_callback=lambda text: "Other [docs]{1}.",
+        )
+
+        assert store.filesrc == "See [docs](url).\n"
+
     def test_placeholder_trimming(self) -> None:
         fragments = [
             markdown.Fragment("a", placeholder_content=[markdown.Fragment("")]),

--- a/translate/storage/markdown.py
+++ b/translate/storage/markdown.py
@@ -134,6 +134,7 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
         base.TranslationStore.__init__(self)
         self.filename = getattr(inputfile, "name", None)
         self.callback = callback or self._dummy_callback
+        self._last_translation: tuple[str, str] | None = None
         self.lookup_callback = (
             self._default_lookup_callback
             if lookup_callback is None
@@ -396,7 +397,10 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
 
     def _default_lookup_callback(self, text: str) -> str | None:
         """Adapt a translation callback to the lookup callback contract."""
-        translation = self.callback(text)
+        if self._last_translation is not None and self._last_translation[0] == text:
+            translation = self._last_translation[1]
+        else:
+            translation = self.callback(text)
         return translation if translation != text else None
 
     def _translate_callback(self, text: str, path: list[str], docpath: str = "") -> str:
@@ -412,7 +416,9 @@ class MarkdownFile(base.TranslationStore[MarkdownUnit]):
             unit.setdocpath(docpath)
 
         # return translated text
-        return self.callback(text)
+        translation = self.callback(text)
+        self._last_translation = text, translation
+        return translation
 
 
 class TranslatingMarkdownRenderer(MarkdownRenderer):
@@ -533,7 +539,13 @@ class TranslatingMarkdownRenderer(MarkdownRenderer):
     ) -> tuple[str, bool]:
         """Look up current and legacy heading translations without ambiguity."""
         if not suffix:
-            return translation, translation != source
+            # An identity target is still a successful lookup. Only use the
+            # secondary lookup to check presence: the primary callback may have
+            # selected a different occurrence of a duplicated source.
+            return translation, translation != source or (
+                self.lookup_callback is not None
+                and self.lookup_callback(source) is not None
+            )
         if translation != source:
             translated_title, _translated_suffix = _split_explicit_heading_id(
                 translation


### PR DESCRIPTION
Recognize successful identity lookups before trying expanded source keys. Preserve the primary callback result and reuse it in the default lookup adapter so presence checks do not consume duplicate occurrences.

Cover Markdown and MDX precedence, duplicate callbacks, and literal braces in expanded-key translations.